### PR TITLE
[#74][FEAT] 로그아웃 API 구현

### DIFF
--- a/src/main/java/com/dokdok/global/security/SecurityConfig.java
+++ b/src/main/java/com/dokdok/global/security/SecurityConfig.java
@@ -5,6 +5,7 @@ import com.dokdok.oauth2.handler.OAuth2AuthenticationFailureHandler;
 import com.dokdok.oauth2.handler.OAuth2AuthenticationSuccessHandler;
 import com.dokdok.oauth2.resolver.CustomAuthorizationRequestResolver;
 import com.dokdok.oauth2.service.CustomOAuth2UserService;
+import com.dokdok.global.response.ApiResponse;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
@@ -17,7 +18,9 @@ import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+import tools.jackson.databind.ObjectMapper;
 
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 
@@ -35,7 +38,8 @@ public class SecurityConfig {
             OAuth2AuthenticationSuccessHandler oauth2AuthenticationSuccessHandler,
             OAuth2AuthenticationFailureHandler oauth2AuthenticationFailureHandler,
             CustomAuthorizationRequestResolver customAuthorizationRequestResolver,
-            CorsConfigurationSource corsConfigurationSource) throws Exception {
+            CorsConfigurationSource corsConfigurationSource,
+            ObjectMapper objectMapper) throws Exception {
 
         http
                 .cors(cors -> cors.configurationSource(corsConfigurationSource))
@@ -59,6 +63,13 @@ public class SecurityConfig {
                         .logoutUrl("/api/auth/logout")
                         .logoutSuccessHandler((request, response, authentication) -> {
                             response.setStatus(HttpServletResponse.SC_OK);
+                            response.setContentType("application/json;charset=UTF-8");
+                            ApiResponse<Void> apiResponse = new ApiResponse<>("SUCCESS", "로그아웃 성공", null);
+                            try {
+                                response.getWriter().write(objectMapper.writeValueAsString(apiResponse));
+                            } catch (IOException e) {
+                                throw new RuntimeException("로그아웃 응답 처리 중 오류", e);
+                            }
                         })
                         .invalidateHttpSession(true)
                         .deleteCookies("JSESSIONID")

--- a/src/main/java/com/dokdok/user/api/AuthApi.java
+++ b/src/main/java/com/dokdok/user/api/AuthApi.java
@@ -3,6 +3,7 @@ package com.dokdok.user.api;
 import com.dokdok.global.response.ApiResponse;
 import com.dokdok.user.dto.response.UserInfoResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -11,6 +12,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 @Tag(name = "인증", description = "인증 관련 API")
@@ -59,4 +61,28 @@ public interface AuthApi {
     })
     @GetMapping(value = "/me", produces = MediaType.APPLICATION_JSON_VALUE)
     ResponseEntity<ApiResponse<UserInfoResponse>> getCurrentUser();
+
+    @Operation(
+            summary = "로그아웃",
+            description = "현재 세션을 무효화하고 보안 컨텍스트를 초기화합니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "로그아웃 성공",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = ApiResponse.class),
+                            examples = @ExampleObject(
+                                    value = "{\"code\":\"SUCCESS\",\"message\":\"로그아웃 성공\",\"data\":null}"
+                            )
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "500",
+                    description = "서버 오류"
+            )
+    })
+    @PostMapping(value = "/logout", produces = MediaType.APPLICATION_JSON_VALUE)
+    ResponseEntity<ApiResponse<Void>> logout();
 }

--- a/src/main/java/com/dokdok/user/api/UserApi.java
+++ b/src/main/java/com/dokdok/user/api/UserApi.java
@@ -2,6 +2,8 @@ package com.dokdok.user.api;
 
 import com.dokdok.global.response.ApiResponse;
 import com.dokdok.user.dto.request.OnboardRequest;
+import com.dokdok.user.dto.request.UpdateUserInfoRequest;
+import com.dokdok.user.dto.response.UserDetailResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
@@ -170,5 +172,143 @@ public interface UserApi {
     @GetMapping(value = "/check-nickname", produces = MediaType.APPLICATION_JSON_VALUE)
     ResponseEntity<ApiResponse<Void>> checkNickname(
             @RequestParam("nickname") String nickname
+    );
+
+    @Operation(
+            summary = "현재 사용자 정보 조회",
+            description = "현재 인증된 사용자의 프로필 정보를 조회합니다. SecurityContext에서 사용자 정보를 가져옵니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "프로필 조회 성공",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = UserDetailResponse.class),
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                              "code": "SUCCESS",
+                                              "message": "프로필 조회 성공",
+                                              "data": {
+                                                "userId": 1,
+                                                "nickname": "테스트닉네임",
+                                                "email": "test@example.com",
+                                                "profileImageUrl": "https://example.com/profile.jpg",
+                                                "createdAt": "2024-01-13T10:30:00"
+                                              }
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "401",
+                    description = "인증되지 않은 사용자",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(
+                                    value = "{\"code\":\"G001\",\"message\":\"인증되지 않은 사용자입니다.\"}"
+                            )
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "500",
+                    description = "서버 오류"
+            )
+    })
+    @GetMapping(value = "/me", produces = MediaType.APPLICATION_JSON_VALUE)
+    ResponseEntity<ApiResponse<UserDetailResponse>> getCurrentUser();
+
+    @Operation(
+            summary = "사용자 정보 수정",
+            description = "현재 사용자의 프로필 정보를 수정합니다. 현재는 닉네임만 수정 가능하며, 유효성 검사 및 중복 확인을 수행합니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "프로필 수정 성공",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = UserDetailResponse.class),
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                              "code": "SUCCESS",
+                                              "message": "프로필 수정 성공",
+                                              "data": {
+                                                "userId": 1,
+                                                "nickname": "변경된닉네임",
+                                                "email": "test@example.com",
+                                                "profileImageUrl": "https://example.com/profile.jpg",
+                                                "createdAt": "2024-01-13T10:30:00"
+                                              }
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "400",
+                    description = "잘못된 요청 (유효성 검사 실패)",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            examples = {
+                                    @ExampleObject(
+                                            name = "닉네임 필수",
+                                            description = "닉네임이 null이거나 빈 문자열인 경우",
+                                            value = "{\"code\":\"U003\",\"message\":\"닉네임은 필수 입력 항목입니다.\"}"
+                                    ),
+                                    @ExampleObject(
+                                            name = "닉네임 길이 오류",
+                                            description = "닉네임이 2자 미만 또는 20자 초과인 경우",
+                                            value = "{\"code\":\"U004\",\"message\":\"닉네임은 2자 이상 20자 이하로 입력해주세요.\"}"
+                                    ),
+                                    @ExampleObject(
+                                            name = "닉네임 형식 오류",
+                                            description = "특수문자, 공백, 이모지 등이 포함된 경우",
+                                            value = "{\"code\":\"U005\",\"message\":\"닉네임은 한글, 영문, 숫자만 사용 가능합니다.\"}"
+                                    )
+                            }
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "401",
+                    description = "인증되지 않은 사용자",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(
+                                    value = "{\"code\":\"G001\",\"message\":\"인증되지 않은 사용자입니다.\"}"
+                            )
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "사용자를 찾을 수 없음",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(
+                                    value = "{\"code\":\"U001\",\"message\":\"존재하지 않는 사용자입니디.\"}"
+                            )
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "409",
+                    description = "닉네임 중복",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(
+                                    value = "{\"code\":\"U002\",\"message\":\"이미 존재하는 사용자 닉네임입니다.\"}"
+                            )
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "500",
+                    description = "서버 오류"
+            )
+    })
+    @PatchMapping(value = "/me", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
+    ResponseEntity<ApiResponse<UserDetailResponse>> updateUserInfo(
+            @Valid @RequestBody UpdateUserInfoRequest request
     );
 }

--- a/src/main/java/com/dokdok/user/api/UserApi.java
+++ b/src/main/java/com/dokdok/user/api/UserApi.java
@@ -12,9 +12,11 @@ import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -310,5 +312,51 @@ public interface UserApi {
     @PatchMapping(value = "/me", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     ResponseEntity<ApiResponse<UserDetailResponse>> updateUserInfo(
             @Valid @RequestBody UpdateUserInfoRequest request
+    );
+
+    @Operation(
+            summary = "회원 탈퇴",
+            description = "현재 인증된 사용자를 소프트 삭제합니다. 처리 후 인증 세션이 해제됩니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "회원 탈퇴 성공",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = ApiResponse.class),
+                            examples = @ExampleObject(
+                                    value = "{\"code\":\"DELETED\",\"message\":\"회원 탈퇴가 완료되었습니다.\"}"
+                            )
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "401",
+                    description = "인증되지 않은 사용자",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(
+                                    value = "{\"code\":\"G102\",\"message\":\"인증이 필요합니다.\"}"
+                            )
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "사용자를 찾을 수 없음",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(
+                                    value = "{\"code\":\"U001\",\"message\":\"존재하지 않는 사용자입니디.\"}"
+                            )
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "500",
+                    description = "서버 오류"
+            )
+    })
+    @DeleteMapping(value = "/me", produces = MediaType.APPLICATION_JSON_VALUE)
+    ResponseEntity<ApiResponse<Void>> deleteCurrentUser(
+            @Parameter(hidden = true) HttpServletRequest request
     );
 }

--- a/src/main/java/com/dokdok/user/controller/AuthController.java
+++ b/src/main/java/com/dokdok/user/controller/AuthController.java
@@ -9,14 +9,19 @@ import com.dokdok.user.api.AuthApi;
 import com.dokdok.user.dto.response.UserInfoResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 
 @Slf4j
 @RestController
+@RequestMapping("/api/auth")
 public class AuthController implements AuthApi {
 
     @Override
+    @GetMapping("/me")
     public ResponseEntity<ApiResponse<UserInfoResponse>> getCurrentUser() {
         if (!SecurityUtil.isAuthenticated()) {
             throw new GlobalException(GlobalErrorCode.UNAUTHORIZED);
@@ -29,5 +34,12 @@ public class AuthController implements AuthApi {
 
         UserInfoResponse userInfo = UserInfoResponse.from(currentUser.getUser());
         return ApiResponse.success(userInfo, "로그인 사용자 정보 조회 성공");
+    }
+
+    @Override
+    @PostMapping("/logout")
+    public ResponseEntity<ApiResponse<Void>> logout() {
+        // 실제 처리는 Security LogoutFilter가 수행하며, 명세/시그니처 충족용
+        return ApiResponse.success("로그아웃 성공");
     }
 }

--- a/src/main/java/com/dokdok/user/controller/UserController.java
+++ b/src/main/java/com/dokdok/user/controller/UserController.java
@@ -3,15 +3,14 @@ package com.dokdok.user.controller;
 import com.dokdok.global.response.ApiResponse;
 import com.dokdok.user.api.UserApi;
 import com.dokdok.user.dto.request.OnboardRequest;
+import com.dokdok.user.dto.request.UpdateUserInfoRequest;
+import com.dokdok.user.dto.response.UserDetailResponse;
 import com.dokdok.user.service.UserService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Slf4j
 @RestController
@@ -33,5 +32,19 @@ public class UserController implements UserApi {
     public ResponseEntity<ApiResponse<Void>> checkNickname(String nickname) {
         userService.checkNickname(nickname);
         return ApiResponse.success("사용 가능한 닉네임입니다.");
+    }
+
+    @Override
+    @GetMapping("/me")
+    public ResponseEntity<ApiResponse<UserDetailResponse>> getCurrentUser() {
+        UserDetailResponse currentUserInfo = userService.getCurrentUserInfo();
+        return ApiResponse.success(currentUserInfo, "프로필 조회 성공");
+    }
+
+    @Override
+    @PatchMapping("/me")
+    public ResponseEntity<ApiResponse<UserDetailResponse>> updateUserInfo(@Valid @RequestBody UpdateUserInfoRequest request) {
+        UserDetailResponse response = userService.updateUserInfo(request);
+        return ApiResponse.success(response, "프로필 수정 성공");
     }
 }

--- a/src/main/java/com/dokdok/user/controller/UserController.java
+++ b/src/main/java/com/dokdok/user/controller/UserController.java
@@ -6,10 +6,13 @@ import com.dokdok.user.dto.request.OnboardRequest;
 import com.dokdok.user.dto.request.UpdateUserInfoRequest;
 import com.dokdok.user.dto.response.UserDetailResponse;
 import com.dokdok.user.service.UserService;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 
 @Slf4j
@@ -46,5 +49,28 @@ public class UserController implements UserApi {
     public ResponseEntity<ApiResponse<UserDetailResponse>> updateUserInfo(@Valid @RequestBody UpdateUserInfoRequest request) {
         UserDetailResponse response = userService.updateUserInfo(request);
         return ApiResponse.success(response, "프로필 수정 성공");
+    }
+
+    @Override
+    @DeleteMapping("/me")
+    public ResponseEntity<ApiResponse<Void>> deleteCurrentUser(HttpServletRequest request) {
+        userService.deleteCurrentUser();
+        ResponseEntity<ApiResponse<Void>> response = ApiResponse.deleted("회원 탈퇴가 완료되었습니다.");
+
+        invalidateSession(request);
+        SecurityContextHolder.clearContext();
+
+        return response;
+    }
+
+    private void invalidateSession(HttpServletRequest request) {
+        if (request == null) {
+            return;
+        }
+
+        HttpSession session = request.getSession(false);
+        if (session != null) {
+            session.invalidate();
+        }
     }
 }

--- a/src/main/java/com/dokdok/user/dto/request/UpdateUserInfoRequest.java
+++ b/src/main/java/com/dokdok/user/dto/request/UpdateUserInfoRequest.java
@@ -1,0 +1,9 @@
+package com.dokdok.user.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record UpdateUserInfoRequest(
+        @NotBlank(message = "닉네임은 필수 입력 항목입니다.")
+        String nickname
+) {
+}

--- a/src/main/java/com/dokdok/user/dto/response/UserDetailResponse.java
+++ b/src/main/java/com/dokdok/user/dto/response/UserDetailResponse.java
@@ -1,0 +1,26 @@
+package com.dokdok.user.dto.response;
+
+import com.dokdok.user.entity.User;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+@Builder
+public record UserDetailResponse(
+        Long userId,
+        String nickname,
+        String email,
+        String profileImageUrl,
+        LocalDateTime createdAt
+)
+{
+    public static UserDetailResponse from(User user) {
+        return UserDetailResponse.builder()
+                .userId(user.getId())
+                .nickname(user.getNickname())
+                .email(user.getUserEmail())
+                .profileImageUrl(user.getProfileImageUrl())
+                .createdAt(user.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/dokdok/user/entity/User.java
+++ b/src/main/java/com/dokdok/user/entity/User.java
@@ -2,6 +2,7 @@ package com.dokdok.user.entity;
 
 import com.dokdok.global.BaseTimeEntity;
 import com.dokdok.oauth2.OAuth2UserInfo;
+import com.dokdok.user.dto.request.UpdateUserInfoRequest;
 import jakarta.persistence.*;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
@@ -48,5 +49,16 @@ public class User extends BaseTimeEntity {
 
     public void updateNickname(String nickname) {
         this.nickname = nickname;
+    }
+
+    /**
+     * 사용자의 정보를 변경합니다.
+     * 현재는 닉네임만 가능.
+     */
+    public void updateInfo(UpdateUserInfoRequest request) {
+
+        if (!this.nickname.equals(request.nickname())) {
+            this.nickname = request.nickname();
+        }
     }
 }

--- a/src/main/java/com/dokdok/user/entity/User.java
+++ b/src/main/java/com/dokdok/user/entity/User.java
@@ -61,4 +61,8 @@ public class User extends BaseTimeEntity {
             this.nickname = request.nickname();
         }
     }
+
+    public void delete() {
+        markDeletedNow();
+    }
 }

--- a/src/main/java/com/dokdok/user/service/UserService.java
+++ b/src/main/java/com/dokdok/user/service/UserService.java
@@ -2,6 +2,8 @@ package com.dokdok.user.service;
 
 import com.dokdok.global.util.SecurityUtil;
 import com.dokdok.user.dto.request.OnboardRequest;
+import com.dokdok.user.dto.request.UpdateUserInfoRequest;
+import com.dokdok.user.dto.response.UserDetailResponse;
 import com.dokdok.user.entity.User;
 import com.dokdok.user.exception.UserErrorCode;
 import com.dokdok.user.exception.UserException;
@@ -50,6 +52,29 @@ public class UserService {
         validateNickname(nickname.trim());
     }
 
+    /**
+     * SecurityUtil에서 현재 세션에 저장된 사용자의 User Entity를 응답 Response Dto형식으로 반환.
+     */
+    public UserDetailResponse getCurrentUserInfo() {
+
+        User currentUser = SecurityUtil.getCurrentUserEntity();
+        return UserDetailResponse.from(currentUser);
+    }
+
+    /**
+     * 사용자의 정보응 변경합니다.
+     */
+    public UserDetailResponse updateUserInfo(UpdateUserInfoRequest request) {
+
+        validateNickname(request.nickname());
+
+        Long currentUserId = SecurityUtil.getCurrentUserId();
+
+        User user = getUserById(currentUserId);
+        user.updateInfo(request);
+
+        return UserDetailResponse.from(user);
+    }
 
     /**
      * 닉네임 유효성을 검사합니다.
@@ -78,4 +103,5 @@ public class UserService {
         return userRepository.findById(userId)
                 .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
     }
+
 }

--- a/src/main/java/com/dokdok/user/service/UserService.java
+++ b/src/main/java/com/dokdok/user/service/UserService.java
@@ -76,6 +76,14 @@ public class UserService {
         return UserDetailResponse.from(user);
     }
 
+    @Transactional
+    public void deleteCurrentUser() {
+        Long currentUserId = SecurityUtil.getCurrentUserId();
+
+        User user = getUserById(currentUserId);
+        user.delete();
+    }
+
     /**
      * 닉네임 유효성을 검사합니다.
      * @param nickname trim된 닉네임
@@ -103,5 +111,4 @@ public class UserService {
         return userRepository.findById(userId)
                 .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
     }
-
 }

--- a/src/test/java/com/dokdok/user/service/UserServiceTest.java
+++ b/src/test/java/com/dokdok/user/service/UserServiceTest.java
@@ -15,11 +15,6 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.security.authentication.TestingAuthenticationToken;
-import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.mock.web.MockHttpServletRequest;
-import org.springframework.mock.web.MockHttpSession;
-
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/src/test/java/com/dokdok/user/service/UserServiceTest.java
+++ b/src/test/java/com/dokdok/user/service/UserServiceTest.java
@@ -476,4 +476,267 @@ class UserServiceTest {
             securityUtilMock.verify(() -> SecurityUtil.updateCurrentUserInContext(any()), never());
         }
     }
+
+    @Test
+    @DisplayName("현재 사용자 정보 조회 - 성공")
+    void getCurrentUserInfo_Success() {
+        // given
+        User user = User.builder()
+                .id(1L)
+                .nickname("테스트닉네임")
+                .userEmail("test@test.com")
+                .profileImageUrl("https://example.com/profile.jpg")
+                .build();
+
+        try (MockedStatic<SecurityUtil> securityUtilMock = mockStatic(SecurityUtil.class)) {
+            securityUtilMock.when(SecurityUtil::getCurrentUserEntity).thenReturn(user);
+
+            // when
+            var response = userService.getCurrentUserInfo();
+
+            // then
+            assertThat(response).isNotNull();
+            assertThat(response.userId()).isEqualTo(1L);
+            assertThat(response.nickname()).isEqualTo("테스트닉네임");
+            assertThat(response.email()).isEqualTo("test@test.com");
+            assertThat(response.profileImageUrl()).isEqualTo("https://example.com/profile.jpg");
+
+            securityUtilMock.verify(SecurityUtil::getCurrentUserEntity, times(1));
+        }
+    }
+
+    @Test
+    @DisplayName("사용자 정보 수정 - 정상적인 닉네임으로 성공")
+    void updateUserInfo_Success() {
+        // given
+        Long userId = 1L;
+        String newNickname = "변경된닉네임";
+        var request = new com.dokdok.user.dto.request.UpdateUserInfoRequest(newNickname);
+
+        User user = User.builder()
+                .id(userId)
+                .nickname("기존닉네임")
+                .userEmail("test@test.com")
+                .build();
+
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        when(userRepository.findByNickname(newNickname)).thenReturn(Optional.empty());
+
+        try (MockedStatic<SecurityUtil> securityUtilMock = mockStatic(SecurityUtil.class)) {
+            securityUtilMock.when(SecurityUtil::getCurrentUserId).thenReturn(userId);
+
+            // when
+            var response = userService.updateUserInfo(request);
+
+            // then
+            assertThat(response).isNotNull();
+            assertThat(response.nickname()).isEqualTo(newNickname);
+            assertThat(user.getNickname()).isEqualTo(newNickname);
+
+            verify(userRepository, times(1)).findById(userId);
+            verify(userRepository, times(1)).findByNickname(newNickname);
+        }
+    }
+
+    @Test
+    @DisplayName("사용자 정보 수정 - 동일한 닉네임으로 변경 시도")
+    void updateUserInfo_SameNickname_Success() {
+        // given
+        Long userId = 1L;
+        String sameNickname = "기존닉네임";
+        var request = new com.dokdok.user.dto.request.UpdateUserInfoRequest(sameNickname);
+
+        User user = User.builder()
+                .id(userId)
+                .nickname(sameNickname)
+                .userEmail("test@test.com")
+                .build();
+
+        when(userRepository.findByNickname(sameNickname)).thenReturn(Optional.of(user));
+
+        try (MockedStatic<SecurityUtil> securityUtilMock = mockStatic(SecurityUtil.class)) {
+            securityUtilMock.when(SecurityUtil::getCurrentUserId).thenReturn(userId);
+
+            // when & then
+            assertThatThrownBy(() -> userService.updateUserInfo(request))
+                    .isInstanceOf(UserException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", UserErrorCode.NICKNAME_ALREADY_EXISTS);
+
+            verify(userRepository, times(1)).findByNickname(sameNickname);
+        }
+    }
+
+    @Test
+    @DisplayName("사용자 정보 수정 - null 닉네임으로 실패")
+    void updateUserInfo_NullNickname_ThrowsException() {
+        // given
+        Long userId = 1L;
+        var request = new com.dokdok.user.dto.request.UpdateUserInfoRequest(null);
+
+        try (MockedStatic<SecurityUtil> securityUtilMock = mockStatic(SecurityUtil.class)) {
+            securityUtilMock.when(SecurityUtil::getCurrentUserId).thenReturn(userId);
+
+            // when & then
+            assertThatThrownBy(() -> userService.updateUserInfo(request))
+                    .isInstanceOf(UserException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", UserErrorCode.NICKNAME_EMPTY);
+
+            verify(userRepository, never()).findById(anyLong());
+            verify(userRepository, never()).findByNickname(anyString());
+        }
+    }
+
+    @Test
+    @DisplayName("사용자 정보 수정 - 빈 닉네임으로 실패")
+    void updateUserInfo_EmptyNickname_ThrowsException() {
+        // given
+        Long userId = 1L;
+        String emptyNickname = "";
+        var request = new com.dokdok.user.dto.request.UpdateUserInfoRequest(emptyNickname);
+
+        try (MockedStatic<SecurityUtil> securityUtilMock = mockStatic(SecurityUtil.class)) {
+            securityUtilMock.when(SecurityUtil::getCurrentUserId).thenReturn(userId);
+
+            // when & then
+            assertThatThrownBy(() -> userService.updateUserInfo(request))
+                    .isInstanceOf(UserException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", UserErrorCode.NICKNAME_EMPTY);
+
+            verify(userRepository, never()).findById(anyLong());
+            verify(userRepository, never()).findByNickname(anyString());
+        }
+    }
+
+    @Test
+    @DisplayName("사용자 정보 수정 - 공백만 있는 닉네임으로 실패")
+    void updateUserInfo_OnlyWhitespace_ThrowsException() {
+        // given
+        Long userId = 1L;
+        String whitespaceNickname = "   ";
+        var request = new com.dokdok.user.dto.request.UpdateUserInfoRequest(whitespaceNickname);
+
+        try (MockedStatic<SecurityUtil> securityUtilMock = mockStatic(SecurityUtil.class)) {
+            securityUtilMock.when(SecurityUtil::getCurrentUserId).thenReturn(userId);
+
+            // when & then
+            assertThatThrownBy(() -> userService.updateUserInfo(request))
+                    .isInstanceOf(UserException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", UserErrorCode.NICKNAME_EMPTY);
+
+            verify(userRepository, never()).findById(anyLong());
+            verify(userRepository, never()).findByNickname(anyString());
+        }
+    }
+
+    @Test
+    @DisplayName("사용자 정보 수정 - 길이가 짧은 닉네임으로 실패")
+    void updateUserInfo_TooShortNickname_ThrowsException() {
+        // given
+        Long userId = 1L;
+        String shortNickname = "a";
+        var request = new com.dokdok.user.dto.request.UpdateUserInfoRequest(shortNickname);
+
+        try (MockedStatic<SecurityUtil> securityUtilMock = mockStatic(SecurityUtil.class)) {
+            securityUtilMock.when(SecurityUtil::getCurrentUserId).thenReturn(userId);
+
+            // when & then
+            assertThatThrownBy(() -> userService.updateUserInfo(request))
+                    .isInstanceOf(UserException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", UserErrorCode.NICKNAME_LENGTH_INVALID);
+
+            verify(userRepository, never()).findById(anyLong());
+        }
+    }
+
+    @Test
+    @DisplayName("사용자 정보 수정 - 길이가 긴 닉네임으로 실패")
+    void updateUserInfo_TooLongNickname_ThrowsException() {
+        // given
+        Long userId = 1L;
+        String longNickname = "a".repeat(21);
+        var request = new com.dokdok.user.dto.request.UpdateUserInfoRequest(longNickname);
+
+        try (MockedStatic<SecurityUtil> securityUtilMock = mockStatic(SecurityUtil.class)) {
+            securityUtilMock.when(SecurityUtil::getCurrentUserId).thenReturn(userId);
+
+            // when & then
+            assertThatThrownBy(() -> userService.updateUserInfo(request))
+                    .isInstanceOf(UserException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", UserErrorCode.NICKNAME_LENGTH_INVALID);
+
+            verify(userRepository, never()).findById(anyLong());
+        }
+    }
+
+    @Test
+    @DisplayName("사용자 정보 수정 - 특수문자 포함 닉네임으로 실패")
+    void updateUserInfo_InvalidFormat_ThrowsException() {
+        // given
+        Long userId = 1L;
+        String invalidNickname = "닉네임!@#";
+        var request = new com.dokdok.user.dto.request.UpdateUserInfoRequest(invalidNickname);
+
+        try (MockedStatic<SecurityUtil> securityUtilMock = mockStatic(SecurityUtil.class)) {
+            securityUtilMock.when(SecurityUtil::getCurrentUserId).thenReturn(userId);
+
+            // when & then
+            assertThatThrownBy(() -> userService.updateUserInfo(request))
+                    .isInstanceOf(UserException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", UserErrorCode.NICKNAME_FORMAT_INVALID);
+
+            verify(userRepository, never()).findById(anyLong());
+        }
+    }
+
+    @Test
+    @DisplayName("사용자 정보 수정 - 중복된 닉네임으로 실패")
+    void updateUserInfo_DuplicateNickname_ThrowsException() {
+        // given
+        Long userId = 1L;
+        String duplicateNickname = "기존닉네임";
+        var request = new com.dokdok.user.dto.request.UpdateUserInfoRequest(duplicateNickname);
+
+        User anotherUser = User.builder()
+                .id(2L)
+                .nickname(duplicateNickname)
+                .build();
+
+        when(userRepository.findByNickname(duplicateNickname)).thenReturn(Optional.of(anotherUser));
+
+        try (MockedStatic<SecurityUtil> securityUtilMock = mockStatic(SecurityUtil.class)) {
+            securityUtilMock.when(SecurityUtil::getCurrentUserId).thenReturn(userId);
+
+            // when & then
+            assertThatThrownBy(() -> userService.updateUserInfo(request))
+                    .isInstanceOf(UserException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", UserErrorCode.NICKNAME_ALREADY_EXISTS);
+
+            verify(userRepository, times(1)).findByNickname(duplicateNickname);
+            verify(userRepository, never()).findById(anyLong());
+        }
+    }
+
+    @Test
+    @DisplayName("사용자 정보 수정 - 존재하지 않는 사용자로 실패")
+    void updateUserInfo_UserNotFound_ThrowsException() {
+        // given
+        Long userId = 1L;
+        String validNickname = "새로운닉네임";
+        var request = new com.dokdok.user.dto.request.UpdateUserInfoRequest(validNickname);
+
+        when(userRepository.findById(userId)).thenReturn(Optional.empty());
+        when(userRepository.findByNickname(validNickname)).thenReturn(Optional.empty());
+
+        try (MockedStatic<SecurityUtil> securityUtilMock = mockStatic(SecurityUtil.class)) {
+            securityUtilMock.when(SecurityUtil::getCurrentUserId).thenReturn(userId);
+
+            // when & then
+            assertThatThrownBy(() -> userService.updateUserInfo(request))
+                    .isInstanceOf(UserException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", UserErrorCode.USER_NOT_FOUND);
+
+            verify(userRepository, times(1)).findById(userId);
+            verify(userRepository, times(1)).findByNickname(validNickname);
+        }
+    }
 }

--- a/src/test/java/com/dokdok/user/service/UserServiceTest.java
+++ b/src/test/java/com/dokdok/user/service/UserServiceTest.java
@@ -10,10 +10,15 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import jakarta.servlet.http.HttpSession;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.authentication.TestingAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpSession;
 
 import java.util.Optional;
 
@@ -737,6 +742,51 @@ class UserServiceTest {
 
             verify(userRepository, times(1)).findById(userId);
             verify(userRepository, times(1)).findByNickname(validNickname);
+        }
+    }
+
+    @Test
+    @DisplayName("회원 탈퇴 - soft delete 수행")
+    void deleteCurrentUser_Success() {
+        // given
+        Long userId = 1L;
+        User user = User.builder()
+                .id(userId)
+                .kakaoId(12345L)
+                .build();
+
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+
+        try (MockedStatic<SecurityUtil> securityUtilMock = mockStatic(SecurityUtil.class)) {
+            securityUtilMock.when(SecurityUtil::getCurrentUserId).thenReturn(userId);
+
+            // when
+            userService.deleteCurrentUser();
+
+            // then
+            assertThat(user.isDeleted()).isTrue();
+            assertThat(user.getDeletedAt()).isNotNull();
+            verify(userRepository, times(1)).findById(userId);
+        }
+    }
+
+    @Test
+    @DisplayName("회원 탈퇴 - 존재하지 않는 사용자 예외")
+    void deleteCurrentUser_UserNotFound_ThrowsException() {
+        // given
+        Long userId = 1L;
+
+        when(userRepository.findById(userId)).thenReturn(Optional.empty());
+
+        try (MockedStatic<SecurityUtil> securityUtilMock = mockStatic(SecurityUtil.class)) {
+            securityUtilMock.when(SecurityUtil::getCurrentUserId).thenReturn(userId);
+
+            // when & then
+            assertThatThrownBy(() -> userService.deleteCurrentUser())
+                    .isInstanceOf(UserException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", UserErrorCode.USER_NOT_FOUND);
+
+            verify(userRepository, times(1)).findById(userId);
         }
     }
 }


### PR DESCRIPTION
## PR 요약
> 이 PR이 어떤 변경을 하는지 간단히 설명하고, 체크 표시는 괄호 사이에 소문자 'x'를 삽입하세요.

- [x] 기능 추가
- [ ] 버그 수정
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 기타 (설명)

---

## 이슈 번호
- #74

---

## 주요 변경 사항
- `src/main/java/com/dokdok/global/security/SecurityConfig.java`: 로그아웃 성공 시 ApiResponse JSON("로그아웃 성공") 반환하도록 변경
- `src/main/java/com/dokdok/user/api/AuthApi.java`: 로그아웃 API 명세 유지(컨트롤러 구현과 시그니처 일치)
- `src/main/java/com/dokdok/user/controller/AuthController.java`: Swagger 명세 충족을 위한 최소 구현 추가
- `src/test/java/com/dokdok/user/service/UserServiceTest.java`: 불필요한 import 정리

---

## 참고 사항
- 테스트: 로컬에서 실행하지 않음 (`./gradlew test` 권장)
- 실제 로그아웃 처리는 Security LogoutFilter에서 수행합니다.
