### PR TITLE
[#66][REFACTOR] 약속 로직의 TODO 변경 및 로직 보완, 비즈니스 로직 수정으로 인한 테스트 코드 변경

### DIFF
--- a/src/main/java/com/dokdok/meeting/controller/MeetingController.java
+++ b/src/main/java/com/dokdok/meeting/controller/MeetingController.java
@@ -41,8 +41,7 @@ public class MeetingController implements MeetingApi {
     public ResponseEntity<ApiResponse<MeetingResponse>> createMeeting(
             @Valid @RequestBody MeetingCreateRequest request
     ) {
-        // todo : 시큐리티 인증 정보에서 userId를 가져오도록 변경
-        return ApiResponse.created(meetingService.createMeeting(request, 1L), "약속 생성 요청에 성공했습니다.");
+        return ApiResponse.created(meetingService.createMeeting(request), "약속 생성 요청에 성공했습니다.");
     }
 
     @Override

--- a/src/main/java/com/dokdok/meeting/exception/MeetingErrorCode.java
+++ b/src/main/java/com/dokdok/meeting/exception/MeetingErrorCode.java
@@ -20,7 +20,9 @@ public enum MeetingErrorCode implements BaseErrorCode {
     INVALID_MEETING_STATUS_CHANGE("M009", "약속 상태를 변경할 수 없습니다.", HttpStatus.BAD_REQUEST),
     MEETING_ALREADY_JOINED("M010", "이미 참가한 약속입니다.", HttpStatus.BAD_REQUEST),
     MEETING_ALREADY_CANCELED("M011", "이미 취소된 약속입니다.", HttpStatus.BAD_REQUEST),
-    MEETING_CANCEL_NOT_ALLOWED("M012", "약속 시작 24시간 이내에는 취소할 수 없습니다.", HttpStatus.BAD_REQUEST);
+    MEETING_CANCEL_NOT_ALLOWED("M012", "약속 시작 24시간 이내에는 취소할 수 없습니다.", HttpStatus.BAD_REQUEST),
+    NOT_MEETING_LEADER("M013", "약속장만 수정할 수 있습니다.", HttpStatus.FORBIDDEN),
+    INVALID_MAX_PARTICIPANTS("M014", "최대 참가 인원은 1명 이상이어야 하며, 모임 전체 인원을 초과할 수 없습니다.", HttpStatus.BAD_REQUEST);
 
     private final String code;
     private final String message;

--- a/src/main/java/com/dokdok/meeting/service/MeetingService.java
+++ b/src/main/java/com/dokdok/meeting/service/MeetingService.java
@@ -1,8 +1,12 @@
 package com.dokdok.meeting.service;
 
 import com.dokdok.book.entity.Book;
+import com.dokdok.book.exception.BookErrorCode;
+import com.dokdok.book.exception.BookException;
 import com.dokdok.book.repository.BookRepository;
 import com.dokdok.gathering.entity.Gathering;
+import com.dokdok.gathering.exception.GatheringErrorCode;
+import com.dokdok.gathering.exception.GatheringException;
 import com.dokdok.gathering.service.GatheringValidator;
 import com.dokdok.gathering.repository.GatheringMemberRepository;
 import com.dokdok.gathering.repository.GatheringRepository;
@@ -44,15 +48,18 @@ public class MeetingService {
     private final UserValidator userValidator;
 
     /**
-     * 특정 약속의 정보를 확인할 수 있다.
+     * 특정 약속의 정보를 확인할 수 있다. 모임에 속한 사용자만 조회 가능
      * @param meetingId 약속 식별자
      * @return 약속 응답 정보
      */
     @Transactional(readOnly = true)
     public MeetingResponse findMeeting(Long meetingId) {
 
-        // todo : 모임에 속해있는 사용자만 확일할 수 있는 제약 사항 추가 -> 시큐리티 role로 확인할지, 따로 메서드로 만들지
+        Long userId = SecurityUtil.getCurrentUserId();
         Meeting meeting = meetingValidator.findMeetingOrThrow(meetingId);
+
+        // 모임 멤버만 약속 조회 가능
+        gatheringValidator.validateMembership(meeting.getGathering().getId(), userId);
 
         List<MeetingMember> meetingMembers = meetingMemberRepository.findAllByMeetingId(meetingId);
         List<Topic> topics = topicRepository.findAllByMeetingId(meetingId);
@@ -61,20 +68,22 @@ public class MeetingService {
     }
 
     /**
-     * 모임원이 약속 생성 신청을 할 수 있다.
+     * 모임원이 약속 생성 신청을 할 수 있다. 모임에 속한 사용자만 생성 가능
      * @param request 약속 생성 신청 폼
-     * @param userId 신청인 식별자
      * @return 약속 응답 정보
      */
     @Transactional
-    public MeetingResponse createMeeting(MeetingCreateRequest request, Long userId) {
-        // todo : 모임에 속해있는 사용자만 약속을 생성할 수 있는 제약 사항 추가
-        Gathering gathering = gatheringRepository.findById(request.gatheringId())
-                .orElseThrow(() -> new MeetingException(MeetingErrorCode.GATHERING_NOT_FOUND));
+    public MeetingResponse createMeeting(MeetingCreateRequest request) {
+        Long userId = SecurityUtil.getCurrentUserId();
 
-        // todo : 개별 Book, User 에러코드 생기면 그 Exception으로 변경하는 게 좋을 듯함
+        // 모임 멤버만 약속 생성 가능
+        gatheringValidator.validateMembership(request.gatheringId(), userId);
+
+        Gathering gathering = gatheringRepository.findById(request.gatheringId())
+                .orElseThrow(() -> new GatheringException(GatheringErrorCode.GATHERING_NOT_FOUND));
+
         Book book = bookRepository.findById(request.bookId())
-                .orElseThrow(() -> new MeetingException(MeetingErrorCode.BOOK_NOT_FOUND));
+                .orElseThrow(() -> new BookException(BookErrorCode.BOOK_NOT_FOUND));
 
         User user = userValidator.findUserOrThrow(userId);
 
@@ -84,6 +93,9 @@ public class MeetingService {
                     .countByGatheringIdAndRemovedAtIsNull(gathering.getId());
         }
 
+        // 최대 참가 인원 검증
+        validateMaxParticipants(maxParticipants, gathering.getId());
+
         Meeting meeting = Meeting.create(request, gathering, book, user, maxParticipants);
         Meeting savedMeeting = meetingRepository.save(meeting);
 
@@ -91,7 +103,7 @@ public class MeetingService {
     }
 
     /**
-     * 약속 상태를 변경한다. - PENDING 상태일 때만 CONFIRMED로 변경 가능
+     * 약속 상태를 변경한다. 모임장만 상태 변경 가능
      * @param meetingId 약속 식별자
      * @param meetingStatus 약속 상태
      * @return 약속 상태 응답 정보
@@ -99,8 +111,11 @@ public class MeetingService {
     @Transactional
     public MeetingStatusResponse changeMeetingStatus(Long meetingId, MeetingStatus meetingStatus) {
 
-        // todo : 모임장만 바꿀 수 있도록 meetingValidator 머지된 후 추가 예정
+        Long userId = SecurityUtil.getCurrentUserId();
         Meeting meeting = meetingValidator.findMeetingOrThrow(meetingId);
+
+        // 모임장만 상태 변경 가능
+        gatheringValidator.validateLeader(meeting.getGathering().getId(), userId);
 
         if (meetingStatus == MeetingStatus.CONFIRMED) {
             validateConfirmable(meeting);
@@ -110,6 +125,23 @@ public class MeetingService {
         meeting.changeStatus(meetingStatus);
 
         return MeetingStatusResponse.from(meeting);
+    }
+
+    /**
+     * 최대 참가 인원의 유효성을 검증한다.
+     * @param maxParticipants 최대 참가 인원
+     * @param gatheringId 모임 식별자
+     */
+    private void validateMaxParticipants(Integer maxParticipants, Long gatheringId) {
+        if (maxParticipants < 1) {
+            throw new MeetingException(MeetingErrorCode.INVALID_MAX_PARTICIPANTS);
+        }
+
+        int totalGatheringMembers = gatheringMemberRepository
+                .countByGatheringIdAndRemovedAtIsNull(gatheringId);
+        if (maxParticipants > totalGatheringMembers) {
+            throw new MeetingException(MeetingErrorCode.INVALID_MAX_PARTICIPANTS);
+        }
     }
 
     /**
@@ -160,7 +192,7 @@ public class MeetingService {
 
         gatheringValidator.validateMembership(meeting.getGathering().getId(), userId);
 
-        if (restoreCanceledMemberIfExists(meetingId, userId)) {
+        if (restoreCanceledMemberIfExists(meetingId, userId, meeting.getMaxParticipants())) {
             return meetingId;
         }
 
@@ -174,9 +206,9 @@ public class MeetingService {
     }
 
     /**
-     * 기존 취소 이력이 있으면 복구하고, 이미 참여 상태면 예외를 던진다.
+     * 기존 취소 이력이 있으면 정원 검증 후 복구하고, 이미 참여 상태면 예외를 던진다.
      */
-    private boolean restoreCanceledMemberIfExists(Long meetingId, Long userId) {
+    private boolean restoreCanceledMemberIfExists(Long meetingId, Long userId, Integer maxParticipants) {
         MeetingMember existingMember = meetingMemberRepository.findAnyByMeetingIdAndUserId(meetingId, userId)
                 .orElse(null);
         if (existingMember == null) {
@@ -185,6 +217,10 @@ public class MeetingService {
         if (existingMember.getCanceledAt() == null) {
             throw new MeetingException(MeetingErrorCode.MEETING_ALREADY_JOINED);
         }
+
+        // 복구 전 정원 검증
+        meetingValidator.validateCapacity(meetingId, maxParticipants);
+
         existingMember.restore();
         return true;
     }
@@ -202,7 +238,7 @@ public class MeetingService {
     }
 
     /**
-     * 약속 참가 신청을 취소한다. 약속 시작 24시간 이내에는 취소할 수 없다.
+     * 약속 참가 신청을 취소한다. 약속 시작까지 24시간 미만 남았으면 취소 불가
      * @param meetingId 약속 식별자
      * @return 취소한 약속 식별자
      */

--- a/src/test/java/com/dokdok/meeting/service/MeetingServiceTest.java
+++ b/src/test/java/com/dokdok/meeting/service/MeetingServiceTest.java
@@ -1,6 +1,8 @@
 package com.dokdok.meeting.service;
 
 import com.dokdok.book.entity.Book;
+import com.dokdok.book.exception.BookErrorCode;
+import com.dokdok.book.exception.BookException;
 import com.dokdok.book.repository.BookRepository;
 import com.dokdok.gathering.entity.Gathering;
 import com.dokdok.gathering.exception.GatheringErrorCode;
@@ -106,6 +108,7 @@ class MeetingServiceTest {
     @Test
     void givenMeetingId_whenFindMeeting_thenMeetingResponse() {
         // given
+        Long userId = 1L;
         given(meetingValidator.findMeetingOrThrow(meetingId))
                 .willReturn(meeting);
         given(meetingMemberRepository.findAllByMeetingId(meetingId))
@@ -113,13 +116,16 @@ class MeetingServiceTest {
         given(topicRepository.findAllByMeetingId(meetingId))
                 .willReturn(java.util.Collections.emptyList());
 
-        // when
-        MeetingResponse findMeeting = meetingService.findMeeting(meetingId);
+        try (MockedStatic<SecurityUtil> securityUtilMock = mockStatic(SecurityUtil.class)) {
+            securityUtilMock.when(SecurityUtil::getCurrentUserId).thenReturn(userId);
 
-        // then
-        assertThat(findMeeting.meetingName()).isEqualTo(meeting.getMeetingName());
-        assertThat(findMeeting.meetingStatus()).isEqualTo(meeting.getMeetingStatus());
+            // when
+            MeetingResponse findMeeting = meetingService.findMeeting(meetingId);
 
+            // then
+            assertThat(findMeeting.meetingName()).isEqualTo(meeting.getMeetingName());
+            assertThat(findMeeting.meetingStatus()).isEqualTo(meeting.getMeetingStatus());
+        }
     }
 
     @DisplayName("존재하지 않는 약속을 조회하면 예외를 던진다.")
@@ -127,15 +133,20 @@ class MeetingServiceTest {
     void givenMissingMeetingId_whenFindMeeting_thenThrowMeetingException() {
         // given
         Long meetingId = 999L;
+        Long userId = 1L;
 
         given(meetingValidator.findMeetingOrThrow(meetingId))
                 .willThrow(new MeetingException(MeetingErrorCode.MEETING_NOT_FOUND));
 
-        // when + then
-        assertThatThrownBy(() -> meetingService.findMeeting(meetingId))
-                .isInstanceOf(MeetingException.class)
-                .extracting("errorCode")
-                .isEqualTo(MeetingErrorCode.MEETING_NOT_FOUND);
+        try (MockedStatic<SecurityUtil> securityUtilMock = mockStatic(SecurityUtil.class)) {
+            securityUtilMock.when(SecurityUtil::getCurrentUserId).thenReturn(userId);
+
+            // when + then
+            assertThatThrownBy(() -> meetingService.findMeeting(meetingId))
+                    .isInstanceOf(MeetingException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(MeetingErrorCode.MEETING_NOT_FOUND);
+        }
     }
 
     @DisplayName("약속 생성 요청을 처리하면 약속 응답을 반환한다.")
@@ -197,20 +208,24 @@ class MeetingServiceTest {
         given(meetingRepository.save(any(Meeting.class)))
                 .willReturn(savedMeeting);
 
-        // when
-        MeetingResponse response = meetingService.createMeeting(request, userId);
+        try (MockedStatic<SecurityUtil> securityUtilMock = mockStatic(SecurityUtil.class)) {
+            securityUtilMock.when(SecurityUtil::getCurrentUserId).thenReturn(userId);
 
-        // then
-        assertThat(response.meetingId()).isEqualTo(savedMeeting.getId());
-        assertThat(response.meetingStatus()).isEqualTo(MeetingStatus.PENDING);
-        assertThat(response.meetingName()).isEqualTo(book.getBookName());
-        assertThat(response.schedule().startDateTime()).isEqualTo(startDate);
-        assertThat(response.participants().maxCount()).isEqualTo(memberCount);
+            // when
+            MeetingResponse response = meetingService.createMeeting(request);
+
+            // then
+            assertThat(response.meetingId()).isEqualTo(savedMeeting.getId());
+            assertThat(response.meetingStatus()).isEqualTo(MeetingStatus.PENDING);
+            assertThat(response.meetingName()).isEqualTo(book.getBookName());
+            assertThat(response.schedule().startDateTime()).isEqualTo(startDate);
+            assertThat(response.participants().maxCount()).isEqualTo(memberCount);
+        }
     }
 
     @DisplayName("모임을 찾지 못하면 약속 생성 요청이 실패한다.")
     @Test
-    void givenMissingGathering_whenCreateMeeting_thenThrowMeetingException() {
+    void givenMissingGathering_whenCreateMeeting_thenThrowGatheringException() {
         // given
         Long gatheringId = 3L;
         Long userId = 7L;
@@ -221,16 +236,20 @@ class MeetingServiceTest {
         given(gatheringRepository.findById(gatheringId))
                 .willReturn(Optional.empty());
 
-        // when + then
-        assertThatThrownBy(() -> meetingService.createMeeting(request, userId))
-                .isInstanceOf(MeetingException.class)
-                .extracting("errorCode")
-                .isEqualTo(MeetingErrorCode.GATHERING_NOT_FOUND);
+        try (MockedStatic<SecurityUtil> securityUtilMock = mockStatic(SecurityUtil.class)) {
+            securityUtilMock.when(SecurityUtil::getCurrentUserId).thenReturn(userId);
+
+            // when + then
+            assertThatThrownBy(() -> meetingService.createMeeting(request))
+                    .isInstanceOf(GatheringException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(GatheringErrorCode.GATHERING_NOT_FOUND);
+        }
     }
 
     @DisplayName("책을 찾지 못하면 약속 생성 요청이 실패한다.")
     @Test
-    void givenMissingBook_whenCreateMeeting_thenThrowMeetingException() {
+    void givenMissingBook_whenCreateMeeting_thenThrowBookException() {
         // given
         Long gatheringId = 3L;
         Long bookId = 12L;
@@ -249,18 +268,23 @@ class MeetingServiceTest {
         given(bookRepository.findById(bookId))
                 .willReturn(Optional.empty());
 
-        // when + then
-        assertThatThrownBy(() -> meetingService.createMeeting(request, userId))
-                .isInstanceOf(MeetingException.class)
-                .extracting("errorCode")
-                .isEqualTo(MeetingErrorCode.BOOK_NOT_FOUND);
+        try (MockedStatic<SecurityUtil> securityUtilMock = mockStatic(SecurityUtil.class)) {
+            securityUtilMock.when(SecurityUtil::getCurrentUserId).thenReturn(userId);
+
+            // when + then
+            assertThatThrownBy(() -> meetingService.createMeeting(request))
+                    .isInstanceOf(BookException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(BookErrorCode.BOOK_NOT_FOUND);
+        }
     }
 
-    @DisplayName("신청된 약속을 확정하면 약속장이 멤버로 포함된다.")
+    @DisplayName("모임장이 약속을 확정하면 약속장이 멤버로 포함된다.")
     @Test
     void givenMeetingStatus_whenChangeStatus_thenMeetingStatusChange() {
         // given
         Long meetingId = 1L;
+        Long gatheringLeaderId = 10L;
         MeetingStatus meetingStatus = MeetingStatus.CONFIRMED;
 
         given(meetingValidator.findMeetingOrThrow(meetingId)).willReturn(meeting);
@@ -269,16 +293,21 @@ class MeetingServiceTest {
         given(meetingMemberRepository.findByMeetingIdAndUserId(meetingId, leader.getId()))
                 .willReturn(Optional.empty());
 
-        // when
-        MeetingStatusResponse response = meetingService.changeMeetingStatus(meetingId, meetingStatus);
+        try (MockedStatic<SecurityUtil> securityUtilMock = mockStatic(SecurityUtil.class)) {
+            securityUtilMock.when(SecurityUtil::getCurrentUserId).thenReturn(gatheringLeaderId);
 
-        // then
-        assertThat(meeting.getMeetingStatus()).isEqualTo(response.meetingStatus());
-        ArgumentCaptor<MeetingMember> meetingMemberCaptor = ArgumentCaptor.forClass(MeetingMember.class);
-        verify(meetingMemberRepository).save(meetingMemberCaptor.capture());
-        MeetingMember savedMember = meetingMemberCaptor.getValue();
-        assertThat(savedMember.getUser().getId()).isEqualTo(leader.getId());
-        assertThat(savedMember.getMeetingRole()).isEqualTo(MeetingMemberRole.LEADER);
+            // when
+            MeetingStatusResponse response = meetingService.changeMeetingStatus(meetingId, meetingStatus);
+
+            // then
+            verify(gatheringValidator).validateLeader(gathering.getId(), gatheringLeaderId);
+            assertThat(meeting.getMeetingStatus()).isEqualTo(response.meetingStatus());
+            ArgumentCaptor<MeetingMember> meetingMemberCaptor = ArgumentCaptor.forClass(MeetingMember.class);
+            verify(meetingMemberRepository).save(meetingMemberCaptor.capture());
+            MeetingMember savedMember = meetingMemberCaptor.getValue();
+            assertThat(savedMember.getUser().getId()).isEqualTo(leader.getId());
+            assertThat(savedMember.getMeetingRole()).isEqualTo(MeetingMemberRole.LEADER);
+        }
     }
 
     @DisplayName("이미 확정된 약속이 있으면 다른 약속을 확정할 수 없다.")
@@ -286,15 +315,41 @@ class MeetingServiceTest {
     void givenConfirmedMeetingExists_whenConfirm_thenThrowMeetingException() {
         // given
         Long meetingId = 1L;
+        Long gatheringLeaderId = 10L;
         given(meetingValidator.findMeetingOrThrow(meetingId)).willReturn(meeting);
         given(meetingRepository.existsByGatheringIdAndMeetingStatus(gathering.getId(), MeetingStatus.CONFIRMED))
                 .willReturn(true);
 
-        // when + then
-        assertThatThrownBy(() -> meetingService.changeMeetingStatus(meetingId, MeetingStatus.CONFIRMED))
-                .isInstanceOf(MeetingException.class)
-                .extracting("errorCode")
-                .isEqualTo(MeetingErrorCode.INVALID_MEETING_STATUS_CHANGE);
+        try (MockedStatic<SecurityUtil> securityUtilMock = mockStatic(SecurityUtil.class)) {
+            securityUtilMock.when(SecurityUtil::getCurrentUserId).thenReturn(gatheringLeaderId);
+
+            // when + then
+            assertThatThrownBy(() -> meetingService.changeMeetingStatus(meetingId, MeetingStatus.CONFIRMED))
+                    .isInstanceOf(MeetingException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(MeetingErrorCode.INVALID_MEETING_STATUS_CHANGE);
+        }
+    }
+
+    @DisplayName("모임장이 아닌 사용자는 약속 상태를 변경할 수 없다.")
+    @Test
+    void givenNotGatheringLeader_whenChangeStatus_thenThrowGatheringException() {
+        // given
+        Long meetingId = 1L;
+        Long notLeaderId = 99L;
+        given(meetingValidator.findMeetingOrThrow(meetingId)).willReturn(meeting);
+        doThrow(new GatheringException(GatheringErrorCode.NOT_GATHERING_LEADER))
+                .when(gatheringValidator).validateLeader(gathering.getId(), notLeaderId);
+
+        try (MockedStatic<SecurityUtil> securityUtilMock = mockStatic(SecurityUtil.class)) {
+            securityUtilMock.when(SecurityUtil::getCurrentUserId).thenReturn(notLeaderId);
+
+            // when + then
+            assertThatThrownBy(() -> meetingService.changeMeetingStatus(meetingId, MeetingStatus.CONFIRMED))
+                    .isInstanceOf(GatheringException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(GatheringErrorCode.NOT_GATHERING_LEADER);
+        }
     }
 
     @DisplayName("약속장이 없으면 약속 확정이 실패한다.")
@@ -302,6 +357,7 @@ class MeetingServiceTest {
     void givenMissingLeader_whenConfirm_thenThrowMeetingException() {
         // given
         Long meetingId = 1L;
+        Long gatheringLeaderId = 10L;
         Meeting missingLeaderMeeting = Meeting.builder()
                 .id(meetingId)
                 .meetingName("Meeting 1")
@@ -312,11 +368,15 @@ class MeetingServiceTest {
         given(meetingRepository.existsByGatheringIdAndMeetingStatus(gathering.getId(), MeetingStatus.CONFIRMED))
                 .willReturn(false);
 
-        // when + then
-        assertThatThrownBy(() -> meetingService.changeMeetingStatus(meetingId, MeetingStatus.CONFIRMED))
-                .isInstanceOf(MeetingException.class)
-                .extracting("errorCode")
-                .isEqualTo(MeetingErrorCode.INVALID_MEETING_STATUS_CHANGE);
+        try (MockedStatic<SecurityUtil> securityUtilMock = mockStatic(SecurityUtil.class)) {
+            securityUtilMock.when(SecurityUtil::getCurrentUserId).thenReturn(gatheringLeaderId);
+
+            // when + then
+            assertThatThrownBy(() -> meetingService.changeMeetingStatus(meetingId, MeetingStatus.CONFIRMED))
+                    .isInstanceOf(MeetingException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(MeetingErrorCode.INVALID_MEETING_STATUS_CHANGE);
+        }
     }
 
     @DisplayName("확정된 약속은 다시 신청 상태로 되돌릴 수 없다.")
@@ -324,6 +384,7 @@ class MeetingServiceTest {
     void givenConfirmedMeeting_whenRollbackToPending_thenThrowMeetingException() {
         // given
         Long meetingId = 1L;
+        Long gatheringLeaderId = 10L;
         Meeting confirmedMeeting = Meeting.builder()
                 .id(meetingId)
                 .meetingName("Meeting 1")
@@ -333,12 +394,15 @@ class MeetingServiceTest {
                 .build();
         given(meetingValidator.findMeetingOrThrow(meetingId)).willReturn(confirmedMeeting);
 
-        // when + then
-        assertThatThrownBy(() -> meetingService.changeMeetingStatus(meetingId, MeetingStatus.PENDING))
-                .isInstanceOf(MeetingException.class)
-                .extracting("errorCode")
-                .isEqualTo(MeetingErrorCode.INVALID_MEETING_STATUS_CHANGE);
+        try (MockedStatic<SecurityUtil> securityUtilMock = mockStatic(SecurityUtil.class)) {
+            securityUtilMock.when(SecurityUtil::getCurrentUserId).thenReturn(gatheringLeaderId);
 
+            // when + then
+            assertThatThrownBy(() -> meetingService.changeMeetingStatus(meetingId, MeetingStatus.PENDING))
+                    .isInstanceOf(MeetingException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(MeetingErrorCode.INVALID_MEETING_STATUS_CHANGE);
+        }
     }
 
     @DisplayName("약속 참가 신청을 한다.")
@@ -425,8 +489,10 @@ class MeetingServiceTest {
         // given
         Long meetingId = 3L;
         Long userId = 7L;
+        Integer maxParticipants = 5;
         Meeting meeting = Meeting.builder()
                 .id(meetingId)
+                .maxParticipants(maxParticipants)
                 .gathering(Gathering.builder()
                         .id(1L)
                         .gatheringName("gathering")
@@ -453,7 +519,7 @@ class MeetingServiceTest {
             // then
             assertThat(response).isEqualTo(meetingId);
             assertThat(canceledMember.getCanceledAt()).isNull();
-            verify(meetingValidator, never()).validateCapacity(any(), any());
+            verify(meetingValidator).validateCapacity(meetingId, maxParticipants);
             verify(userValidator, never()).findUserOrThrow(any());
             verify(meetingMemberRepository, never()).save(any());
         }


### PR DESCRIPTION
## PR 요약
> 이 PR이 어떤 변경을 하는지 간단히 설명하고, 체크 표시는 괄호 사이에 소문자 'x'를 삽입하세요.

- [ ] 기능 추가
- [ ] 버그 수정
- [x] 코드 리팩토링
- [ ] 문서 수정
- [ ] 기타 (설명)

---

## 이슈 번호
- #66

---

## 주요 변경 사항
> 주요 파일, 로직, 컴포넌트 등을 구체적으로 적어주세요.

  1. 약속 상태 변경 권한 수정

  변경 내용: 약속 상태 변경 권한을 약속장에서 모임장으로 변경

  MeetingService.changeMeetingStatus()
  - 기존: 약속장(meeting.getMeetingLeader()) 검증
  - 변경: 모임장(gatheringValidator.validateLeader()) 검증
  - 미사용 메서드 제거: validateMeetingLeader() 삭제

  영향
  - 약속 확정/취소는 이제 모임장만 가능
  - 약속을 생성한 사람(약속장)이 아닌 모임 관리자(모임장)가 약속을 관리

  2. 약속 생성 시 userId 처리 방식 개선

  변경 내용: 하드코딩된 userId를 제거하고 SecurityUtil에서 인증 정보 획득

  MeetingService.createMeeting()
  - 메서드 시그니처 변경: createMeeting(request, userId) → createMeeting(request)
  - 메서드 내부에서 SecurityUtil.getCurrentUserId()로 현재 사용자 ID 획득

  MeetingController.createMeeting()
  - 하드코딩 제거: createMeeting(request, 1L) → createMeeting(request)
  - TODO 주석 제거

  3. 테스트 코드 수정

---

## 참고 사항
> 리뷰어가 알아야 할 추가 정보, 테스트 방법 등을 작성해주세요.

예:
- 테스트 계정 정보
- 관련 API 엔드포인트
- 로컬 테스트 방법

---
