### PR TITLE
[#61][FIX] 카카오 OAuth 리다이렉트 시 세션 쿠키 소실 문제 해결

### DIFF
--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -47,9 +47,11 @@ logging:
   level:
     com.dokdok: INFO
     org.hibernate.SQL: INFO
-    # DEV 환경에서는 민감한 정보 노출 방지
+    # OAuth 디버깅 (문제 해결 시 DEBUG로 변경)
     org.springframework.security: INFO
     org.springframework.security.oauth2: INFO
+    org.springframework.security.web.authentication: DEBUG
+    org.springframework.security.oauth2.client: DEBUG
   pattern:
     console: '%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n'
   file:
@@ -67,8 +69,10 @@ server:
     session:
       timeout: 30m  # 세션 타임아웃 30분
       cookie:
-        same-site: none  # 크로스 오리진 요청에서 쿠키 전송 허용
-        secure: true     # HTTPS에서만 쿠키 전송 (same-site=none일 때 필수)
+        same-site: lax   # OAuth GET 리다이렉트에서 쿠키 전송 허용
+        secure: true     # HTTPS에서만 쿠키 전송
+        http-only: true  # XSS 방지
+        path: /          # 모든 경로에서 쿠키 사용
 
 # Swagger/OpenAPI Configuration
 springdoc:


### PR DESCRIPTION
## 이슈 번호
Closes #61

## 변경 사항
### 주요 변경 사항
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 기타

### 변경 내용
- **세션 쿠키 설정 변경**: `SameSite=none` → `SameSite=lax`
  - 카카오 OAuth GET 리다이렉트에서 쿠키 전송 허용
  - `lax`가 더 안전하고 안정적
- **보안 설정 추가**:
  - `http-only: true` (XSS 방지)
  - `path: /` (명시적 경로 설정)
- **OAuth 디버깅 로그 추가**:
  - `org.springframework.security.web.authentication: DEBUG`
  - `org.springframework.security.oauth2.client: DEBUG`

## 변경 파일
- `src/main/resources/application-dev.yaml`: +7/-3

## 문제 상황
배포 환경(HTTPS)에서 카카오 소셜 로그인 시 리다이렉트 단계에서 세션 쿠키가 소실되어 `authorization_request_not_found` 오류 발생

### OAuth 플로우
1. **시작**: `/oauth2/authorization/kakao` → `JSESSIONID` 쿠키 생성
2. **카카오 인증**: 카카오 로그인 페이지로 리다이렉트
3. **콜백**: 카카오가 `/login/oauth2/code/kakao`로 리다이렉트 → ❌ **쿠키 소실**

## 해결 방법
`SameSite=lax`는 다른 사이트에서 오는 **GET 요청에서 쿠키 전송을 허용**합니다. 카카오 OAuth는 GET으로 리다이렉트하므로 `lax`로 충분하며, `none`보다 안전합니다.

## 테스트 체크리스트
- [ ] 배포 환경에서 카카오 로그인 시도
- [ ] 브라우저 개발자 도구에서 JSESSIONID 쿠키 확인
  - OAuth 시작: Set-Cookie 확인
  - 리다이렉트: Cookie 전달 확인 (동일한 JSESSIONID)
  - SameSite=lax, Secure=true, HttpOnly=true 확인
- [ ] 서버 로그에서 authorization request 저장/복원 확인
- [ ] 정상적으로 로그인 성공 확인