### PR TITLE
[#4] [FEAT] 외부 API를 사용하여 책 정보 불러오는 기능 구현

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,3 +9,7 @@ POSTGRES_PASSWORD=
 # Application Database Connection
 DB_USERNAME=dkdk
 DB_PASSWORD=
+
+# Kakao book API
+KAKAO_API_KEY=
+KAKAO_API_BASE_URL=

--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,9 @@ dependencies {
     annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
     annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
 
+	// WebFlux
+	implementation 'org.springframework.boot:spring-boot-starter-webflux'
+
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	developmentOnly 'org.springframework.boot:spring-boot-docker-compose'
@@ -49,6 +52,7 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/dokdok/_global/BaseTimeEntity.java
+++ b/src/main/java/com/dokdok/_global/BaseTimeEntity.java
@@ -1,4 +1,4 @@
-package com.dokdok.global;
+package com.dokdok._global;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;

--- a/src/main/java/com/dokdok/_global/config/KakaoWebClientConfig.java
+++ b/src/main/java/com/dokdok/_global/config/KakaoWebClientConfig.java
@@ -1,0 +1,30 @@
+package com.dokdok._global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Configuration
+public class KakaoWebClientConfig {
+
+    @Value("${kakao.api.key}")
+    private String apiKey;
+
+    @Value("${kakao.api.base-url}")
+    private String baseUrl;
+
+    @Bean
+    public WebClient kakaoWebClient() {
+        System.out.println("apiKey: " + apiKey);
+        System.out.println("baseUrl: " + baseUrl);
+        return WebClient.builder()
+                .baseUrl(baseUrl)
+                .defaultHeader(
+                        HttpHeaders.AUTHORIZATION,
+                        "KakaoAK " + apiKey
+                )
+                .build();
+    }
+}

--- a/src/main/java/com/dokdok/_global/exception/GlobalErrorCode.java
+++ b/src/main/java/com/dokdok/_global/exception/GlobalErrorCode.java
@@ -1,4 +1,4 @@
-package com.dokdok.global.exception;
+package com.dokdok._global.exception;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/src/main/java/com/dokdok/_global/exception/GlobalException.java
+++ b/src/main/java/com/dokdok/_global/exception/GlobalException.java
@@ -1,4 +1,4 @@
-package com.dokdok.global.exception;
+package com.dokdok._global.exception;
 
 import lombok.Getter;
 

--- a/src/main/java/com/dokdok/_global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/dokdok/_global/exception/GlobalExceptionHandler.java
@@ -1,6 +1,6 @@
-package com.dokdok.global.exception;
+package com.dokdok._global.exception;
 
-import com.dokdok.global.response.ApiResponse;
+import com.dokdok._global.response.ApiResponse;
 import tools.jackson.databind.exc.InvalidFormatException;
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.ConstraintViolationException;

--- a/src/main/java/com/dokdok/_global/response/ApiResponse.java
+++ b/src/main/java/com/dokdok/_global/response/ApiResponse.java
@@ -1,4 +1,4 @@
-package com.dokdok.global.response;
+package com.dokdok._global.response;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import org.springframework.http.HttpStatus;

--- a/src/main/java/com/dokdok/book/controller/BookController.java
+++ b/src/main/java/com/dokdok/book/controller/BookController.java
@@ -1,0 +1,21 @@
+package com.dokdok.book.controller;
+
+import com.dokdok.book.dto.response.KakaoBookResponse;
+import com.dokdok.book.service.BookService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/book")
+public class BookController {
+    private final BookService bookService;
+
+    @GetMapping("/search")
+    public KakaoBookResponse searchBook(@RequestParam String title) {
+        return bookService.searchBook(title);
+    }
+}

--- a/src/main/java/com/dokdok/book/dto/request/KakaoBookRequest.java
+++ b/src/main/java/com/dokdok/book/dto/request/KakaoBookRequest.java
@@ -1,0 +1,25 @@
+package com.dokdok.book.dto.request;
+
+import com.dokdok.book.entity.Book;
+
+import java.util.List;
+
+public record KakaoBookRequest(
+        String title,
+        List<String> authors,
+        String publisher,
+        String isbn,
+        String thumbnail
+) {
+    public Book toEntity() {
+        return Book.builder()
+                .bookName(title)
+                .author(authors != null && !authors.isEmpty()
+                        ? String.join(", ", authors)
+                        : null)
+                .publisher(publisher)
+                .thumbnail(thumbnail)
+                .isbn(isbn)
+                .build();
+    }
+}

--- a/src/main/java/com/dokdok/book/dto/response/KakaoBookResponse.java
+++ b/src/main/java/com/dokdok/book/dto/response/KakaoBookResponse.java
@@ -1,0 +1,26 @@
+package com.dokdok.book.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+public record KakaoBookResponse(
+        List<Document> documents,
+        Meta meta
+) {
+    public record Document(
+            String title,
+            String contents,
+            List<String> authors,
+            String publisher,
+            String isbn,
+            String thumbnail
+    ) {}
+
+    public record Meta(
+            @JsonProperty("is_end") boolean isEnd,
+            @JsonProperty("pageable_count") int pageableCount,
+            @JsonProperty("total_count") int totalCount
+    ) {}
+}
+

--- a/src/main/java/com/dokdok/book/entity/Book.java
+++ b/src/main/java/com/dokdok/book/entity/Book.java
@@ -31,11 +31,8 @@ public class Book {
     @Column(name = "author", length = 100)
     private String author;
 
-    @Column(name = "category", length = 100)
-    private String category;
-
     @Column(name = "book_image_url", length = 500)
-    private String bookImageUrl;
+    private String thumbnail;
 
     @Column(name = "isbn", length = 20)
     private String isbn;

--- a/src/main/java/com/dokdok/book/entity/PersonalReadingRecord.java
+++ b/src/main/java/com/dokdok/book/entity/PersonalReadingRecord.java
@@ -1,6 +1,6 @@
 package com.dokdok.book.entity;
 
-import com.dokdok.global.BaseTimeEntity;
+import com.dokdok._global.BaseTimeEntity;
 import com.dokdok.user.entity.User;
 import jakarta.persistence.*;
 import lombok.*;

--- a/src/main/java/com/dokdok/book/repository/BookRepository.java
+++ b/src/main/java/com/dokdok/book/repository/BookRepository.java
@@ -1,0 +1,12 @@
+package com.dokdok.book.repository;
+
+import com.dokdok.book.entity.Book;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface BookRepository extends JpaRepository<Book, Long> {
+    Optional<Book> findByIsbn(String isbn);
+}

--- a/src/main/java/com/dokdok/book/service/BookService.java
+++ b/src/main/java/com/dokdok/book/service/BookService.java
@@ -1,11 +1,7 @@
 package com.dokdok.book.service;
 
-import com.dokdok.book.dto.response.BookDetailResponse;
 import com.dokdok.book.dto.response.KakaoBookResponse;
-import com.dokdok.book.entity.Book;
-import com.dokdok.book.repository.BookRepository;
 import com.dokdok.book.webClient.KakaoBookClient;
-import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -13,17 +9,10 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class BookService {
 
-    private final BookRepository bookRepository;
     private final KakaoBookClient kakaoBookClient;
 
     // 외부 API로 책 검색 후 가지고오기 or 저장하기
     public KakaoBookResponse searchBook(String query) {
         return kakaoBookClient.searchBooks(query);
-    }
-
-    public BookDetailResponse findBookByIsbn(String isbn) {
-        Book entity = bookRepository.findByIsbn(isbn)
-                .orElseThrow(() -> new EntityNotFoundException("데이터가 존재하지 않습니다."));
-        return BookDetailResponse.from(entity);
     }
 }

--- a/src/main/java/com/dokdok/book/service/BookService.java
+++ b/src/main/java/com/dokdok/book/service/BookService.java
@@ -1,0 +1,29 @@
+package com.dokdok.book.service;
+
+import com.dokdok.book.dto.response.BookDetailResponse;
+import com.dokdok.book.dto.response.KakaoBookResponse;
+import com.dokdok.book.entity.Book;
+import com.dokdok.book.repository.BookRepository;
+import com.dokdok.book.webClient.KakaoBookClient;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class BookService {
+
+    private final BookRepository bookRepository;
+    private final KakaoBookClient kakaoBookClient;
+
+    // 외부 API로 책 검색 후 가지고오기 or 저장하기
+    public KakaoBookResponse searchBook(String query) {
+        return kakaoBookClient.searchBooks(query);
+    }
+
+    public BookDetailResponse findBookByIsbn(String isbn) {
+        Book entity = bookRepository.findByIsbn(isbn)
+                .orElseThrow(() -> new EntityNotFoundException("데이터가 존재하지 않습니다."));
+        return BookDetailResponse.from(entity);
+    }
+}

--- a/src/main/java/com/dokdok/book/webClient/KakaoBookClient.java
+++ b/src/main/java/com/dokdok/book/webClient/KakaoBookClient.java
@@ -1,0 +1,25 @@
+package com.dokdok.book.webClient;
+
+import com.dokdok.book.dto.response.KakaoBookResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Component
+@RequiredArgsConstructor
+public class KakaoBookClient {
+
+    private final WebClient kakaoWebClient;
+
+    public KakaoBookResponse searchBooks(String query) {
+        return kakaoWebClient.get()
+                .uri(uriBuilder -> uriBuilder
+                    .path("/v3/search/book")
+                    .queryParam("query", query)
+                    .build())
+                .retrieve()
+                .bodyToMono(KakaoBookResponse.class)
+                .block();
+    }
+
+}

--- a/src/main/java/com/dokdok/gathering/entity/Gathering.java
+++ b/src/main/java/com/dokdok/gathering/entity/Gathering.java
@@ -1,6 +1,6 @@
 package com.dokdok.gathering.entity;
 
-import com.dokdok.global.BaseTimeEntity;
+import com.dokdok._global.BaseTimeEntity;
 import com.dokdok.user.entity.User;
 import jakarta.persistence.*;
 import lombok.*;

--- a/src/main/java/com/dokdok/keyword/entity/Keyword.java
+++ b/src/main/java/com/dokdok/keyword/entity/Keyword.java
@@ -1,6 +1,6 @@
 package com.dokdok.keyword.entity;
 
-import com.dokdok.global.BaseTimeEntity;
+import com.dokdok._global.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.*;
 import lombok.experimental.SuperBuilder;

--- a/src/main/java/com/dokdok/meeting/entity/Meeting.java
+++ b/src/main/java/com/dokdok/meeting/entity/Meeting.java
@@ -2,7 +2,7 @@ package com.dokdok.meeting.entity;
 
 import com.dokdok.book.entity.Book;
 import com.dokdok.gathering.entity.Gathering;
-import com.dokdok.global.BaseTimeEntity;
+import com.dokdok._global.BaseTimeEntity;
 import com.dokdok.user.entity.User;
 import jakarta.persistence.*;
 import lombok.*;

--- a/src/main/java/com/dokdok/retrospective/entity/Retrospective.java
+++ b/src/main/java/com/dokdok/retrospective/entity/Retrospective.java
@@ -1,6 +1,6 @@
 package com.dokdok.retrospective.entity;
 
-import com.dokdok.global.BaseTimeEntity;
+import com.dokdok._global.BaseTimeEntity;
 import com.dokdok.meeting.entity.Meeting;
 import com.dokdok.user.entity.User;
 import jakarta.persistence.*;

--- a/src/main/java/com/dokdok/retrospective/entity/SharedRetrospective.java
+++ b/src/main/java/com/dokdok/retrospective/entity/SharedRetrospective.java
@@ -1,6 +1,6 @@
 package com.dokdok.retrospective.entity;
 
-import com.dokdok.global.BaseTimeEntity;
+import com.dokdok._global.BaseTimeEntity;
 import com.dokdok.meeting.entity.Meeting;
 import com.dokdok.user.entity.User;
 import jakarta.persistence.*;

--- a/src/main/java/com/dokdok/topic/entity/Topic.java
+++ b/src/main/java/com/dokdok/topic/entity/Topic.java
@@ -1,6 +1,6 @@
 package com.dokdok.topic.entity;
 
-import com.dokdok.global.BaseTimeEntity;
+import com.dokdok._global.BaseTimeEntity;
 import com.dokdok.meeting.entity.Meeting;
 import com.dokdok.user.entity.User;
 import jakarta.persistence.*;

--- a/src/main/java/com/dokdok/topic/entity/TopicAnswer.java
+++ b/src/main/java/com/dokdok/topic/entity/TopicAnswer.java
@@ -1,6 +1,6 @@
 package com.dokdok.topic.entity;
 
-import com.dokdok.global.BaseTimeEntity;
+import com.dokdok._global.BaseTimeEntity;
 import com.dokdok.user.entity.User;
 import jakarta.persistence.*;
 import lombok.*;

--- a/src/main/java/com/dokdok/user/entity/User.java
+++ b/src/main/java/com/dokdok/user/entity/User.java
@@ -1,6 +1,6 @@
 package com.dokdok.user.entity;
 
-import com.dokdok.global.BaseTimeEntity;
+import com.dokdok._global.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.*;
 import lombok.experimental.SuperBuilder;

--- a/src/main/resources/application-test.yaml
+++ b/src/main/resources/application-test.yaml
@@ -20,3 +20,8 @@ spring:
           persistence:
             schema-generation:
               create-source: metadata
+
+kakao:
+  api:
+    key: ${KAKAO_API_KEY:dummy}
+    base-url: ${KAKAO_API_BASE_URL:https://dapi.kakao.com}

--- a/src/test/java/com/dokdok/book/api/KakaoBookAPI_GET.java
+++ b/src/test/java/com/dokdok/book/api/KakaoBookAPI_GET.java
@@ -1,0 +1,101 @@
+package com.dokdok.book.api;
+
+import com.dokdok.book.dto.response.KakaoBookResponse;
+import com.dokdok.book.webClient.KakaoBookClient;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("카카오 도서 검색 API 연동 테스트")
+class KakaoBookAPI_GET {
+
+    private static final String DEFAULT_BASE_URL = "https://dapi.kakao.com";
+    private static final String PRIMARY_ENV_KEY = "KAKAO_REST_API_KEY";
+    private static final String FALLBACK_ENV_KEY = "KAKAO_API_KEY";
+    private static final String BASE_URL_KEY = "KAKAO_API_BASE_URL";
+    private static final Map<String, String> DOTENV = loadDotEnv();
+
+    @Test
+    @DisplayName("환경변수 또는 .env의 API 키로 책 검색 시 결과를 반환한다")
+    void searchBooks_withValidApiKey_returnsResults() {
+        String apiKey = resolveApiKey();
+        Assumptions.assumeFalse(apiKey.isBlank(), "Kakao API key is missing; skipping external API call.");
+
+        String baseUrl = resolveBaseUrl();
+        KakaoBookClient kakaoBookClient = new KakaoBookClient(createWebClient(baseUrl, apiKey));
+        KakaoBookResponse response = kakaoBookClient.searchBooks("harry potter");
+
+        assertThat(response).isNotNull();
+        assertThat(response.documents()).isNotNull();
+        assertThat(response.documents()).isNotEmpty();
+        assertThat(response.meta()).isNotNull();
+        assertThat(response.meta().totalCount()).isGreaterThan(0);
+    }
+
+    private WebClient createWebClient(String baseUrl, String apiKey) {
+        return WebClient.builder()
+                .baseUrl(baseUrl)
+                .defaultHeader(HttpHeaders.AUTHORIZATION, "KakaoAK " + apiKey)
+                .build();
+    }
+
+    private static String resolveApiKey() {
+        return resolveFromEnvOrDotEnv(PRIMARY_ENV_KEY, FALLBACK_ENV_KEY);
+    }
+
+    private static String resolveBaseUrl() {
+        String value = resolveFromEnvOrDotEnv(BASE_URL_KEY, null);
+        return value.isBlank() ? DEFAULT_BASE_URL : value;
+    }
+
+    private static String resolveFromEnvOrDotEnv(String key, String secondaryKey) {
+        String value = readKey(key);
+        if (value.isBlank() && secondaryKey != null) {
+            value = readKey(secondaryKey);
+        }
+        return value;
+    }
+
+    private static String readKey(String key) {
+        String value = System.getenv(key);
+        if (value == null || value.isBlank()) {
+            value = DOTENV.getOrDefault(key, "");
+        }
+        return value.trim();
+    }
+
+    private static Map<String, String> loadDotEnv() {
+        Path path = Path.of(".env");
+        if (!Files.exists(path)) {
+            return Collections.emptyMap();
+        }
+
+        Map<String, String> values = new HashMap<>();
+        try {
+            for (String line : Files.readAllLines(path)) {
+                String trimmed = line.trim();
+                if (trimmed.startsWith("#") || !trimmed.contains("=")) {
+                    continue;
+                }
+                int idx = trimmed.indexOf('=');
+                String key = trimmed.substring(0, idx).trim();
+                String val = trimmed.substring(idx + 1).trim();
+                values.put(key, val);
+            }
+        } catch (IOException ignored) {
+            return Collections.emptyMap();
+        }
+        return values;
+    }
+}


### PR DESCRIPTION
• ## PR 요약

  > 이 PR이 어떤 변경을 하는지 간단히 설명하고, 체크 표시는 괄호 사이에 소문자 'x'를 삽입하세요.                                                                                                                                                                                                                            

  - [x] 기능 추가
  - [ ] 버그 수정
  - [ ] 코드 리팩토링
  - [ ] 문서 수정
  - [ ] 기타 (설명)

  ———

  ## 이슈 번호

  - #4 

  ———

  ## 주요 변경 사항

  - src/test/java/com/dokdok/book/api/KakaoBookAPI_GET.java: 
  카카오 도서 API 실제 호출 테스트를 추가하고, API 키/베이스 URL을 환경변수(KAKAO_REST_API_KEY → KAKAO_API_KEY, KAKAO_API_BASE_URL)나 .env에서 자동으로 읽어 사용하도록 헬퍼 메서드 추가.
  - src/test/java/com/dokdok/book/api/KakaoBookAPI_GET.java: 
  키가 없을 경우 테스트를 건너뛰도록 Assumptions 사용, 기본 베이스 URL은 https://dapi.kakao.com으로 설정.

  ———

  ## 참고 사항

  - 로컬 실행 시 .env에 KAKAO_API_KEY 또는 환경변수 KAKAO_REST_API_KEY/KAKAO_API_KEY를 설정하면 테스트가 실행됩니다. 키가 없으면 자동으로 스킵됩니다.
  - 실행 예시: KAKAO_REST_API_KEY=<실제키> ./gradlew test --tests com.dokdok.book.api.KakaoBookAPI_GET