### PR TITLE
[#35][FEAT] 모임원 강퇴 API

### DIFF
--- a/src/main/java/com/dokdok/gathering/api/GatheringApi.java
+++ b/src/main/java/com/dokdok/gathering/api/GatheringApi.java
@@ -203,4 +203,46 @@ public interface GatheringApi {
             )
             @PathVariable Long gatheringId
     );
+
+    @Operation(
+            summary = "모임원 강퇴",
+            description = """
+            모임원을 강퇴합니다.
+            - 모임의 리더만 강퇴할 수 있습니다.
+            - 리더는 강퇴할 수 없습니다.
+            """
+    )
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "강퇴 성공"
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "401",
+                    description = "인증 실패 - 로그인이 필요합니다."
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "403",
+                    description = "권한 없음 - 모임의 리더만 강퇴할 수 있습니다."
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "모임 또는 멤버를 찾을 수 없음"
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "409",
+                    description = "리더는 강퇴할 수 없음"
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "500",
+                    description = "서버 오류"
+            )
+    })
+    @DeleteMapping("/{gatheringId}/members/{userId}")
+    ResponseEntity<ApiResponse<Void>> removeMember(
+            @Parameter(description = "모임 ID", required = true, example = "123")
+            @PathVariable Long gatheringId,
+            @Parameter(description = "강퇴할 유저 ID", required = true, example = "456")
+            @PathVariable Long userId
+    );
 }

--- a/src/main/java/com/dokdok/gathering/controller/GatheringController.java
+++ b/src/main/java/com/dokdok/gathering/controller/GatheringController.java
@@ -53,7 +53,7 @@ public class GatheringController implements GatheringApi {
         return ApiResponse.deleted("모임 삭제 성공");
     }
 
-    @DeleteMapping("{/{gatheringId}/members/{userId}")
+    @DeleteMapping("/{gatheringId}/members/{userId}")
     public ResponseEntity<ApiResponse<Void>> removeMember(
             @PathVariable Long gatheringId,
             @PathVariable Long userId

--- a/src/main/java/com/dokdok/gathering/controller/GatheringController.java
+++ b/src/main/java/com/dokdok/gathering/controller/GatheringController.java
@@ -52,4 +52,13 @@ public class GatheringController implements GatheringApi {
         gatheringService.deleteGathering(gatheringId);
         return ApiResponse.deleted("모임 삭제 성공");
     }
+
+    @DeleteMapping("{/{gatheringId}/members/{userId}")
+    public ResponseEntity<ApiResponse<Void>> removeMember(
+            @PathVariable Long gatheringId,
+            @PathVariable Long userId
+    ){
+        gatheringService.removeMember(gatheringId,userId);
+        return ApiResponse.deleted("모임원 강퇴 성공");
+    }
 }

--- a/src/main/java/com/dokdok/gathering/entity/GatheringMember.java
+++ b/src/main/java/com/dokdok/gathering/entity/GatheringMember.java
@@ -1,7 +1,5 @@
 package com.dokdok.gathering.entity;
 
-import com.dokdok.gathering.exception.GatheringErrorCode;
-import com.dokdok.gathering.exception.GatheringException;
 import com.dokdok.user.entity.User;
 import jakarta.persistence.*;
 import lombok.*;

--- a/src/main/java/com/dokdok/gathering/entity/GatheringMember.java
+++ b/src/main/java/com/dokdok/gathering/entity/GatheringMember.java
@@ -1,8 +1,11 @@
 package com.dokdok.gathering.entity;
 
+import com.dokdok.gathering.exception.GatheringErrorCode;
+import com.dokdok.gathering.exception.GatheringException;
 import com.dokdok.user.entity.User;
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.SQLRestriction;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -18,6 +21,7 @@ import java.time.temporal.ChronoUnit;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
+@SQLRestriction("removed_at IS NULL")
 public class GatheringMember {
 
     @Id
@@ -64,5 +68,9 @@ public class GatheringMember {
                 this.joinedAt.toLocalDate(),
                 LocalDate.now()
         );
+    }
+
+    public void remove() {
+        this.removedAt = LocalDateTime.now();
     }
 }

--- a/src/main/java/com/dokdok/gathering/exception/GatheringErrorCode.java
+++ b/src/main/java/com/dokdok/gathering/exception/GatheringErrorCode.java
@@ -12,7 +12,9 @@ public enum GatheringErrorCode implements BaseErrorCode {
     GATHERING_NOT_FOUND("G001", "모임을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
     NOT_GATHERING_MEMBER("G002", "모임의 멤버가 아닙니다.", HttpStatus.FORBIDDEN),
     NOT_GATHERING_LEADER("G003","리더만 가능한 작업입니다.", HttpStatus.FORBIDDEN),
-    ALREADY_INACTIVE("G004","이미 비활성 상태인 모임은 삭제할 수 없습니다.",HttpStatus.CONFLICT);
+    ALREADY_INACTIVE("G004","이미 비활성 상태인 모임은 삭제할 수 없습니다.",HttpStatus.CONFLICT),
+    CANNOT_REMOVE_LEADER("G005", "유일한 리더는 강퇴할 수 없습니다.", HttpStatus.FORBIDDEN),
+    ALREADY_REMOVED_MEMBER("G006", "이미 제거된 멤버입니다.", HttpStatus.CONFLICT);
 
     private final String code;
     private final String message;

--- a/src/main/java/com/dokdok/gathering/service/GatheringService.java
+++ b/src/main/java/com/dokdok/gathering/service/GatheringService.java
@@ -3,6 +3,9 @@ package com.dokdok.gathering.service;
 import com.dokdok.gathering.dto.*;
 import com.dokdok.gathering.entity.Gathering;
 import com.dokdok.gathering.entity.GatheringMember;
+import com.dokdok.gathering.entity.GatheringRole;
+import com.dokdok.gathering.exception.GatheringErrorCode;
+import com.dokdok.gathering.exception.GatheringException;
 import com.dokdok.gathering.repository.GatheringMemberRepository;
 import com.dokdok.gathering.repository.GatheringRepository;
 import com.dokdok.global.util.SecurityUtil;
@@ -24,7 +27,6 @@ public class GatheringService {
 
 	private final GatheringMemberRepository gatheringMemberRepository;
 	private final GatheringValidator gatheringValidator;
-	private final GatheringRepository gatheringRepository;
 	private final MeetingRepository meetingRepository;
 
 	public MyGatheringListResponse getMyGatherings(Pageable pageable) {
@@ -94,5 +96,29 @@ public class GatheringService {
 		gatheringValidator.validateLeader(gatheringId, userId);
 
 		gathering.deleteGathering();
+	}
+
+	// 모임원 탈퇴 - 리더만 가능
+	@Transactional
+	public void removeMember(Long gatheringId, Long targetUserId) {
+		Long requestId = SecurityUtil.getCurrentUserId();
+
+		// 모임 존재 여부
+		gatheringValidator.validateAndGetGathering(gatheringId);
+
+		// 권한이 리더인지 검증
+		gatheringValidator.validateLeader(gatheringId,requestId);
+
+		// 강퇴 대상 멤버 조회 & 존재여부
+		GatheringMember targetMember = gatheringValidator.validateAndGetMember(gatheringId, targetUserId);
+
+		// 강퇴 대상이 리더인지 확인
+		if (targetMember.getRole() == GatheringRole.LEADER) {
+			throw new GatheringException(GatheringErrorCode.CANNOT_REMOVE_LEADER);
+		}
+
+
+		targetMember.remove();
+
 	}
 }

--- a/src/main/java/com/dokdok/gathering/service/GatheringService.java
+++ b/src/main/java/com/dokdok/gathering/service/GatheringService.java
@@ -7,7 +7,6 @@ import com.dokdok.gathering.entity.GatheringRole;
 import com.dokdok.gathering.exception.GatheringErrorCode;
 import com.dokdok.gathering.exception.GatheringException;
 import com.dokdok.gathering.repository.GatheringMemberRepository;
-import com.dokdok.gathering.repository.GatheringRepository;
 import com.dokdok.global.util.SecurityUtil;
 import com.dokdok.meeting.entity.MeetingStatus;
 import com.dokdok.meeting.repository.MeetingRepository;
@@ -117,8 +116,6 @@ public class GatheringService {
 			throw new GatheringException(GatheringErrorCode.CANNOT_REMOVE_LEADER);
 		}
 
-
 		targetMember.remove();
-
 	}
 }

--- a/src/test/java/com/dokdok/gathering/service/GatheringServiceTest.java
+++ b/src/test/java/com/dokdok/gathering/service/GatheringServiceTest.java
@@ -544,4 +544,80 @@ class GatheringServiceTest {
 		verify(gatheringValidator, times(1)).validateAndGetGathering(gatheringId);
 		verify(gatheringValidator, times(1)).validateLeader(gatheringId, memberId);
 	}
+
+	@Test
+	@DisplayName("모임원 강퇴 성공 - 리더가 일반 멤버 강퇴")
+	void removeMember_Success() {
+		// given
+		Long gatheringId = 1L;
+		Long leaderId = 1L;
+		Long targetUserId = 2L;
+
+		securityUtilMock.when(SecurityUtil::getCurrentUserId).thenReturn(leaderId);
+
+		given(gatheringValidator.validateAndGetGathering(gatheringId)).willReturn(gathering1);
+		given(gatheringValidator.validateAndGetMember(gatheringId, targetUserId)).willReturn(normalMember);
+
+		// when
+		gatheringService.removeMember(gatheringId, targetUserId);
+
+		// then
+		assertThat(normalMember.getRemovedAt()).isNotNull();
+
+		securityUtilMock.verify(SecurityUtil::getCurrentUserId, times(1));
+		verify(gatheringValidator, times(1)).validateAndGetGathering(gatheringId);
+		verify(gatheringValidator, times(1)).validateLeader(gatheringId, leaderId);
+		verify(gatheringValidator, times(1)).validateAndGetMember(gatheringId, targetUserId);
+	}
+
+	@Test
+	@DisplayName("모임원 강퇴 실패 - 강퇴 대상이 리더")
+	void removeMember_Fail_TargetIsLeader() {
+		// given
+		Long gatheringId = 1L;
+		Long leaderId = 1L;
+		Long targetUserId = 1L;
+
+		securityUtilMock.when(SecurityUtil::getCurrentUserId).thenReturn(leaderId);
+
+		given(gatheringValidator.validateAndGetGathering(gatheringId)).willReturn(gathering1);
+		given(gatheringValidator.validateAndGetMember(gatheringId, targetUserId)).willReturn(leaderMember);
+
+		// when & then
+		assertThatThrownBy(() -> gatheringService.removeMember(gatheringId, targetUserId))
+				.isInstanceOf(GatheringException.class)
+				.hasMessage(GatheringErrorCode.CANNOT_REMOVE_LEADER.getMessage());
+
+		assertThat(leaderMember.getRemovedAt()).isNull();
+
+		securityUtilMock.verify(SecurityUtil::getCurrentUserId, times(1));
+		verify(gatheringValidator, times(1)).validateAndGetGathering(gatheringId);
+		verify(gatheringValidator, times(1)).validateLeader(gatheringId, leaderId);
+		verify(gatheringValidator, times(1)).validateAndGetMember(gatheringId, targetUserId);
+	}
+
+	@Test
+	@DisplayName("모임원 강퇴 실패 - 리더가 아닌 멤버")
+	void removeMember_Fail_NotLeader() {
+		// given
+		Long gatheringId = 1L;
+		Long memberId = 2L;
+		Long targetUserId = 3L;
+
+		securityUtilMock.when(SecurityUtil::getCurrentUserId).thenReturn(memberId);
+
+		given(gatheringValidator.validateAndGetGathering(gatheringId)).willReturn(gathering1);
+		doThrow(new GatheringException(GatheringErrorCode.NOT_GATHERING_LEADER))
+				.when(gatheringValidator).validateLeader(gatheringId, memberId);
+
+		// when & then
+		assertThatThrownBy(() -> gatheringService.removeMember(gatheringId, targetUserId))
+				.isInstanceOf(GatheringException.class)
+				.hasMessage(GatheringErrorCode.NOT_GATHERING_LEADER.getMessage());
+
+		securityUtilMock.verify(SecurityUtil::getCurrentUserId, times(1));
+		verify(gatheringValidator, times(1)).validateAndGetGathering(gatheringId);
+		verify(gatheringValidator, times(1)).validateLeader(gatheringId, memberId);
+		verify(gatheringValidator, times(0)).validateAndGetMember(any(), any());
+	}
 }


### PR DESCRIPTION
## PR 요약
> 이 PR이 어떤 변경을 하는지 간단히 설명하고, 체크 표시는 괄호 사이에 소문자 'x'를 삽입하세요.

- [x] 기능 추가
- [ ] 버그 수정
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 기타 (설명)

---

## 이슈 번호
- #35 

---

## 주요 변경 사항
> 주요 파일, 로직, 컴포넌트 등을 구체적으로 적어주세요.
 - src/main/java/com/dokdok/gathering/api/GatheringApi.java: 모임 삭제/모임원 강퇴 Swagger 문서 추가 - API 명세 문서화 목적
 - src/main/java/com/dokdok/gathering/controller/GatheringController.java: 모임 삭제 및 모임원 강퇴 DELETE 엔드포인트 추가 - 요청 라우팅 연결
 - src/main/java/com/dokdok/gathering/service/GatheringService.java: 모임원 강퇴 처리 로직 추가 및 관련 검증 흐름 반영 - 비즈니스 로직 구현
 - src/main/java/com/dokdok/gathering/entity/GatheringMember.java: removedAt 기반 탈퇴 처리 및 필터링 추가 - 소프트 탈퇴 처리
 - src/main/java/com/dokdok/gathering/exception/GatheringErrorCode.java: 강퇴 관련 에러코드 추가 - 예외 케이스 명확화
 - src/test/java/com/dokdok/gathering/service/GatheringServiceTest.java: 모임 삭제/강퇴 테스트 추가 및 보정 - 동작 검증 보강

