### PR TITLE
[#78][FEAT] 주제 좋아요/좋아요 취소 API 구현

### DIFF
--- a/src/main/java/com/dokdok/gathering/service/GatheringValidator.java
+++ b/src/main/java/com/dokdok/gathering/service/GatheringValidator.java
@@ -17,6 +17,17 @@ public class GatheringValidator {
 	private final GatheringMemberRepository gatheringMemberRepository;
 	private final GatheringRepository gatheringRepository;
 
+	/**
+	 * 존재하는 모임인지 검증한다.
+	 */
+	public void validateGathering(Long gatheringId) {
+		boolean isGathering = gatheringRepository.existsById(gatheringId);
+
+		if (!isGathering) {
+			throw new GatheringException(GatheringErrorCode.NOT_GATHERING_MEMBER);
+		}
+	}
+
     /**
      * 모임에 속해있는 사용자인지 검증한다.
      */

--- a/src/main/java/com/dokdok/meeting/repository/MeetingMemberRepository.java
+++ b/src/main/java/com/dokdok/meeting/repository/MeetingMemberRepository.java
@@ -45,4 +45,9 @@ public interface MeetingMemberRepository extends JpaRepository<MeetingMember, Lo
       AND mm.canceledAt IS NULL
       """)
     int countActiveMembers(@Param("meetingId") Long meetingId);
+
+    boolean existsByIdAndUserId(
+            Long meetingId,
+            Long userId
+    );
 }

--- a/src/main/java/com/dokdok/meeting/service/MeetingValidator.java
+++ b/src/main/java/com/dokdok/meeting/service/MeetingValidator.java
@@ -20,11 +20,11 @@ public class MeetingValidator {
     /**
      * 약속이 모임에 속하는지 검증한다.
      */
-    public void validateMemberInGathering(Long meetingId, Long gatheringId) {
-        boolean isMemberInGathering = meetingRepository
+    public void validateMeetingInGathering(Long meetingId, Long gatheringId) {
+        boolean isMeetingInGathering = meetingRepository
                 .existsByIdAndGatheringId(meetingId, gatheringId);
 
-        if (!isMemberInGathering) {
+        if (!isMeetingInGathering) {
             throw new MeetingException(MeetingErrorCode.NOT_GATHERING_MEETING);
         }
     }
@@ -52,8 +52,12 @@ public class MeetingValidator {
     /**
      * 사용자의 약속 참여 여부를 확인한다.
      */
-    public boolean isMeetingMember(Long meetingId, Long userId) {
-        return meetingMemberRepository.findByMeetingIdAndUserId(meetingId, userId).isPresent();
+    public void validateMeetingMember(Long meetingId, Long userId) {
+        boolean isMeetingMember = meetingMemberRepository.existsByIdAndUserId(meetingId, userId);
+
+        if(!isMeetingMember) {
+            throw new MeetingException(MeetingErrorCode.NOT_MEETING_MEMBER);
+        }
     }
 
     /**

--- a/src/main/java/com/dokdok/topic/api/TopicApi.java
+++ b/src/main/java/com/dokdok/topic/api/TopicApi.java
@@ -3,6 +3,7 @@ package com.dokdok.topic.api;
 import com.dokdok.global.response.ApiResponse;
 import com.dokdok.topic.dto.request.SuggestTopicRequest;
 import com.dokdok.topic.dto.response.SuggestTopicResponse;
+import com.dokdok.topic.dto.response.TopicLikeResponse;
 import com.dokdok.topic.dto.response.TopicsPageResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -105,6 +106,34 @@ public interface TopicApi {
     })
     @DeleteMapping(value = "/{topicId}")
     ResponseEntity<ApiResponse<Void>> deleteTopic(
+            @PathVariable Long gatheringId,
+            @PathVariable Long meetingId,
+            @PathVariable Long topicId
+    );
+
+    @Operation(
+            summary = "주제 좋아요 토글",
+            description = "주제에 대한 좋아요를 추가하거나 취소합니다. 이미 좋아요한 주제를 다시 요청하면 좋아요가 취소됩니다.",
+            parameters = {
+                    @Parameter(name = "gatheringId", description = "모임 식별자", in = ParameterIn.PATH, required = true),
+                    @Parameter(name = "meetingId", description = "약속 식별자", in = ParameterIn.PATH, required = true),
+                    @Parameter(name = "topicId", description = "주제 식별자", in = ParameterIn.PATH, required = true)
+            }
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "좋아요 토글 성공",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = TopicLikeResponse.class))
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "모임 또는 약속의 멤버가 아님"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "모임, 약속 또는 주제를 찾을 수 없음"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 오류")
+    })
+    @PostMapping("/{topicId}/likes")
+    ResponseEntity<ApiResponse<TopicLikeResponse>> toggleLike(
             @PathVariable Long gatheringId,
             @PathVariable Long meetingId,
             @PathVariable Long topicId

--- a/src/main/java/com/dokdok/topic/controller/TopicController.java
+++ b/src/main/java/com/dokdok/topic/controller/TopicController.java
@@ -4,7 +4,9 @@ import com.dokdok.global.response.ApiResponse;
 import com.dokdok.topic.api.TopicApi;
 import com.dokdok.topic.dto.request.SuggestTopicRequest;
 import com.dokdok.topic.dto.response.SuggestTopicResponse;
+import com.dokdok.topic.dto.response.TopicLikeResponse;
 import com.dokdok.topic.dto.response.TopicsPageResponse;
+import com.dokdok.topic.entity.TopicMessage;
 import com.dokdok.topic.service.TopicService;
 import lombok.RequiredArgsConstructor;
 import org.springdoc.core.annotations.ParameterObject;
@@ -47,6 +49,7 @@ public class TopicController implements TopicApi {
         return ApiResponse.success(response, "제안된 주제 조회를 완료했습니다.");
     }
 
+    @Override
     @DeleteMapping(value = "/{topicId}")
     public ResponseEntity<ApiResponse<Void>> deleteTopic(
             Long gatheringId,
@@ -57,6 +60,23 @@ public class TopicController implements TopicApi {
         topicService.deleteTopic(gatheringId, meetingId, topicId);
 
         return ApiResponse.deleted("주제가 삭제되었습니다.");
+    }
+
+    @Override
+    @PostMapping("/{topicId}/likes")
+    public ResponseEntity<ApiResponse<TopicLikeResponse>> toggleLike(
+            Long gatheringId,
+            Long meetingId,
+            Long topicId
+    ) {
+
+        TopicLikeResponse response = topicService.toggleTopicLike(gatheringId, meetingId, topicId);
+
+        TopicMessage message = response.liked()
+                ? TopicMessage.LIKE_SUCCESS
+                : TopicMessage.LIKE_CANCEL;
+
+        return ApiResponse.success(response, message.getMessage());
     }
 
 }

--- a/src/main/java/com/dokdok/topic/dto/response/TopicLikeResponse.java
+++ b/src/main/java/com/dokdok/topic/dto/response/TopicLikeResponse.java
@@ -1,0 +1,19 @@
+package com.dokdok.topic.dto.response;
+
+import com.dokdok.topic.entity.TopicMessage;
+
+public record TopicLikeResponse(
+        Long topicId,
+        Boolean liked,
+        int newCount
+) {
+
+    public static TopicLikeResponse from(Long topicId, TopicMessage result, int newCount) {
+        return new TopicLikeResponse(
+                topicId,
+                result == TopicMessage.LIKE_SUCCESS,
+                newCount
+        );
+    }
+
+}

--- a/src/main/java/com/dokdok/topic/entity/Topic.java
+++ b/src/main/java/com/dokdok/topic/entity/Topic.java
@@ -55,7 +55,7 @@ public class Topic extends BaseTimeEntity {
     @Builder.Default
     private Integer likeCount = 0;
 
-    public static Topic of(
+    public static Topic create(
             Meeting meeting,
             User user,
             String title,

--- a/src/main/java/com/dokdok/topic/entity/TopicLike.java
+++ b/src/main/java/com/dokdok/topic/entity/TopicLike.java
@@ -27,14 +27,21 @@ public class TopicLike {
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
-    @Column(name = "liked")
-    private Boolean liked;
-
     @Column(name = "liked_at", nullable = false, updatable = false)
     private LocalDateTime likedAt;
 
     @PrePersist
     protected void onCreate() {
         this.likedAt = LocalDateTime.now();
+    }
+
+    public static TopicLike create(
+            Topic topic,
+            User user
+    ) {
+        return TopicLike.builder()
+                .topic(topic)
+                .user(user)
+                .build();
     }
 }

--- a/src/main/java/com/dokdok/topic/entity/TopicMessage.java
+++ b/src/main/java/com/dokdok/topic/entity/TopicMessage.java
@@ -1,0 +1,23 @@
+package com.dokdok.topic.entity;
+
+import lombok.Getter;
+
+@Getter
+public enum TopicMessage {
+    LIKE_SUCCESS("주제를 좋아요 했습니다."),
+    LIKE_CANCEL("주제 좋아요를 취소했습니다.");
+
+    private final String message;
+
+    TopicMessage(String message) {
+        this.message = message;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public static TopicMessage from(boolean liked) {
+        return liked ? LIKE_SUCCESS : LIKE_CANCEL;
+    }
+}

--- a/src/main/java/com/dokdok/topic/repository/TopicLikeRepository.java
+++ b/src/main/java/com/dokdok/topic/repository/TopicLikeRepository.java
@@ -1,0 +1,17 @@
+package com.dokdok.topic.repository;
+
+import com.dokdok.topic.entity.Topic;
+import com.dokdok.topic.entity.TopicLike;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface TopicLikeRepository extends JpaRepository<TopicLike, Long> {
+
+    boolean existsByTopicId(Long topicId);
+
+    void deleteByTopicIdAndUserId(Long topicId, Long id);
+}

--- a/src/main/java/com/dokdok/topic/repository/TopicRepository.java
+++ b/src/main/java/com/dokdok/topic/repository/TopicRepository.java
@@ -26,12 +26,12 @@ public interface TopicRepository extends JpaRepository<Topic, Long> {
 
     @Modifying
     @Query("""
-      UPDATE Topic t
-      SET t.deletedAt = CURRENT_TIMESTAMP
-      WHERE t.meeting.id = :meetingId
-      AND t.proposedBy.id = :userId
-      AND t.deletedAt IS NULL
-      """)
+            UPDATE Topic t
+            SET t.deletedAt = CURRENT_TIMESTAMP
+            WHERE t.meeting.id = :meetingId
+            AND t.proposedBy.id = :userId
+            AND t.deletedAt IS NULL
+            """)
     void softDeleteByMeetingIdAndProposedById(
             @Param("meetingId") Long meetingId,
             @Param("userId") Long userId
@@ -62,5 +62,22 @@ public interface TopicRepository extends JpaRepository<Topic, Long> {
             @Param("userId") Long userId
     );
 
-    Optional<Topic> findByIdAndDeletedAtIsNull(Long topicId);
+    @Modifying
+    @Query("""
+                UPDATE Topic t
+                SET t.likeCount = t.likeCount + 1
+                WHERE t.id = :topicId
+            """)
+    void increaseLikeCount(@Param("topicId") Long topicId);
+
+    @Modifying
+    @Query("""
+                UPDATE Topic t
+                SET t.likeCount = t.likeCount - 1
+                WHERE t.id = :topicId
+                  AND t.likeCount > 0
+            """)
+    void decreaseLikeCount(@Param("topicId") Long topicId);
+
+
 }

--- a/src/main/java/com/dokdok/topic/service/TopicAnswerService.java
+++ b/src/main/java/com/dokdok/topic/service/TopicAnswerService.java
@@ -38,7 +38,7 @@ public class TopicAnswerService {
         Long userId = SecurityUtil.getCurrentUserId();
 
         gatheringValidator.validateMembership(gatheringId, userId);
-        meetingValidator.validateMemberInGathering(meetingId, gatheringId);
+        meetingValidator.validateMeetingInGathering(meetingId, gatheringId);
         topicValidator.validateTopicInMeeting(topicId, meetingId);
 
         Topic topic = topicRepository.getReferenceById(topicId);
@@ -60,7 +60,7 @@ public class TopicAnswerService {
         Long userId = SecurityUtil.getCurrentUserId();
 
         gatheringValidator.validateMembership(gatheringId, userId);
-        meetingValidator.validateMemberInGathering(meetingId, gatheringId);
+        meetingValidator.validateMeetingInGathering(meetingId, gatheringId);
         topicValidator.validateTopicInMeeting(topicId, meetingId);
 
         TopicAnswer answer = topicValidator.getTopicAnswer(topicId, userId);
@@ -78,7 +78,7 @@ public class TopicAnswerService {
         Long userId = SecurityUtil.getCurrentUserId();
 
         gatheringValidator.validateMembership(gatheringId, userId);
-        meetingValidator.validateMemberInGathering(meetingId, gatheringId);
+        meetingValidator.validateMeetingInGathering(meetingId, gatheringId);
         topicValidator.validateTopicInMeeting(topicId, meetingId);
 
         TopicAnswer answer = topicValidator.getTopicAnswer(topicId, userId);
@@ -101,7 +101,7 @@ public class TopicAnswerService {
         Long userId = SecurityUtil.getCurrentUserId();
 
         gatheringValidator.validateMembership(gatheringId, userId);
-        meetingValidator.validateMemberInGathering(meetingId, gatheringId);
+        meetingValidator.validateMeetingInGathering(meetingId, gatheringId);
         topicValidator.validateTopicInMeeting(topicId, meetingId);
 
         TopicAnswer answer = topicValidator.getTopicAnswer(topicId, userId);

--- a/src/main/java/com/dokdok/topic/service/TopicService.java
+++ b/src/main/java/com/dokdok/topic/service/TopicService.java
@@ -1,5 +1,7 @@
 package com.dokdok.topic.service;
 
+import com.dokdok.gathering.entity.Gathering;
+import com.dokdok.gathering.repository.GatheringRepository;
 import com.dokdok.gathering.service.GatheringValidator;
 import com.dokdok.global.util.SecurityUtil;
 import com.dokdok.meeting.entity.Meeting;
@@ -7,8 +9,12 @@ import com.dokdok.meeting.entity.MeetingMember;
 import com.dokdok.meeting.service.MeetingValidator;
 import com.dokdok.topic.dto.request.SuggestTopicRequest;
 import com.dokdok.topic.dto.response.SuggestTopicResponse;
+import com.dokdok.topic.dto.response.TopicLikeResponse;
 import com.dokdok.topic.dto.response.TopicsPageResponse;
 import com.dokdok.topic.entity.Topic;
+import com.dokdok.topic.entity.TopicLike;
+import com.dokdok.topic.entity.TopicMessage;
+import com.dokdok.topic.repository.TopicLikeRepository;
 import com.dokdok.topic.repository.TopicRepository;
 import com.dokdok.user.entity.User;
 import lombok.RequiredArgsConstructor;
@@ -19,7 +25,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.RequestMapping;
 
-import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -27,8 +32,9 @@ import java.util.Optional;
 public class TopicService {
 
     private final TopicRepository topicRepository;
-    private final MeetingValidator meetingValidator;
+    private final TopicLikeRepository topicLikeRepository;
     private final GatheringValidator gatheringValidator;
+    private final MeetingValidator meetingValidator;
     private final TopicValidator topicValidator;
 
     @Transactional
@@ -39,10 +45,8 @@ public class TopicService {
     ) {
         Long userId = SecurityUtil.getCurrentUserId();
 
-        gatheringValidator.validateMembership(gatheringId, userId);
-
-        meetingValidator.validateMemberInGathering(meetingId, gatheringId);
-
+        gatheringValidator.validateGathering(gatheringId);
+        meetingValidator.validateMeetingInGathering(meetingId, gatheringId);
         meetingValidator.validateMeetingStatus(meetingId);
 
         MeetingMember meetingMember = meetingValidator.getMeetingMember(meetingId, userId);
@@ -50,7 +54,7 @@ public class TopicService {
         Meeting meeting = meetingMember.getMeeting();
         User user = meetingMember.getUser();
 
-        Topic topic = Topic.of(
+        Topic topic = Topic.create(
                 meeting,
                 user,
                 request.title(),
@@ -69,11 +73,8 @@ public class TopicService {
             Long meetingId,
             Pageable pageable
     ) {
-        Long userId = SecurityUtil.getCurrentUserId();
-
-        gatheringValidator.validateMembership(gatheringId, userId);
-
-        meetingValidator.validateMemberInGathering(meetingId, gatheringId);
+        gatheringValidator.validateGathering(gatheringId);
+        meetingValidator.validateMeetingInGathering(meetingId, gatheringId);
 
         Pageable noSortPageable =
                 PageRequest.of(pageable.getPageNumber(), pageable.getPageSize());
@@ -92,14 +93,47 @@ public class TopicService {
     ) {
         Long userId = SecurityUtil.getCurrentUserId();
 
-        gatheringValidator.validateMembership(gatheringId, userId);
-
-        meetingValidator.validateMemberInGathering(meetingId, gatheringId);
-
+        gatheringValidator.validateGathering(gatheringId);
+        meetingValidator.validateMeetingInGathering(meetingId, gatheringId);
+        meetingValidator.validateMeetingMember(meetingId, userId);
         topicValidator.validateTopicInMeeting(topicId, meetingId);
 
         Topic topic = topicValidator.getDeletableTopic(topicId, userId);
 
         topic.softDelete();
+    }
+
+    @Transactional
+    public TopicLikeResponse toggleTopicLike(
+            Long gatheringId,
+            Long meetingId,
+            Long topicId
+    ) {
+        User user = SecurityUtil.getCurrentUserEntity();
+
+        gatheringValidator.validateGathering(gatheringId);
+        meetingValidator.validateMeetingInGathering(meetingId, gatheringId);
+        meetingValidator.validateMeetingMember(meetingId, user.getId());
+
+        Topic topic = topicValidator.getTopicInMeeting(topicId, meetingId);
+
+        boolean exists = topicLikeRepository.existsByTopicId(topicId);
+
+        TopicMessage message;
+        int newCount;
+
+        if (exists) {
+            topicLikeRepository.deleteByTopicIdAndUserId(topicId, user.getId());
+            topicRepository.decreaseLikeCount(topicId);
+            message = TopicMessage.LIKE_CANCEL;
+            newCount = topic.getLikeCount() - 1;
+        } else {
+            topicLikeRepository.save(TopicLike.create(topic, user));
+            topicRepository.increaseLikeCount(topicId);
+            message = TopicMessage.LIKE_SUCCESS;
+            newCount = topic.getLikeCount() + 1;
+        }
+
+        return TopicLikeResponse.from(topicId, message, newCount);
     }
 }

--- a/src/main/java/com/dokdok/topic/service/TopicValidator.java
+++ b/src/main/java/com/dokdok/topic/service/TopicValidator.java
@@ -1,12 +1,15 @@
 package com.dokdok.topic.service;
 
+import com.dokdok.topic.dto.response.TopicLikeResponse;
 import com.dokdok.topic.entity.TopicAnswer;
 import com.dokdok.topic.entity.Topic;
 import com.dokdok.meeting.exception.MeetingErrorCode;
 import com.dokdok.meeting.exception.MeetingException;
+import com.dokdok.topic.entity.TopicLike;
 import com.dokdok.topic.exception.TopicErrorCode;
 import com.dokdok.topic.exception.TopicException;
 import com.dokdok.topic.repository.TopicAnswerRepository;
+import com.dokdok.topic.repository.TopicLikeRepository;
 import com.dokdok.topic.repository.TopicRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -19,11 +22,12 @@ public class TopicValidator {
 
     private final TopicRepository topicRepository;
     private final TopicAnswerRepository topicAnswerRepository;
+    private final TopicLikeRepository topicLikeRepository;
 
     /**
-     * 해당 약속에 속한 주제인지 검증한다.
+     * 해당 약속에 속한 주제인지 검증하고 Topic을 반환한다.
      */
-    public void validateTopicInMeeting(Long topicId, Long meetingId) {
+    public Topic getTopicInMeeting(Long topicId, Long meetingId) {
         Topic topic = topicRepository.findDetailById(topicId)
                 .orElseThrow(() -> new TopicException(TopicErrorCode.TOPIC_NOT_FOUND));
 
@@ -34,6 +38,15 @@ public class TopicValidator {
         if (!topic.getMeeting().getId().equals(meetingId)) {
             throw new TopicException(TopicErrorCode.TOPIC_NOT_IN_MEETING);
         }
+
+        return topic;
+    }
+
+    /**
+     * 해당 약속에 속한 주제인지 검증한다.
+     */
+    public void validateTopicInMeeting(Long topicId, Long meetingId) {
+        getTopicInMeeting(topicId, meetingId);
     }
 
     public TopicAnswer getTopicAnswer(Long topicId, Long userId) {
@@ -43,16 +56,15 @@ public class TopicValidator {
 
     /**
      * 주제에 대한 삭제 권한 검증한다
-     * 권한 소유 : 모임장, 약속장, 약속 제안자
+     * 권한 소유 : 모임장, 약속장, 주제 제안자
      */
     public Topic getDeletableTopic(
             Long topicId,
             Long userId
     ) {
-        Topic topic = topicRepository.findTopicWithDeletePermission(topicId, userId)
-                .orElseThrow(() -> new TopicException(TopicErrorCode.TOPIC_USER_CANNOT_DELETE));
 
-        return topic;
+        return topicRepository.findTopicWithDeletePermission(topicId, userId)
+                .orElseThrow(() -> new TopicException(TopicErrorCode.TOPIC_USER_CANNOT_DELETE));
     }
 
 }

--- a/src/test/java/com/dokdok/topic/service/TopicServiceTest.java
+++ b/src/test/java/com/dokdok/topic/service/TopicServiceTest.java
@@ -20,6 +20,7 @@ import com.dokdok.topic.entity.TopicStatus;
 import com.dokdok.topic.entity.TopicType;
 import com.dokdok.topic.exception.TopicErrorCode;
 import com.dokdok.topic.exception.TopicException;
+import com.dokdok.topic.repository.TopicLikeRepository;
 import com.dokdok.topic.repository.TopicRepository;
 import com.dokdok.user.entity.User;
 import org.junit.jupiter.api.BeforeEach;
@@ -51,6 +52,9 @@ class TopicServiceTest {
 
     @Mock
     private TopicRepository topicRepository;
+
+    @Mock
+    private TopicLikeRepository topicLikeRepository;
 
     @Mock
     private MeetingValidator meetingValidator;
@@ -121,13 +125,13 @@ class TopicServiceTest {
             securityUtilMock.when(SecurityUtil::getCurrentUserId)
                     .thenReturn(userId);
 
-            // 모임 멤버 검증 통과
+            // 모임 검증 통과
             doNothing().when(gatheringValidator)
-                    .validateMembership(gatheringId, userId);
+                    .validateGathering(gatheringId);
 
             // 회차 소속 검증 통과
             doNothing().when(meetingValidator)
-                    .validateMemberInGathering(meetingId, gatheringId);
+                    .validateMeetingInGathering(meetingId, gatheringId);
 
             // 회차 상태 검증 통과
             doNothing().when(meetingValidator)
@@ -152,8 +156,8 @@ class TopicServiceTest {
             assertThat(response.createdBy().userId()).isEqualTo(1L);
             assertThat(response.createdBy().nickname()).isEqualTo("책벌레김");
 
-            verify(gatheringValidator).validateMembership(gatheringId, userId);
-            verify(meetingValidator).validateMemberInGathering(meetingId, gatheringId);
+            verify(gatheringValidator).validateGathering(gatheringId);
+            verify(meetingValidator).validateMeetingInGathering(meetingId, gatheringId);
             verify(meetingValidator).validateMeetingStatus(meetingId);
             verify(meetingValidator).getMeetingMember(meetingId, userId);
             verify(topicRepository).save(any(Topic.class));
@@ -176,8 +180,8 @@ class TopicServiceTest {
                     .hasFieldOrPropertyWithValue("errorCode",
                             GlobalErrorCode.UNAUTHORIZED);
 
-            verify(gatheringValidator, never()).validateMembership(any(), any());
-            verify(meetingValidator, never()).validateMemberInGathering(any(), any());
+            verify(gatheringValidator, never()).validateGathering(any());
+            verify(meetingValidator, never()).validateMeetingInGathering(any(), any());
             verify(meetingValidator, never()).getMeetingMember(any(), any());
             verify(topicRepository, never()).save(any());
         }
@@ -194,17 +198,17 @@ class TopicServiceTest {
             securityUtilMock.when(SecurityUtil::getCurrentUserId)
                     .thenReturn(userId);
 
-            doThrow(new GatheringException(GatheringErrorCode.NOT_GATHERING_MEMBER))
+            doThrow(new GatheringException(GatheringErrorCode.GATHERING_NOT_FOUND))
                     .when(gatheringValidator)
-                    .validateMembership(gatheringId, userId);
+                    .validateGathering(gatheringId);
 
             assertThatThrownBy(() ->
                     topicService.createTopic(gatheringId, meetingId, testRequest))
                     .isInstanceOf(GatheringException.class)
                     .hasFieldOrPropertyWithValue("errorCode",
-                            GatheringErrorCode.NOT_GATHERING_MEMBER);
+                            GatheringErrorCode.GATHERING_NOT_FOUND);
 
-            verify(meetingValidator, never()).validateMemberInGathering(any(), any());
+            verify(meetingValidator, never()).validateMeetingInGathering(any(), any());
             verify(meetingValidator, never()).getMeetingMember(any(), any());
             verify(topicRepository, never()).save(any());
         }
@@ -222,11 +226,11 @@ class TopicServiceTest {
                     .thenReturn(userId);
 
             doNothing().when(gatheringValidator)
-                    .validateMembership(gatheringId, userId);
+                    .validateGathering(gatheringId);
 
             doThrow(new MeetingException(MeetingErrorCode.NOT_GATHERING_MEETING))
                     .when(meetingValidator)
-                    .validateMemberInGathering(meetingId, gatheringId);
+                    .validateMeetingInGathering(meetingId, gatheringId);
 
             assertThatThrownBy(() ->
                     topicService.createTopic(gatheringId, meetingId, testRequest))
@@ -252,10 +256,10 @@ class TopicServiceTest {
                     .thenReturn(userId);
 
             doNothing().when(gatheringValidator)
-                    .validateMembership(gatheringId, userId);
+                    .validateGathering(gatheringId);
 
             doNothing().when(meetingValidator)
-                    .validateMemberInGathering(meetingId, gatheringId);
+                    .validateMeetingInGathering(meetingId, gatheringId);
 
             doThrow(new MeetingException(MeetingErrorCode.MEETING_ALREADY_CONFIRMED))
                     .when(meetingValidator)
@@ -284,10 +288,10 @@ class TopicServiceTest {
                     .thenReturn(userId);
 
             doNothing().when(gatheringValidator)
-                    .validateMembership(gatheringId, userId);
+                    .validateGathering(gatheringId);
 
             doNothing().when(meetingValidator)
-                    .validateMemberInGathering(meetingId, gatheringId);
+                    .validateMeetingInGathering(meetingId, gatheringId);
 
             doNothing().when(meetingValidator)
                     .validateMeetingStatus(meetingId);
@@ -314,7 +318,6 @@ class TopicServiceTest {
         void getTopics_Success() {
             Long gatheringId = 1L;
             Long meetingId = 1L;
-            Long userId = 1L;
             Pageable pageable = PageRequest.of(0, 10);
 
             User user1 = User.builder()
@@ -354,39 +357,34 @@ class TopicServiceTest {
             List<Topic> topics = List.of(topic1, topic2);
             Page<Topic> topicPage = new PageImpl<>(topics, pageable, topics.size());
 
-            try (MockedStatic<SecurityUtil> securityUtilMock = mockStatic(SecurityUtil.class)) {
-                securityUtilMock.when(SecurityUtil::getCurrentUserId)
-                        .thenReturn(userId);
+            doNothing().when(gatheringValidator)
+                    .validateGathering(gatheringId);
 
-                doNothing().when(gatheringValidator)
-                        .validateMembership(gatheringId, userId);
+            doNothing().when(meetingValidator)
+                    .validateMeetingInGathering(meetingId, gatheringId);
 
-                doNothing().when(meetingValidator)
-                        .validateMemberInGathering(meetingId, gatheringId);
+            given(topicRepository.findTopicsByMeetingId(eq(meetingId), any(Pageable.class)))
+                    .willReturn(topicPage);
 
-                given(topicRepository.findTopicsByMeetingId(eq(meetingId), any(Pageable.class)))
-                        .willReturn(topicPage);
+            TopicsPageResponse response = topicService.getTopics(gatheringId, meetingId, pageable);
 
-                TopicsPageResponse response = topicService.getTopics(gatheringId, meetingId, pageable);
+            assertThat(response).isNotNull();
+            assertThat(response.topics()).hasSize(2);
+            assertThat(response.totalCount()).isEqualTo(2);
+            assertThat(response.currentPage()).isEqualTo(0);
+            assertThat(response.pageSize()).isEqualTo(10);
+            assertThat(response.totalPages()).isEqualTo(1);
 
-                assertThat(response).isNotNull();
-                assertThat(response.topics()).hasSize(2);
-                assertThat(response.totalCount()).isEqualTo(2);
-                assertThat(response.currentPage()).isEqualTo(0);
-                assertThat(response.pageSize()).isEqualTo(10);
-                assertThat(response.totalPages()).isEqualTo(1);
+            assertThat(response.topics().get(0).title()).isEqualTo("의미 있는 이름 짓기");
+            assertThat(response.topics().get(0).likeCount()).isEqualTo(5);
+            assertThat(response.topics().get(0).topicType()).isEqualTo(TopicType.DISCUSSION);
 
-                assertThat(response.topics().get(0).title()).isEqualTo("의미 있는 이름 짓기");
-                assertThat(response.topics().get(0).likeCount()).isEqualTo(5);
-                assertThat(response.topics().get(0).topicType()).isEqualTo(TopicType.DISCUSSION);
+            assertThat(response.topics().get(1).title()).isEqualTo("함수 작성 원칙");
+            assertThat(response.topics().get(1).likeCount()).isEqualTo(3);
 
-                assertThat(response.topics().get(1).title()).isEqualTo("함수 작성 원칙");
-                assertThat(response.topics().get(1).likeCount()).isEqualTo(3);
-
-                verify(gatheringValidator).validateMembership(gatheringId, userId);
-                verify(meetingValidator).validateMemberInGathering(meetingId, gatheringId);
-                verify(topicRepository).findTopicsByMeetingId(eq(meetingId), any(Pageable.class));
-            }
+            verify(gatheringValidator).validateGathering(gatheringId);
+            verify(meetingValidator).validateMeetingInGathering(meetingId, gatheringId);
+            verify(topicRepository).findTopicsByMeetingId(eq(meetingId), any(Pageable.class));
         }
 
         @Test
@@ -394,37 +392,31 @@ class TopicServiceTest {
         void getTopics_EmptyList() {
             Long gatheringId = 1L;
             Long meetingId = 1L;
-            Long userId = 1L;
             Pageable pageable = PageRequest.of(0, 10);
 
             Page<Topic> emptyPage = new PageImpl<>(List.of(), pageable, 0);
 
-            try (MockedStatic<SecurityUtil> securityUtilMock = mockStatic(SecurityUtil.class)) {
-                securityUtilMock.when(SecurityUtil::getCurrentUserId)
-                        .thenReturn(userId);
+            doNothing().when(gatheringValidator)
+                    .validateGathering(gatheringId);
 
-                doNothing().when(gatheringValidator)
-                        .validateMembership(gatheringId, userId);
+            doNothing().when(meetingValidator)
+                    .validateMeetingInGathering(meetingId, gatheringId);
 
-                doNothing().when(meetingValidator)
-                        .validateMemberInGathering(meetingId, gatheringId);
+            given(topicRepository.findTopicsByMeetingId(eq(meetingId), any(Pageable.class)))
+                    .willReturn(emptyPage);
 
-                given(topicRepository.findTopicsByMeetingId(eq(meetingId), any(Pageable.class)))
-                        .willReturn(emptyPage);
+            TopicsPageResponse response = topicService.getTopics(gatheringId, meetingId, pageable);
 
-                TopicsPageResponse response = topicService.getTopics(gatheringId, meetingId, pageable);
+            assertThat(response).isNotNull();
+            assertThat(response.topics()).isEmpty();
+            assertThat(response.totalCount()).isEqualTo(0);
+            assertThat(response.currentPage()).isEqualTo(0);
+            assertThat(response.pageSize()).isEqualTo(10);
+            assertThat(response.totalPages()).isEqualTo(0);
 
-                assertThat(response).isNotNull();
-                assertThat(response.topics()).isEmpty();
-                assertThat(response.totalCount()).isEqualTo(0);
-                assertThat(response.currentPage()).isEqualTo(0);
-                assertThat(response.pageSize()).isEqualTo(10);
-                assertThat(response.totalPages()).isEqualTo(0);
-
-                verify(gatheringValidator).validateMembership(gatheringId, userId);
-                verify(meetingValidator).validateMemberInGathering(meetingId, gatheringId);
-                verify(topicRepository).findTopicsByMeetingId(eq(meetingId), any(Pageable.class));
-            }
+            verify(gatheringValidator).validateGathering(gatheringId);
+            verify(meetingValidator).validateMeetingInGathering(meetingId, gatheringId);
+            verify(topicRepository).findTopicsByMeetingId(eq(meetingId), any(Pageable.class));
         }
 
         @Test
@@ -432,7 +424,6 @@ class TopicServiceTest {
         void getTopics_WithPagination() {
             Long gatheringId = 1L;
             Long meetingId = 1L;
-            Long userId = 1L;
             Pageable pageable = PageRequest.of(1, 5);
 
             List<Topic> topics = List.of(
@@ -448,80 +439,46 @@ class TopicServiceTest {
             );
             Page<Topic> topicPage = new PageImpl<>(topics, pageable, 11);
 
-            try (MockedStatic<SecurityUtil> securityUtilMock = mockStatic(SecurityUtil.class)) {
-                securityUtilMock.when(SecurityUtil::getCurrentUserId)
-                        .thenReturn(userId);
+            doNothing().when(gatheringValidator)
+                    .validateGathering(gatheringId);
 
-                doNothing().when(gatheringValidator)
-                        .validateMembership(gatheringId, userId);
+            doNothing().when(meetingValidator)
+                    .validateMeetingInGathering(meetingId, gatheringId);
 
-                doNothing().when(meetingValidator)
-                        .validateMemberInGathering(meetingId, gatheringId);
+            given(topicRepository.findTopicsByMeetingId(eq(meetingId), any(Pageable.class)))
+                    .willReturn(topicPage);
 
-                given(topicRepository.findTopicsByMeetingId(eq(meetingId), any(Pageable.class)))
-                        .willReturn(topicPage);
+            TopicsPageResponse response = topicService.getTopics(gatheringId, meetingId, pageable);
 
-                TopicsPageResponse response = topicService.getTopics(gatheringId, meetingId, pageable);
+            assertThat(response).isNotNull();
+            assertThat(response.topics()).hasSize(1);
+            assertThat(response.totalCount()).isEqualTo(11);
+            assertThat(response.currentPage()).isEqualTo(1);
+            assertThat(response.pageSize()).isEqualTo(5);
+            assertThat(response.totalPages()).isEqualTo(3);
 
-                assertThat(response).isNotNull();
-                assertThat(response.topics()).hasSize(1);
-                assertThat(response.totalCount()).isEqualTo(11);
-                assertThat(response.currentPage()).isEqualTo(1);
-                assertThat(response.pageSize()).isEqualTo(5);
-                assertThat(response.totalPages()).isEqualTo(3);
-
-                verify(topicRepository).findTopicsByMeetingId(eq(meetingId), any(Pageable.class));
-            }
+            verify(topicRepository).findTopicsByMeetingId(eq(meetingId), any(Pageable.class));
         }
 
         @Test
-        @DisplayName("인증되지 않은 사용자인 경우 예외가 발생한다")
-        void getTopics_Unauthorized_ThrowsException() {
-            Long gatheringId = 1L;
+        @DisplayName("모임을 찾을 수 없는 경우 예외가 발생한다")
+        void getTopics_GatheringNotFound_ThrowsException() {
+            Long gatheringId = 999L;
             Long meetingId = 1L;
             Pageable pageable = PageRequest.of(0, 10);
 
-            try (MockedStatic<SecurityUtil> securityUtilMock = mockStatic(SecurityUtil.class)) {
-                securityUtilMock.when(SecurityUtil::getCurrentUserId)
-                        .thenThrow(new GlobalException(GlobalErrorCode.UNAUTHORIZED));
+            doThrow(new GatheringException(GatheringErrorCode.GATHERING_NOT_FOUND))
+                    .when(gatheringValidator)
+                    .validateGathering(gatheringId);
 
-                assertThatThrownBy(() ->
-                        topicService.getTopics(gatheringId, meetingId, pageable))
-                        .isInstanceOf(GlobalException.class)
-                        .hasFieldOrPropertyWithValue("errorCode",
-                                GlobalErrorCode.UNAUTHORIZED);
+            assertThatThrownBy(() ->
+                    topicService.getTopics(gatheringId, meetingId, pageable))
+                    .isInstanceOf(GatheringException.class)
+                    .hasFieldOrPropertyWithValue("errorCode",
+                            GatheringErrorCode.GATHERING_NOT_FOUND);
 
-                verify(gatheringValidator, never()).validateMembership(any(), any());
-                verify(meetingValidator, never()).validateMemberInGathering(any(), any());
-                verify(topicRepository, never()).findTopicsByMeetingId(any(), any());
-            }
-        }
-
-        @Test
-        @DisplayName("모임 멤버가 아닌 경우 예외가 발생한다")
-        void getTopics_NotGatheringMember_ThrowsException() {
-            Long gatheringId = 1L;
-            Long meetingId = 1L;
-            Long userId = 1L;
-            Pageable pageable = PageRequest.of(0, 10);
-
-            try (MockedStatic<SecurityUtil> securityUtilMock = mockStatic(SecurityUtil.class)) {
-                securityUtilMock.when(SecurityUtil::getCurrentUserId)
-                        .thenReturn(userId);
-
-                doThrow(new GatheringException(GatheringErrorCode.NOT_GATHERING_MEMBER))
-                        .when(gatheringValidator)
-                        .validateMembership(gatheringId, userId);
-
-                assertThatThrownBy(() ->
-                        topicService.getTopics(gatheringId, meetingId, pageable))
-                        .isInstanceOf(GatheringException.class)
-                        .hasFieldOrPropertyWithValue("errorCode",
-                                GatheringErrorCode.NOT_GATHERING_MEMBER);
-
-                verify(meetingValidator, never()).validateMemberInGathering(any(), any());
-                verify(topicRepository, never()).findTopicsByMeetingId(any(), any());
-            }
+            verify(meetingValidator, never()).validateMeetingInGathering(any(), any());
+            verify(topicRepository, never()).findTopicsByMeetingId(any(), any());
         }
 
         @Test
@@ -529,28 +486,22 @@ class TopicServiceTest {
         void getTopics_MeetingNotInGathering_ThrowsException() {
             Long gatheringId = 1L;
             Long meetingId = 999L;
-            Long userId = 1L;
             Pageable pageable = PageRequest.of(0, 10);
 
-            try (MockedStatic<SecurityUtil> securityUtilMock = mockStatic(SecurityUtil.class)) {
-                securityUtilMock.when(SecurityUtil::getCurrentUserId)
-                        .thenReturn(userId);
+            doNothing().when(gatheringValidator)
+                    .validateGathering(gatheringId);
 
-                doNothing().when(gatheringValidator)
-                        .validateMembership(gatheringId, userId);
+            doThrow(new MeetingException(MeetingErrorCode.NOT_GATHERING_MEETING))
+                    .when(meetingValidator)
+                    .validateMeetingInGathering(meetingId, gatheringId);
 
-                doThrow(new MeetingException(MeetingErrorCode.NOT_GATHERING_MEETING))
-                        .when(meetingValidator)
-                        .validateMemberInGathering(meetingId, gatheringId);
+            assertThatThrownBy(() ->
+                    topicService.getTopics(gatheringId, meetingId, pageable))
+                    .isInstanceOf(MeetingException.class)
+                    .hasFieldOrPropertyWithValue("errorCode",
+                            MeetingErrorCode.NOT_GATHERING_MEETING);
 
-                assertThatThrownBy(() ->
-                        topicService.getTopics(gatheringId, meetingId, pageable))
-                        .isInstanceOf(MeetingException.class)
-                        .hasFieldOrPropertyWithValue("errorCode",
-                                MeetingErrorCode.NOT_GATHERING_MEETING);
-
-                verify(topicRepository, never()).findTopicsByMeetingId(any(), any());
-            }
+            verify(topicRepository, never()).findTopicsByMeetingId(any(), any());
         }
     }
 
@@ -573,10 +524,13 @@ class TopicServiceTest {
                         .thenReturn(userId);
 
                 doNothing().when(gatheringValidator)
-                        .validateMembership(gatheringId, userId);
+                        .validateGathering(gatheringId);
 
                 doNothing().when(meetingValidator)
-                        .validateMemberInGathering(meetingId, gatheringId);
+                        .validateMeetingInGathering(meetingId, gatheringId);
+
+                doNothing().when(meetingValidator)
+                        .validateMeetingMember(meetingId, userId);
 
                 doNothing().when(topicValidator)
                         .validateTopicInMeeting(topicId, meetingId);
@@ -586,8 +540,9 @@ class TopicServiceTest {
 
                 topicService.deleteTopic(gatheringId, meetingId, topicId);
 
-                verify(gatheringValidator).validateMembership(gatheringId, userId);
-                verify(meetingValidator).validateMemberInGathering(meetingId, gatheringId);
+                verify(gatheringValidator).validateGathering(gatheringId);
+                verify(meetingValidator).validateMeetingInGathering(meetingId, gatheringId);
+                verify(meetingValidator).validateMeetingMember(meetingId, userId);
                 verify(topicValidator).validateTopicInMeeting(topicId, meetingId);
                 verify(topicValidator).getDeletableTopic(topicId, userId);
                 verify(mockTopic).softDelete();
@@ -611,17 +566,17 @@ class TopicServiceTest {
                         .hasFieldOrPropertyWithValue("errorCode",
                                 GlobalErrorCode.UNAUTHORIZED);
 
-                verify(gatheringValidator, never()).validateMembership(any(), any());
-                verify(meetingValidator, never()).validateMemberInGathering(any(), any());
+                verify(gatheringValidator, never()).validateGathering(any());
+                verify(meetingValidator, never()).validateMeetingInGathering(any(), any());
                 verify(topicValidator, never()).validateTopicInMeeting(any(), any());
                 verify(topicValidator, never()).getDeletableTopic(any(), any());
             }
         }
 
         @Test
-        @DisplayName("모임 멤버가 아닌 경우 예외가 발생한다")
-        void deleteTopic_NotGatheringMember_ThrowsException() {
-            Long gatheringId = 1L;
+        @DisplayName("모임을 찾을 수 없는 경우 예외가 발생한다")
+        void deleteTopic_GatheringNotFound_ThrowsException() {
+            Long gatheringId = 999L;
             Long meetingId = 1L;
             Long topicId = 1L;
             Long userId = 1L;
@@ -630,17 +585,18 @@ class TopicServiceTest {
                 securityUtilMock.when(SecurityUtil::getCurrentUserId)
                         .thenReturn(userId);
 
-                doThrow(new GatheringException(GatheringErrorCode.NOT_GATHERING_MEMBER))
+                doThrow(new GatheringException(GatheringErrorCode.GATHERING_NOT_FOUND))
                         .when(gatheringValidator)
-                        .validateMembership(gatheringId, userId);
+                        .validateGathering(gatheringId);
 
                 assertThatThrownBy(() ->
                         topicService.deleteTopic(gatheringId, meetingId, topicId))
                         .isInstanceOf(GatheringException.class)
                         .hasFieldOrPropertyWithValue("errorCode",
-                                GatheringErrorCode.NOT_GATHERING_MEMBER);
+                                GatheringErrorCode.GATHERING_NOT_FOUND);
 
-                verify(meetingValidator, never()).validateMemberInGathering(any(), any());
+                verify(meetingValidator, never()).validateMeetingInGathering(any(), any());
+                verify(meetingValidator, never()).validateMeetingMember(any(), any());
                 verify(topicValidator, never()).validateTopicInMeeting(any(), any());
                 verify(topicValidator, never()).getDeletableTopic(any(), any());
             }
@@ -659,11 +615,11 @@ class TopicServiceTest {
                         .thenReturn(userId);
 
                 doNothing().when(gatheringValidator)
-                        .validateMembership(gatheringId, userId);
+                        .validateGathering(gatheringId);
 
                 doThrow(new MeetingException(MeetingErrorCode.NOT_GATHERING_MEETING))
                         .when(meetingValidator)
-                        .validateMemberInGathering(meetingId, gatheringId);
+                        .validateMeetingInGathering(meetingId, gatheringId);
 
                 assertThatThrownBy(() ->
                         topicService.deleteTopic(gatheringId, meetingId, topicId))
@@ -671,6 +627,7 @@ class TopicServiceTest {
                         .hasFieldOrPropertyWithValue("errorCode",
                                 MeetingErrorCode.NOT_GATHERING_MEETING);
 
+                verify(meetingValidator, never()).validateMeetingMember(any(), any());
                 verify(topicValidator, never()).validateTopicInMeeting(any(), any());
                 verify(topicValidator, never()).getDeletableTopic(any(), any());
             }
@@ -689,10 +646,13 @@ class TopicServiceTest {
                         .thenReturn(userId);
 
                 doNothing().when(gatheringValidator)
-                        .validateMembership(gatheringId, userId);
+                        .validateGathering(gatheringId);
 
                 doNothing().when(meetingValidator)
-                        .validateMemberInGathering(meetingId, gatheringId);
+                        .validateMeetingInGathering(meetingId, gatheringId);
+
+                doNothing().when(meetingValidator)
+                        .validateMeetingMember(meetingId, userId);
 
                 doThrow(new TopicException(TopicErrorCode.TOPIC_NOT_IN_MEETING))
                         .when(topicValidator)
@@ -721,10 +681,13 @@ class TopicServiceTest {
                         .thenReturn(userId);
 
                 doNothing().when(gatheringValidator)
-                        .validateMembership(gatheringId, userId);
+                        .validateGathering(gatheringId);
 
                 doNothing().when(meetingValidator)
-                        .validateMemberInGathering(meetingId, gatheringId);
+                        .validateMeetingInGathering(meetingId, gatheringId);
+
+                doNothing().when(meetingValidator)
+                        .validateMeetingMember(meetingId, userId);
 
                 doThrow(new TopicException(TopicErrorCode.TOPIC_NOT_FOUND))
                         .when(topicValidator)
@@ -753,10 +716,13 @@ class TopicServiceTest {
                         .thenReturn(userId);
 
                 doNothing().when(gatheringValidator)
-                        .validateMembership(gatheringId, userId);
+                        .validateGathering(gatheringId);
 
                 doNothing().when(meetingValidator)
-                        .validateMemberInGathering(meetingId, gatheringId);
+                        .validateMeetingInGathering(meetingId, gatheringId);
+
+                doNothing().when(meetingValidator)
+                        .validateMeetingMember(meetingId, userId);
 
                 doThrow(new TopicException(TopicErrorCode.TOPIC_ALREADY_DELETED))
                         .when(topicValidator)
@@ -785,10 +751,13 @@ class TopicServiceTest {
                         .thenReturn(userId);
 
                 doNothing().when(gatheringValidator)
-                        .validateMembership(gatheringId, userId);
+                        .validateGathering(gatheringId);
 
                 doNothing().when(meetingValidator)
-                        .validateMemberInGathering(meetingId, gatheringId);
+                        .validateMeetingInGathering(meetingId, gatheringId);
+
+                doNothing().when(meetingValidator)
+                        .validateMeetingMember(meetingId, userId);
 
                 doNothing().when(topicValidator)
                         .validateTopicInMeeting(topicId, meetingId);


### PR DESCRIPTION
## PR 요약

- [x] 기능 추가
- [ ] 버그 수정
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 기타 (설명)

---

## 이슈 번호
- #78

---

## 주요 변경 사항

- `src/main/java/com/dokdok/gathering`: +11/-0 (1 files) — 요구사항 반영
- `src/main/java/com/dokdok/meeting`: +14/-5 (2 files) — 요구사항 반영
- `src/main/java/com/dokdok/topic`: +215/-37 (11 files) — 요구사항 반영
- `src/test/java/com/dokdok/topic`: +141/-172 (1 files) — 요구사항 반영

---

## 참고 사항
- 기존에는 POST /likes / PATCH /likes API로 분리되어 있었으나, 토글 하나로 통합하여 호출 편의성을 높였습니다.
한 번의 요청으로 좋아요 상태를 확인하고, 추가/취소를 자동으로 처리합니다.

---
