### PR TITLE
[#61][FIX] 카카오 OAuth 리다이렉트 시 세션 쿠키 소실 및 테이블 미존재 문제 해결

### DIFF
--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -30,7 +30,7 @@ spring:
   # JPA Configuration
   jpa:
     hibernate:
-      ddl-auto: none
+      ddl-auto: update
     show-sql: true
     properties:
       hibernate:


### PR DESCRIPTION
## 이슈 번호
Closes #61

## 변경 사항
### 주요 변경 사항
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 기타

### 변경 내용
#### 1. 세션 쿠키 설정 변경
- **세션 쿠키 설정 변경**: `SameSite=none` → `SameSite=lax`
  - 카카오 OAuth GET 리다이렉트에서 쿠키 전송 허용
  - `lax`가 더 안전하고 안정적
- **보안 설정 추가**:
  - `http-only: true` (XSS 방지)
  - `path: /` (명시적 경로 설정)
- **OAuth 디버깅 로그 추가**:
  - `org.springframework.security.web.authentication: DEBUG`
  - `org.springframework.security.oauth2.client: DEBUG`

#### 2. JPA ddl-auto 설정 변경
- **ddl-auto**: `none` → `update` 변경
- 개발 환경에서 테이블 자동 생성 활성화
- `users` 테이블 미존재로 인한 "relation does not exist" 오류 해결

## 변경 파일
- `src/main/resources/application-dev.yaml`: +8/-4

## 문제 상황

### 1. 세션 쿠키 소실
배포 환경(HTTPS)에서 카카오 소셜 로그인 시 리다이렉트 단계에서 세션 쿠키가 소실되어 `authorization_request_not_found` 오류 발생

#### OAuth 플로우
1. **시작**: `/oauth2/authorization/kakao` → `JSESSIONID` 쿠키 생성
2. **카카오 인증**: 카카오 로그인 페이지로 리다이렉트
3. **콜백**: 카카오가 `/login/oauth2/code/kakao`로 리다이렉트 → ❌ **쿠키 소실**

### 2. 데이터베이스 테이블 미존재
EC2 배포 환경에서 `users` 테이블이 존재하지 않아 다음 오류 발생:
```
ERROR: relation "users" does not exist
```

## 해결 방법

### 세션 쿠키 문제
`SameSite=lax`는 다른 사이트에서 오는 **GET 요청에서 쿠키 전송을 허용**합니다. 카카오 OAuth는 GET으로 리다이렉트하므로 `lax`로 충분하며, `none`보다 안전합니다.

### 테이블 자동 생성
개발 환경에서 `ddl-auto: update` 설정으로 Hibernate가 엔티티를 기반으로 테이블을 자동 생성/업데이트하도록 변경

## 테스트 체크리스트
- [ ] 배포 환경에서 카카오 로그인 시도
- [ ] 브라우저 개발자 도구에서 JSESSIONID 쿠키 확인
  - OAuth 시작: Set-Cookie 확인
  - 리다이렉트: Cookie 전달 확인 (동일한 JSESSIONID)
  - SameSite=lax, Secure=true, HttpOnly=true 확인
- [ ] 서버 로그에서 authorization request 저장/복원 확인
- [ ] users 테이블 자동 생성 확인
- [ ] 정상적으로 로그인 성공 확인