### PR TITLE
[#16][#67][FEAT] 회원 프로필 조회 및 수정 API 구현

### DIFF
--- a/src/main/java/com/dokdok/user/api/UserApi.java
+++ b/src/main/java/com/dokdok/user/api/UserApi.java
@@ -2,6 +2,8 @@ package com.dokdok.user.api;
 
 import com.dokdok.global.response.ApiResponse;
 import com.dokdok.user.dto.request.OnboardRequest;
+import com.dokdok.user.dto.request.UpdateUserInfoRequest;
+import com.dokdok.user.dto.response.UserDetailResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
@@ -170,5 +172,143 @@ public interface UserApi {
     @GetMapping(value = "/check-nickname", produces = MediaType.APPLICATION_JSON_VALUE)
     ResponseEntity<ApiResponse<Void>> checkNickname(
             @RequestParam("nickname") String nickname
+    );
+
+    @Operation(
+            summary = "현재 사용자 정보 조회",
+            description = "현재 인증된 사용자의 프로필 정보를 조회합니다. SecurityContext에서 사용자 정보를 가져옵니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "프로필 조회 성공",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = UserDetailResponse.class),
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                              "code": "SUCCESS",
+                                              "message": "프로필 조회 성공",
+                                              "data": {
+                                                "userId": 1,
+                                                "nickname": "테스트닉네임",
+                                                "email": "test@example.com",
+                                                "profileImageUrl": "https://example.com/profile.jpg",
+                                                "createdAt": "2024-01-13T10:30:00"
+                                              }
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "401",
+                    description = "인증되지 않은 사용자",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(
+                                    value = "{\"code\":\"G001\",\"message\":\"인증되지 않은 사용자입니다.\"}"
+                            )
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "500",
+                    description = "서버 오류"
+            )
+    })
+    @GetMapping(value = "/me", produces = MediaType.APPLICATION_JSON_VALUE)
+    ResponseEntity<ApiResponse<UserDetailResponse>> getCurrentUser();
+
+    @Operation(
+            summary = "사용자 정보 수정",
+            description = "현재 사용자의 프로필 정보를 수정합니다. 현재는 닉네임만 수정 가능하며, 유효성 검사 및 중복 확인을 수행합니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "프로필 수정 성공",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = UserDetailResponse.class),
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                              "code": "SUCCESS",
+                                              "message": "프로필 수정 성공",
+                                              "data": {
+                                                "userId": 1,
+                                                "nickname": "변경된닉네임",
+                                                "email": "test@example.com",
+                                                "profileImageUrl": "https://example.com/profile.jpg",
+                                                "createdAt": "2024-01-13T10:30:00"
+                                              }
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "400",
+                    description = "잘못된 요청 (유효성 검사 실패)",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            examples = {
+                                    @ExampleObject(
+                                            name = "닉네임 필수",
+                                            description = "닉네임이 null이거나 빈 문자열인 경우",
+                                            value = "{\"code\":\"U003\",\"message\":\"닉네임은 필수 입력 항목입니다.\"}"
+                                    ),
+                                    @ExampleObject(
+                                            name = "닉네임 길이 오류",
+                                            description = "닉네임이 2자 미만 또는 20자 초과인 경우",
+                                            value = "{\"code\":\"U004\",\"message\":\"닉네임은 2자 이상 20자 이하로 입력해주세요.\"}"
+                                    ),
+                                    @ExampleObject(
+                                            name = "닉네임 형식 오류",
+                                            description = "특수문자, 공백, 이모지 등이 포함된 경우",
+                                            value = "{\"code\":\"U005\",\"message\":\"닉네임은 한글, 영문, 숫자만 사용 가능합니다.\"}"
+                                    )
+                            }
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "401",
+                    description = "인증되지 않은 사용자",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(
+                                    value = "{\"code\":\"G001\",\"message\":\"인증되지 않은 사용자입니다.\"}"
+                            )
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "사용자를 찾을 수 없음",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(
+                                    value = "{\"code\":\"U001\",\"message\":\"존재하지 않는 사용자입니디.\"}"
+                            )
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "409",
+                    description = "닉네임 중복",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(
+                                    value = "{\"code\":\"U002\",\"message\":\"이미 존재하는 사용자 닉네임입니다.\"}"
+                            )
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "500",
+                    description = "서버 오류"
+            )
+    })
+    @PatchMapping(value = "/me", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
+    ResponseEntity<ApiResponse<UserDetailResponse>> updateUserInfo(
+            @Valid @RequestBody UpdateUserInfoRequest request
     );
 }

--- a/src/main/java/com/dokdok/user/controller/UserController.java
+++ b/src/main/java/com/dokdok/user/controller/UserController.java
@@ -3,15 +3,14 @@ package com.dokdok.user.controller;
 import com.dokdok.global.response.ApiResponse;
 import com.dokdok.user.api.UserApi;
 import com.dokdok.user.dto.request.OnboardRequest;
+import com.dokdok.user.dto.request.UpdateUserInfoRequest;
+import com.dokdok.user.dto.response.UserDetailResponse;
 import com.dokdok.user.service.UserService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Slf4j
 @RestController
@@ -33,5 +32,19 @@ public class UserController implements UserApi {
     public ResponseEntity<ApiResponse<Void>> checkNickname(String nickname) {
         userService.checkNickname(nickname);
         return ApiResponse.success("사용 가능한 닉네임입니다.");
+    }
+
+    @Override
+    @GetMapping("/me")
+    public ResponseEntity<ApiResponse<UserDetailResponse>> getCurrentUser() {
+        UserDetailResponse currentUserInfo = userService.getCurrentUserInfo();
+        return ApiResponse.success(currentUserInfo, "프로필 조회 성공");
+    }
+
+    @Override
+    @PatchMapping("/me")
+    public ResponseEntity<ApiResponse<UserDetailResponse>> updateUserInfo(@Valid @RequestBody UpdateUserInfoRequest request) {
+        UserDetailResponse response = userService.updateUserInfo(request);
+        return ApiResponse.success(response, "프로필 수정 성공");
     }
 }

--- a/src/main/java/com/dokdok/user/dto/request/UpdateUserInfoRequest.java
+++ b/src/main/java/com/dokdok/user/dto/request/UpdateUserInfoRequest.java
@@ -1,0 +1,9 @@
+package com.dokdok.user.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record UpdateUserInfoRequest(
+        @NotBlank(message = "닉네임은 필수 입력 항목입니다.")
+        String nickname
+) {
+}

--- a/src/main/java/com/dokdok/user/dto/response/UserDetailResponse.java
+++ b/src/main/java/com/dokdok/user/dto/response/UserDetailResponse.java
@@ -1,0 +1,26 @@
+package com.dokdok.user.dto.response;
+
+import com.dokdok.user.entity.User;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+@Builder
+public record UserDetailResponse(
+        Long userId,
+        String nickname,
+        String email,
+        String profileImageUrl,
+        LocalDateTime createdAt
+)
+{
+    public static UserDetailResponse from(User user) {
+        return UserDetailResponse.builder()
+                .userId(user.getId())
+                .nickname(user.getNickname())
+                .email(user.getUserEmail())
+                .profileImageUrl(user.getProfileImageUrl())
+                .createdAt(user.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/dokdok/user/entity/User.java
+++ b/src/main/java/com/dokdok/user/entity/User.java
@@ -2,6 +2,7 @@ package com.dokdok.user.entity;
 
 import com.dokdok.global.BaseTimeEntity;
 import com.dokdok.oauth2.OAuth2UserInfo;
+import com.dokdok.user.dto.request.UpdateUserInfoRequest;
 import jakarta.persistence.*;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
@@ -48,5 +49,16 @@ public class User extends BaseTimeEntity {
 
     public void updateNickname(String nickname) {
         this.nickname = nickname;
+    }
+
+    /**
+     * 사용자의 정보를 변경합니다.
+     * 현재는 닉네임만 가능.
+     */
+    public void updateInfo(UpdateUserInfoRequest request) {
+
+        if (!this.nickname.equals(request.nickname())) {
+            this.nickname = request.nickname();
+        }
     }
 }

--- a/src/main/java/com/dokdok/user/service/UserService.java
+++ b/src/main/java/com/dokdok/user/service/UserService.java
@@ -2,6 +2,8 @@ package com.dokdok.user.service;
 
 import com.dokdok.global.util.SecurityUtil;
 import com.dokdok.user.dto.request.OnboardRequest;
+import com.dokdok.user.dto.request.UpdateUserInfoRequest;
+import com.dokdok.user.dto.response.UserDetailResponse;
 import com.dokdok.user.entity.User;
 import com.dokdok.user.exception.UserErrorCode;
 import com.dokdok.user.exception.UserException;
@@ -50,6 +52,29 @@ public class UserService {
         validateNickname(nickname.trim());
     }
 
+    /**
+     * SecurityUtil에서 현재 세션에 저장된 사용자의 User Entity를 응답 Response Dto형식으로 반환.
+     */
+    public UserDetailResponse getCurrentUserInfo() {
+
+        User currentUser = SecurityUtil.getCurrentUserEntity();
+        return UserDetailResponse.from(currentUser);
+    }
+
+    /**
+     * 사용자의 정보응 변경합니다.
+     */
+    public UserDetailResponse updateUserInfo(UpdateUserInfoRequest request) {
+
+        validateNickname(request.nickname());
+
+        Long currentUserId = SecurityUtil.getCurrentUserId();
+
+        User user = getUserById(currentUserId);
+        user.updateInfo(request);
+
+        return UserDetailResponse.from(user);
+    }
 
     /**
      * 닉네임 유효성을 검사합니다.
@@ -78,4 +103,5 @@ public class UserService {
         return userRepository.findById(userId)
                 .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
     }
+
 }

--- a/src/test/java/com/dokdok/user/service/UserServiceTest.java
+++ b/src/test/java/com/dokdok/user/service/UserServiceTest.java
@@ -476,4 +476,267 @@ class UserServiceTest {
             securityUtilMock.verify(() -> SecurityUtil.updateCurrentUserInContext(any()), never());
         }
     }
+
+    @Test
+    @DisplayName("현재 사용자 정보 조회 - 성공")
+    void getCurrentUserInfo_Success() {
+        // given
+        User user = User.builder()
+                .id(1L)
+                .nickname("테스트닉네임")
+                .userEmail("test@test.com")
+                .profileImageUrl("https://example.com/profile.jpg")
+                .build();
+
+        try (MockedStatic<SecurityUtil> securityUtilMock = mockStatic(SecurityUtil.class)) {
+            securityUtilMock.when(SecurityUtil::getCurrentUserEntity).thenReturn(user);
+
+            // when
+            var response = userService.getCurrentUserInfo();
+
+            // then
+            assertThat(response).isNotNull();
+            assertThat(response.userId()).isEqualTo(1L);
+            assertThat(response.nickname()).isEqualTo("테스트닉네임");
+            assertThat(response.email()).isEqualTo("test@test.com");
+            assertThat(response.profileImageUrl()).isEqualTo("https://example.com/profile.jpg");
+
+            securityUtilMock.verify(SecurityUtil::getCurrentUserEntity, times(1));
+        }
+    }
+
+    @Test
+    @DisplayName("사용자 정보 수정 - 정상적인 닉네임으로 성공")
+    void updateUserInfo_Success() {
+        // given
+        Long userId = 1L;
+        String newNickname = "변경된닉네임";
+        var request = new com.dokdok.user.dto.request.UpdateUserInfoRequest(newNickname);
+
+        User user = User.builder()
+                .id(userId)
+                .nickname("기존닉네임")
+                .userEmail("test@test.com")
+                .build();
+
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        when(userRepository.findByNickname(newNickname)).thenReturn(Optional.empty());
+
+        try (MockedStatic<SecurityUtil> securityUtilMock = mockStatic(SecurityUtil.class)) {
+            securityUtilMock.when(SecurityUtil::getCurrentUserId).thenReturn(userId);
+
+            // when
+            var response = userService.updateUserInfo(request);
+
+            // then
+            assertThat(response).isNotNull();
+            assertThat(response.nickname()).isEqualTo(newNickname);
+            assertThat(user.getNickname()).isEqualTo(newNickname);
+
+            verify(userRepository, times(1)).findById(userId);
+            verify(userRepository, times(1)).findByNickname(newNickname);
+        }
+    }
+
+    @Test
+    @DisplayName("사용자 정보 수정 - 동일한 닉네임으로 변경 시도")
+    void updateUserInfo_SameNickname_Success() {
+        // given
+        Long userId = 1L;
+        String sameNickname = "기존닉네임";
+        var request = new com.dokdok.user.dto.request.UpdateUserInfoRequest(sameNickname);
+
+        User user = User.builder()
+                .id(userId)
+                .nickname(sameNickname)
+                .userEmail("test@test.com")
+                .build();
+
+        when(userRepository.findByNickname(sameNickname)).thenReturn(Optional.of(user));
+
+        try (MockedStatic<SecurityUtil> securityUtilMock = mockStatic(SecurityUtil.class)) {
+            securityUtilMock.when(SecurityUtil::getCurrentUserId).thenReturn(userId);
+
+            // when & then
+            assertThatThrownBy(() -> userService.updateUserInfo(request))
+                    .isInstanceOf(UserException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", UserErrorCode.NICKNAME_ALREADY_EXISTS);
+
+            verify(userRepository, times(1)).findByNickname(sameNickname);
+        }
+    }
+
+    @Test
+    @DisplayName("사용자 정보 수정 - null 닉네임으로 실패")
+    void updateUserInfo_NullNickname_ThrowsException() {
+        // given
+        Long userId = 1L;
+        var request = new com.dokdok.user.dto.request.UpdateUserInfoRequest(null);
+
+        try (MockedStatic<SecurityUtil> securityUtilMock = mockStatic(SecurityUtil.class)) {
+            securityUtilMock.when(SecurityUtil::getCurrentUserId).thenReturn(userId);
+
+            // when & then
+            assertThatThrownBy(() -> userService.updateUserInfo(request))
+                    .isInstanceOf(UserException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", UserErrorCode.NICKNAME_EMPTY);
+
+            verify(userRepository, never()).findById(anyLong());
+            verify(userRepository, never()).findByNickname(anyString());
+        }
+    }
+
+    @Test
+    @DisplayName("사용자 정보 수정 - 빈 닉네임으로 실패")
+    void updateUserInfo_EmptyNickname_ThrowsException() {
+        // given
+        Long userId = 1L;
+        String emptyNickname = "";
+        var request = new com.dokdok.user.dto.request.UpdateUserInfoRequest(emptyNickname);
+
+        try (MockedStatic<SecurityUtil> securityUtilMock = mockStatic(SecurityUtil.class)) {
+            securityUtilMock.when(SecurityUtil::getCurrentUserId).thenReturn(userId);
+
+            // when & then
+            assertThatThrownBy(() -> userService.updateUserInfo(request))
+                    .isInstanceOf(UserException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", UserErrorCode.NICKNAME_EMPTY);
+
+            verify(userRepository, never()).findById(anyLong());
+            verify(userRepository, never()).findByNickname(anyString());
+        }
+    }
+
+    @Test
+    @DisplayName("사용자 정보 수정 - 공백만 있는 닉네임으로 실패")
+    void updateUserInfo_OnlyWhitespace_ThrowsException() {
+        // given
+        Long userId = 1L;
+        String whitespaceNickname = "   ";
+        var request = new com.dokdok.user.dto.request.UpdateUserInfoRequest(whitespaceNickname);
+
+        try (MockedStatic<SecurityUtil> securityUtilMock = mockStatic(SecurityUtil.class)) {
+            securityUtilMock.when(SecurityUtil::getCurrentUserId).thenReturn(userId);
+
+            // when & then
+            assertThatThrownBy(() -> userService.updateUserInfo(request))
+                    .isInstanceOf(UserException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", UserErrorCode.NICKNAME_EMPTY);
+
+            verify(userRepository, never()).findById(anyLong());
+            verify(userRepository, never()).findByNickname(anyString());
+        }
+    }
+
+    @Test
+    @DisplayName("사용자 정보 수정 - 길이가 짧은 닉네임으로 실패")
+    void updateUserInfo_TooShortNickname_ThrowsException() {
+        // given
+        Long userId = 1L;
+        String shortNickname = "a";
+        var request = new com.dokdok.user.dto.request.UpdateUserInfoRequest(shortNickname);
+
+        try (MockedStatic<SecurityUtil> securityUtilMock = mockStatic(SecurityUtil.class)) {
+            securityUtilMock.when(SecurityUtil::getCurrentUserId).thenReturn(userId);
+
+            // when & then
+            assertThatThrownBy(() -> userService.updateUserInfo(request))
+                    .isInstanceOf(UserException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", UserErrorCode.NICKNAME_LENGTH_INVALID);
+
+            verify(userRepository, never()).findById(anyLong());
+        }
+    }
+
+    @Test
+    @DisplayName("사용자 정보 수정 - 길이가 긴 닉네임으로 실패")
+    void updateUserInfo_TooLongNickname_ThrowsException() {
+        // given
+        Long userId = 1L;
+        String longNickname = "a".repeat(21);
+        var request = new com.dokdok.user.dto.request.UpdateUserInfoRequest(longNickname);
+
+        try (MockedStatic<SecurityUtil> securityUtilMock = mockStatic(SecurityUtil.class)) {
+            securityUtilMock.when(SecurityUtil::getCurrentUserId).thenReturn(userId);
+
+            // when & then
+            assertThatThrownBy(() -> userService.updateUserInfo(request))
+                    .isInstanceOf(UserException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", UserErrorCode.NICKNAME_LENGTH_INVALID);
+
+            verify(userRepository, never()).findById(anyLong());
+        }
+    }
+
+    @Test
+    @DisplayName("사용자 정보 수정 - 특수문자 포함 닉네임으로 실패")
+    void updateUserInfo_InvalidFormat_ThrowsException() {
+        // given
+        Long userId = 1L;
+        String invalidNickname = "닉네임!@#";
+        var request = new com.dokdok.user.dto.request.UpdateUserInfoRequest(invalidNickname);
+
+        try (MockedStatic<SecurityUtil> securityUtilMock = mockStatic(SecurityUtil.class)) {
+            securityUtilMock.when(SecurityUtil::getCurrentUserId).thenReturn(userId);
+
+            // when & then
+            assertThatThrownBy(() -> userService.updateUserInfo(request))
+                    .isInstanceOf(UserException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", UserErrorCode.NICKNAME_FORMAT_INVALID);
+
+            verify(userRepository, never()).findById(anyLong());
+        }
+    }
+
+    @Test
+    @DisplayName("사용자 정보 수정 - 중복된 닉네임으로 실패")
+    void updateUserInfo_DuplicateNickname_ThrowsException() {
+        // given
+        Long userId = 1L;
+        String duplicateNickname = "기존닉네임";
+        var request = new com.dokdok.user.dto.request.UpdateUserInfoRequest(duplicateNickname);
+
+        User anotherUser = User.builder()
+                .id(2L)
+                .nickname(duplicateNickname)
+                .build();
+
+        when(userRepository.findByNickname(duplicateNickname)).thenReturn(Optional.of(anotherUser));
+
+        try (MockedStatic<SecurityUtil> securityUtilMock = mockStatic(SecurityUtil.class)) {
+            securityUtilMock.when(SecurityUtil::getCurrentUserId).thenReturn(userId);
+
+            // when & then
+            assertThatThrownBy(() -> userService.updateUserInfo(request))
+                    .isInstanceOf(UserException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", UserErrorCode.NICKNAME_ALREADY_EXISTS);
+
+            verify(userRepository, times(1)).findByNickname(duplicateNickname);
+            verify(userRepository, never()).findById(anyLong());
+        }
+    }
+
+    @Test
+    @DisplayName("사용자 정보 수정 - 존재하지 않는 사용자로 실패")
+    void updateUserInfo_UserNotFound_ThrowsException() {
+        // given
+        Long userId = 1L;
+        String validNickname = "새로운닉네임";
+        var request = new com.dokdok.user.dto.request.UpdateUserInfoRequest(validNickname);
+
+        when(userRepository.findById(userId)).thenReturn(Optional.empty());
+        when(userRepository.findByNickname(validNickname)).thenReturn(Optional.empty());
+
+        try (MockedStatic<SecurityUtil> securityUtilMock = mockStatic(SecurityUtil.class)) {
+            securityUtilMock.when(SecurityUtil::getCurrentUserId).thenReturn(userId);
+
+            // when & then
+            assertThatThrownBy(() -> userService.updateUserInfo(request))
+                    .isInstanceOf(UserException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", UserErrorCode.USER_NOT_FOUND);
+
+            verify(userRepository, times(1)).findById(userId);
+            verify(userRepository, times(1)).findByNickname(validNickname);
+        }
+    }
 }


### PR DESCRIPTION
## PR 요약
> 회원 프로필 조회 및 수정 API를 구현했습니다.

- [x] 기능 추가
- [ ] 버그 수정
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 기타 (설명)

---

## 이슈 번호
- #16 (회원 프로필 조회 API)
- #67 (회원 프로필 수정 API)

---

## 주요 변경 사항
> 회원 프로필 조회 및 수정 기능 구현

- `UserDetailResponse`: 사용자 상세 정보 응답 DTO 추가 (userId, nickname, email, profileImageUrl, createdAt)
- `UpdateUserInfoRequest`: 사용자 정보 수정 요청 DTO 추가 (닉네임 수정)
- `UserApi`: GET /api/users/me, PATCH /api/users/me 엔드포인트 Swagger 명세 추가
- `UserController`: getCurrentUser, updateUserInfo 메서드 구현 (UserApi 인터페이스 구현)
- `UserService`: getCurrentUserInfo, updateUserInfo 메서드 추가 (SecurityContext에서 현재 사용자 조회 및 수정)
- `User`: updateInfo 메서드 추가 (닉네임 업데이트)
- `UserServiceTest`: getCurrentUserInfo, updateUserInfo 단위 테스트 12개 추가

**검증 규칙**
- 닉네임: 2~20자, 한글/영문/숫자만 허용
- 중복 닉네임 체크
- 인증된 사용자만 접근 가능

---

## 참고 사항
> 테스트 및 확인 방법

**API 엔드포인트**
- `GET /api/users/me`: 현재 사용자 프로필 조회
- `PATCH /api/users/me`: 사용자 프로필 수정

**로컬 테스트 방법**
1. 애플리케이션 실행 후 카카오 로그인으로 인증
2. Swagger UI 접속: http://localhost:8080/swagger-ui/index.html
3. GET /api/users/me로 현재 사용자 정보 조회
4. PATCH /api/users/me로 닉네임 수정 테스트

**단위 테스트 실행**
```bash
./gradlew test --tests UserServiceTest
```

**테스트 케이스**
- getCurrentUserInfo: 정상 조회 (1개)
- updateUserInfo: 정상 수정, null/빈값/공백/길이/형식/중복 검증 (11개)

---