### PR TITLE
[#19][FEAT] 주제 확정 api

### DIFF
--- a/src/main/java/com/dokdok/topic/api/TopicApi.java
+++ b/src/main/java/com/dokdok/topic/api/TopicApi.java
@@ -1,7 +1,9 @@
 package com.dokdok.topic.api;
 
 import com.dokdok.global.response.ApiResponse;
+import com.dokdok.topic.dto.request.ConfirmTopicsRequest;
 import com.dokdok.topic.dto.request.SuggestTopicRequest;
+import com.dokdok.topic.dto.response.ConfirmTopicsResponse;
 import com.dokdok.topic.dto.response.SuggestTopicResponse;
 import com.dokdok.topic.dto.response.TopicsPageResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -17,8 +19,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 
 @Tag(name = "주제 관리", description = "주제 관련 API")
@@ -81,5 +83,32 @@ public interface TopicApi {
             @PathVariable Long meetingId,
             @ParameterObject
             @PageableDefault(size = 10) Pageable pageable
+    );
+
+    @Operation(
+            summary = "제안된 주제 확정",
+            description = "약속에서 제안된 주제를 확정합니다.",
+            parameters = {
+                    @Parameter(name = "gatheringId", description = "모임 식별자", in = ParameterIn.PATH, required = true),
+                    @Parameter(name = "meetingId", description = "약속 식별자", in = ParameterIn.PATH, required = true)
+            }
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "주제 확정 성공",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = ConfirmTopicsResponse.class))
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "모임 또는 약속의 멤버가 아님"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "모임 또는 약속 또는 주제를 찾을 수 없음"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 오류")
+    })
+    @PatchMapping(value = "/topics/confirm", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
+    ResponseEntity<ApiResponse<ConfirmTopicsResponse>> confirmTopics(
+            @PathVariable Long gatheringId,
+            @PathVariable Long meetingId,
+            @Valid @RequestBody ConfirmTopicsRequest request
     );
 }

--- a/src/main/java/com/dokdok/topic/controller/TopicController.java
+++ b/src/main/java/com/dokdok/topic/controller/TopicController.java
@@ -2,7 +2,9 @@ package com.dokdok.topic.controller;
 
 import com.dokdok.global.response.ApiResponse;
 import com.dokdok.topic.api.TopicApi;
+import com.dokdok.topic.dto.request.ConfirmTopicsRequest;
 import com.dokdok.topic.dto.request.SuggestTopicRequest;
+import com.dokdok.topic.dto.response.ConfirmTopicsResponse;
 import com.dokdok.topic.dto.response.SuggestTopicResponse;
 import com.dokdok.topic.dto.response.TopicsPageResponse;
 import com.dokdok.topic.service.TopicService;
@@ -12,6 +14,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -49,4 +52,17 @@ public class TopicController implements TopicApi {
         return ApiResponse.success(response, "제안된 주제 조회를 완료했습니다.");
     }
 
+    @Override
+    @PatchMapping(value = "/topics/confirm")
+    public ResponseEntity<ApiResponse<ConfirmTopicsResponse>> confirmTopics(
+            Long gatheringId,
+            Long meetingId,
+            ConfirmTopicsRequest request
+    ) {
+        ConfirmTopicsResponse response = topicService.confirmTopics(
+                gatheringId, meetingId, request
+        );
+
+        return ApiResponse.success(response, "주제가 확정되었습니다.");
+    }
 }

--- a/src/main/java/com/dokdok/topic/dto/request/ConfirmTopicsRequest.java
+++ b/src/main/java/com/dokdok/topic/dto/request/ConfirmTopicsRequest.java
@@ -1,0 +1,11 @@
+package com.dokdok.topic.dto.request;
+
+import jakarta.validation.constraints.NotEmpty;
+
+import java.util.List;
+
+public record ConfirmTopicsRequest(
+        @NotEmpty(message = "topicIds는 필수입니다")
+        List<Long> topicIds
+) {
+}

--- a/src/main/java/com/dokdok/topic/dto/response/ConfirmTopicsResponse.java
+++ b/src/main/java/com/dokdok/topic/dto/response/ConfirmTopicsResponse.java
@@ -1,0 +1,12 @@
+package com.dokdok.topic.dto.response;
+
+import com.dokdok.topic.entity.TopicStatus;
+
+public record ConfirmTopicsResponse(
+        Long meetingId,
+        TopicStatus topicStatus
+) {
+    public static ConfirmTopicsResponse from(Long meetingId) {
+        return new ConfirmTopicsResponse(meetingId, TopicStatus.CONFIRMED);
+    }
+}

--- a/src/main/java/com/dokdok/topic/entity/Topic.java
+++ b/src/main/java/com/dokdok/topic/entity/Topic.java
@@ -53,6 +53,9 @@ public class Topic extends BaseTimeEntity {
     @Builder.Default
     private Integer likeCount = 0;
 
+    @Column(name = "confirm_order")
+    private Integer confirmOrder;
+
     public static Topic of(
             Meeting meeting,
             User user,
@@ -67,5 +70,13 @@ public class Topic extends BaseTimeEntity {
                 .description(description)
                 .topicType(topicType)
                 .build();
+    }
+
+    public void updateStatus(TopicStatus topicStatus) {
+        this.topicStatus = topicStatus;
+    }
+
+    public void updateConfirmOrder(Integer confirmOrder) {
+        this.confirmOrder = confirmOrder;
     }
 }

--- a/src/main/java/com/dokdok/topic/exception/TopicErrorCode.java
+++ b/src/main/java/com/dokdok/topic/exception/TopicErrorCode.java
@@ -11,7 +11,8 @@ public enum TopicErrorCode implements BaseErrorCode {
     // 리소스 에러
     TOPIC_NOT_FOUND("E101", "토픽을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
     TOPIC_ANSWER_NOT_FOUND("E102", "답변을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
-    TOPIC_ANSWER_ALREADY_SUBMITTED("E103", "이미 제출된 답변입니다.", HttpStatus.CONFLICT);
+    TOPIC_ANSWER_ALREADY_SUBMITTED("E103", "이미 제출된 답변입니다.", HttpStatus.CONFLICT),
+    TOPIC_ANSWER_ALREADY_EXISTS("E104", "이미 답변이 존재합니다.", HttpStatus.CONFLICT);
 
     private final String code;
     private final String message;

--- a/src/main/java/com/dokdok/topic/repository/TopicAnswerRepository.java
+++ b/src/main/java/com/dokdok/topic/repository/TopicAnswerRepository.java
@@ -7,4 +7,6 @@ import java.util.Optional;
 
 public interface TopicAnswerRepository extends JpaRepository<TopicAnswer, Long> {
     Optional<TopicAnswer> findByTopicIdAndUserId(Long topicId, Long userId);
+
+    boolean existsByTopicIdAndUserId(Long topicId, Long userId);
 }

--- a/src/main/java/com/dokdok/topic/repository/TopicRepository.java
+++ b/src/main/java/com/dokdok/topic/repository/TopicRepository.java
@@ -15,8 +15,7 @@ import java.util.List;
 public interface TopicRepository extends JpaRepository<Topic, Long> {
 
     List<Topic> findAllByMeetingId(Long meetingId);
-
-    boolean existsByIdAndMeetingId(Long topicId, Long meetingId);
+    List<Topic> findAllByIdInAndMeetingId(List<Long> topicIds, Long meetingId);
 
     @Modifying
     @Query("""

--- a/src/main/java/com/dokdok/topic/service/TopicAnswerService.java
+++ b/src/main/java/com/dokdok/topic/service/TopicAnswerService.java
@@ -41,6 +41,11 @@ public class TopicAnswerService {
         meetingValidator.validateMemberInGathering(meetingId, gatheringId);
         topicValidator.validateTopicInMeeting(topicId, meetingId);
 
+        boolean exists = topicAnswerRepository.findByTopicIdAndUserId(topicId, userId).isPresent();
+        if (exists) {
+            throw new TopicException(TopicErrorCode.TOPIC_ANSWER_ALREADY_EXISTS);
+        }
+
         Topic topic = topicRepository.getReferenceById(topicId);
         User user = SecurityUtil.getCurrentUserEntity();
 

--- a/src/main/java/com/dokdok/topic/service/TopicAnswerService.java
+++ b/src/main/java/com/dokdok/topic/service/TopicAnswerService.java
@@ -41,7 +41,7 @@ public class TopicAnswerService {
         meetingValidator.validateMemberInGathering(meetingId, gatheringId);
         topicValidator.validateTopicInMeeting(topicId, meetingId);
 
-        boolean exists = topicAnswerRepository.findByTopicIdAndUserId(topicId, userId).isPresent();
+        boolean exists = topicAnswerRepository.existsByTopicIdAndUserId(topicId, userId);
         if (exists) {
             throw new TopicException(TopicErrorCode.TOPIC_ANSWER_ALREADY_EXISTS);
         }

--- a/src/main/java/com/dokdok/topic/service/TopicService.java
+++ b/src/main/java/com/dokdok/topic/service/TopicService.java
@@ -5,10 +5,15 @@ import com.dokdok.global.util.SecurityUtil;
 import com.dokdok.meeting.entity.Meeting;
 import com.dokdok.meeting.entity.MeetingMember;
 import com.dokdok.meeting.service.MeetingValidator;
+import com.dokdok.topic.dto.request.ConfirmTopicsRequest;
 import com.dokdok.topic.dto.request.SuggestTopicRequest;
+import com.dokdok.topic.dto.response.ConfirmTopicsResponse;
 import com.dokdok.topic.dto.response.SuggestTopicResponse;
 import com.dokdok.topic.dto.response.TopicsPageResponse;
 import com.dokdok.topic.entity.Topic;
+import com.dokdok.topic.entity.TopicStatus;
+import com.dokdok.topic.exception.TopicErrorCode;
+import com.dokdok.topic.exception.TopicException;
 import com.dokdok.topic.repository.TopicRepository;
 import com.dokdok.user.entity.User;
 import lombok.RequiredArgsConstructor;
@@ -18,6 +23,12 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.RequestMapping;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -79,5 +90,40 @@ public class TopicService {
                 topicRepository.findTopicsByMeetingId(meetingId, noSortPageable);
 
         return TopicsPageResponse.from(topicPage);
+    }
+
+    @Transactional
+    public ConfirmTopicsResponse confirmTopics(
+            Long gatheringId,
+            Long meetingId,
+            ConfirmTopicsRequest request
+    ) {
+        Long userId = SecurityUtil.getCurrentUserId();
+
+        gatheringValidator.validateMembership(gatheringId, userId);
+        meetingValidator.validateMemberInGathering(meetingId, gatheringId);
+
+        List<Long> topicIds = request.topicIds();
+
+        List<Topic> topics = topicRepository.findAllByIdInAndMeetingId(topicIds, meetingId);
+        if (topics.size() != topicIds.size()) {
+            throw new TopicException(TopicErrorCode.TOPIC_NOT_FOUND);
+        }
+
+        Map<Long, Topic> topicMap =
+                topics.stream()
+                        .collect(Collectors.toMap(Topic::getId, Function.identity()));
+
+        for (int i = 0; i < topicIds.size(); i++) {
+            Long topicId = topicIds.get(i);
+            Topic topic = topicMap.get(topicId);
+            if (topic == null) {
+                throw new TopicException(TopicErrorCode.TOPIC_NOT_FOUND);
+            }
+            topic.updateStatus(TopicStatus.CONFIRMED);
+            topic.updateConfirmOrder(i + 1);
+        }
+
+        return ConfirmTopicsResponse.from(meetingId);
     }
 }

--- a/src/test/java/com/dokdok/topic/service/TopicServiceTest.java
+++ b/src/test/java/com/dokdok/topic/service/TopicServiceTest.java
@@ -12,12 +12,16 @@ import com.dokdok.meeting.entity.MeetingStatus;
 import com.dokdok.meeting.exception.MeetingErrorCode;
 import com.dokdok.meeting.exception.MeetingException;
 import com.dokdok.meeting.service.MeetingValidator;
+import com.dokdok.topic.dto.request.ConfirmTopicsRequest;
 import com.dokdok.topic.dto.request.SuggestTopicRequest;
+import com.dokdok.topic.dto.response.ConfirmTopicsResponse;
 import com.dokdok.topic.dto.response.SuggestTopicResponse;
 import com.dokdok.topic.dto.response.TopicsPageResponse;
 import com.dokdok.topic.entity.Topic;
 import com.dokdok.topic.entity.TopicStatus;
 import com.dokdok.topic.entity.TopicType;
+import com.dokdok.topic.exception.TopicErrorCode;
+import com.dokdok.topic.exception.TopicException;
 import com.dokdok.topic.repository.TopicRepository;
 import com.dokdok.user.entity.User;
 import org.junit.jupiter.api.BeforeEach;
@@ -102,6 +106,86 @@ class TopicServiceTest {
                 "변수명, 함수명, 클래스명을 짓는 원칙에 대해 토론합니다.",
                 TopicType.DISCUSSION
         );
+    }
+
+    @Test
+    @DisplayName("선택한 주제를 확정 상태로 변경한다")
+    void confirmTopics_Success() {
+        Long gatheringId = 1L;
+        Long meetingId = 1L;
+        Long userId = 1L;
+        List<Long> topicIds = List.of(12L, 13L);
+        ConfirmTopicsRequest request = new ConfirmTopicsRequest(topicIds);
+
+        Topic topic1 = Topic.builder()
+                .id(12L)
+                .meeting(testMeeting)
+                .topicStatus(TopicStatus.PROPOSED)
+                .build();
+        Topic topic2 = Topic.builder()
+                .id(13L)
+                .meeting(testMeeting)
+                .topicStatus(TopicStatus.VOTING)
+                .build();
+
+        try (MockedStatic<SecurityUtil> securityUtilMock = mockStatic(SecurityUtil.class)) {
+            securityUtilMock.when(SecurityUtil::getCurrentUserId)
+                    .thenReturn(userId);
+
+            doNothing().when(gatheringValidator)
+                    .validateMembership(gatheringId, userId);
+            doNothing().when(meetingValidator)
+                    .validateMemberInGathering(meetingId, gatheringId);
+            given(topicRepository.findAllByIdInAndMeetingId(topicIds, meetingId))
+                    .willReturn(List.of(topic1, topic2));
+
+            ConfirmTopicsResponse response =
+                    topicService.confirmTopics(gatheringId, meetingId, request);
+
+            assertThat(response.meetingId()).isEqualTo(meetingId);
+            assertThat(response.topicStatus()).isEqualTo(TopicStatus.CONFIRMED);
+            assertThat(topic1.getTopicStatus()).isEqualTo(TopicStatus.CONFIRMED);
+            assertThat(topic2.getTopicStatus()).isEqualTo(TopicStatus.CONFIRMED);
+            assertThat(topic1.getConfirmOrder()).isEqualTo(1);
+            assertThat(topic2.getConfirmOrder()).isEqualTo(2);
+
+            verify(gatheringValidator).validateMembership(gatheringId, userId);
+            verify(meetingValidator).validateMemberInGathering(meetingId, gatheringId);
+            verify(topicRepository).findAllByIdInAndMeetingId(topicIds, meetingId);
+        }
+    }
+
+    @Test
+    @DisplayName("선택한 주제가 존재하지 않으면 예외가 발생한다")
+    void confirmTopics_ThrowsWhenTopicMissing() {
+        Long gatheringId = 1L;
+        Long meetingId = 1L;
+        Long userId = 1L;
+        List<Long> topicIds = List.of(12L, 13L);
+        ConfirmTopicsRequest request = new ConfirmTopicsRequest(topicIds);
+
+        Topic topic1 = Topic.builder()
+                .id(12L)
+                .meeting(testMeeting)
+                .topicStatus(TopicStatus.PROPOSED)
+                .build();
+
+        try (MockedStatic<SecurityUtil> securityUtilMock = mockStatic(SecurityUtil.class)) {
+            securityUtilMock.when(SecurityUtil::getCurrentUserId)
+                    .thenReturn(userId);
+
+            doNothing().when(gatheringValidator)
+                    .validateMembership(gatheringId, userId);
+            doNothing().when(meetingValidator)
+                    .validateMemberInGathering(meetingId, gatheringId);
+            given(topicRepository.findAllByIdInAndMeetingId(topicIds, meetingId))
+                    .willReturn(List.of(topic1));
+
+            assertThatThrownBy(() ->
+                    topicService.confirmTopics(gatheringId, meetingId, request))
+                    .isInstanceOf(TopicException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", TopicErrorCode.TOPIC_NOT_FOUND);
+        }
     }
 
     @Test


### PR DESCRIPTION
 ## PR 요약

  > 이 PR이 어떤 변경을 하는지 간단히 설명하고, 체크 표시는 괄호 사이에 소문자 'x'를 삽입하세요.                                                                                     

  - [x] 기능 추가
  - [ ] 버그 수정
  - [ ] 코드 리팩토링
  - [ ] 문서 수정
  - [ ] 기타 (설명)

  ———

  ## 이슈 번호

  - #19 

  ———

  ## 주요 변경 사항

  > 주요 파일, 로직, 컴포넌트 등을 구체적으로 적어주세요.                                                                                                                            

  - src/main/java/com/dokdok/topic/api/TopicApi.java: 주제 확정 PATCH 엔드포인트 스펙 추가
  - src/main/java/com/dokdok/topic/controller/TopicController.java: 주제 확정 API 연결 및 응답 처리
  - src/main/java/com/dokdok/topic/service/TopicService.java: 확정 로직 구현(권한 검증, 순서대로 CONFIRMED + confirmOrder 저장)
  - src/main/java/com/dokdok/topic/entity/Topic.java: 확정 순서 저장용 confirmOrder 컬럼 및 업데이트 메서드 추가
  - src/main/java/com/dokdok/topic/repository/TopicRepository.java: 확정 대상 조회용 findAllByIdInAndMeetingId 추가
  - src/main/java/com/dokdok/topic/dto/request/ConfirmTopicsRequest.java: topicIds만 받는 요청 DTO 추가
  - src/main/java/com/dokdok/topic/dto/response/ConfirmTopicsResponse.java: 확정 응답 DTO 추가
  - src/test/java/com/dokdok/topic/service/TopicServiceTest.java: 확정 성공/누락 예외 테스트 추가

  ———

  ## 참고 사항

  > 리뷰어가 알아야 할 추가 정보, 테스트 방법 등을 작성해주세요.                                                                                                                     

  - 관련 API: PATCH /api/gatherings/{gathering_id}/meetings/{meeting_id}/topics/confirm