### PR TITLE
[#85][FEAT] 모임 가입 신청

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,4 @@ scripts/PR_BODY.md
 
 /logs/**
 /claude.md
+/agent.md

--- a/src/main/java/com/dokdok/gathering/api/GatheringApi.java
+++ b/src/main/java/com/dokdok/gathering/api/GatheringApi.java
@@ -1,9 +1,10 @@
 package com.dokdok.gathering.api;
 
-import com.dokdok.gathering.dto.response.GatheringDetailResponse;
+
 import com.dokdok.gathering.dto.request.GatheringCreateRequest;
-import com.dokdok.gathering.dto.response.GatheringCreateResponse;
 import com.dokdok.gathering.dto.request.GatheringUpdateRequest;
+import com.dokdok.gathering.dto.response.GatheringCreateResponse;
+import com.dokdok.gathering.dto.response.GatheringDetailResponse;
 import com.dokdok.gathering.dto.response.GatheringUpdateResponse;
 import com.dokdok.gathering.dto.response.MyGatheringListResponse;
 import com.dokdok.global.response.ApiResponse;

--- a/src/main/java/com/dokdok/gathering/controller/GatheringController.java
+++ b/src/main/java/com/dokdok/gathering/controller/GatheringController.java
@@ -2,11 +2,8 @@ package com.dokdok.gathering.controller;
 
 import com.dokdok.gathering.api.GatheringApi;
 import com.dokdok.gathering.dto.request.GatheringCreateRequest;
-import com.dokdok.gathering.dto.response.GatheringDetailResponse;
-import com.dokdok.gathering.dto.response.GatheringCreateResponse;
+import com.dokdok.gathering.dto.response.*;
 import com.dokdok.gathering.dto.request.GatheringUpdateRequest;
-import com.dokdok.gathering.dto.response.GatheringUpdateResponse;
-import com.dokdok.gathering.dto.response.MyGatheringListResponse;
 import com.dokdok.gathering.service.GatheringService;
 import com.dokdok.global.response.ApiResponse;
 import jakarta.validation.Valid;
@@ -31,12 +28,19 @@ public class GatheringController implements GatheringApi {
         return ApiResponse.created(response, "모임 생성에 성공하였습니다.");
     }
 
+    @PostMapping("/join/{invitationLink}")
+    public ResponseEntity<ApiResponse<GatheringJoinResponse>> joinGathering(@PathVariable("invitationLink")  String invitationLink) {
+
+        GatheringJoinResponse response = gatheringService.joinGathering(invitationLink);
+        return ApiResponse.success(response);
+    }
+
     @Override
     @GetMapping
     public ResponseEntity<ApiResponse<MyGatheringListResponse>> getMyGatherings(Pageable pageable) {
         MyGatheringListResponse response = gatheringService.getMyGatherings(pageable);
 
-        return ApiResponse.success(response, "모임 리스트 조회 성공");
+        return ApiResponse.success(response, "모임 가입 요청이 완료되었습니다. 모임장의 승인을 기다려주세요.");
     }
 
     @Override

--- a/src/main/java/com/dokdok/gathering/dto/request/GatheringUpdateRequest.java
+++ b/src/main/java/com/dokdok/gathering/dto/request/GatheringUpdateRequest.java
@@ -1,4 +1,4 @@
-package com.dokdok.gathering.dto;
+package com.dokdok.gathering.dto.request;
 
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;

--- a/src/main/java/com/dokdok/gathering/dto/response/GatheringDetailResponse.java
+++ b/src/main/java/com/dokdok/gathering/dto/response/GatheringDetailResponse.java
@@ -1,4 +1,4 @@
-package com.dokdok.gathering.dto;
+package com.dokdok.gathering.dto.response;
 
 import com.dokdok.gathering.entity.Gathering;
 import com.dokdok.gathering.entity.GatheringMember;

--- a/src/main/java/com/dokdok/gathering/dto/response/GatheringJoinResponse.java
+++ b/src/main/java/com/dokdok/gathering/dto/response/GatheringJoinResponse.java
@@ -1,0 +1,20 @@
+package com.dokdok.gathering.dto.response;
+
+import com.dokdok.gathering.entity.GatheringMember;
+import com.dokdok.gathering.entity.GatheringMemberStatus;
+import lombok.Builder;
+
+@Builder
+public record GatheringJoinResponse(
+        Long gatheringId,
+        String gatheringName,
+        GatheringMemberStatus memberStatus
+) {
+    public static GatheringJoinResponse from(GatheringMember member) {
+        return GatheringJoinResponse.builder()
+                .gatheringId(member.getGathering().getId())
+                .gatheringName(member.getGathering().getGatheringName())
+                .memberStatus(member.getMemberStatus())
+                .build();
+    }
+}

--- a/src/main/java/com/dokdok/gathering/dto/response/GatheringSimpleResponse.java
+++ b/src/main/java/com/dokdok/gathering/dto/response/GatheringSimpleResponse.java
@@ -1,4 +1,4 @@
-package com.dokdok.gathering.dto;
+package com.dokdok.gathering.dto.response;
 
 import com.dokdok.gathering.entity.GatheringMember;
 import com.dokdok.gathering.entity.GatheringRole;

--- a/src/main/java/com/dokdok/gathering/dto/response/GatheringUpdateResponse.java
+++ b/src/main/java/com/dokdok/gathering/dto/response/GatheringUpdateResponse.java
@@ -1,4 +1,4 @@
-package com.dokdok.gathering.dto;
+package com.dokdok.gathering.dto.response;
 
 import com.dokdok.gathering.entity.Gathering;
 import lombok.Builder;

--- a/src/main/java/com/dokdok/gathering/dto/response/MyGatheringListResponse.java
+++ b/src/main/java/com/dokdok/gathering/dto/response/MyGatheringListResponse.java
@@ -1,4 +1,4 @@
-package com.dokdok.gathering.dto;
+package com.dokdok.gathering.dto.response;
 
 import com.dokdok.gathering.entity.GatheringMember;
 import lombok.Builder;

--- a/src/main/java/com/dokdok/gathering/entity/GatheringMember.java
+++ b/src/main/java/com/dokdok/gathering/entity/GatheringMember.java
@@ -18,9 +18,9 @@ import java.time.temporal.ChronoUnit;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-@Builder
-@SQLRestriction("removed_at IS NULL")
-public class GatheringMember {
+    @Builder
+    @SQLRestriction("removed_at IS NULL")
+    public class GatheringMember {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -39,6 +39,11 @@ public class GatheringMember {
     @Builder.Default
     private Boolean isFavorite = false;
 
+    @Column(name = "member_status", nullable = true, length = 20)
+    @Enumerated(EnumType.STRING)
+    @Builder.Default
+    private GatheringMemberStatus memberStatus = GatheringMemberStatus.PENDING;
+
     @Column(name = "role", nullable = false, length = 20)
     @Enumerated(EnumType.STRING)
     @Builder.Default
@@ -54,6 +59,16 @@ public class GatheringMember {
 
     @Column(name = "removed_at")
     private LocalDateTime removedAt;
+
+    public static GatheringMember of(Gathering gathering, User user,
+                                     GatheringRole role, GatheringMemberStatus status) {
+        return GatheringMember.builder()
+                .gathering(gathering)
+                .user(user)
+                .role(role)
+                .memberStatus(status)
+                .build();
+    }
 
     /**
      * 가입일로부터 경과한 일수를 계산합니다.

--- a/src/main/java/com/dokdok/gathering/entity/GatheringMemberStatus.java
+++ b/src/main/java/com/dokdok/gathering/entity/GatheringMemberStatus.java
@@ -1,0 +1,7 @@
+package com.dokdok.gathering.entity;
+
+public enum GatheringMemberStatus {
+    PENDING,
+    ACTIVE,
+    REJECTED
+}

--- a/src/main/java/com/dokdok/gathering/exception/GatheringErrorCode.java
+++ b/src/main/java/com/dokdok/gathering/exception/GatheringErrorCode.java
@@ -15,7 +15,9 @@ public enum GatheringErrorCode implements BaseErrorCode {
     ALREADY_INACTIVE("G004","이미 비활성 상태인 모임은 삭제할 수 없습니다.",HttpStatus.CONFLICT),
     CANNOT_REMOVE_LEADER("G005", "유일한 리더는 강퇴할 수 없습니다.", HttpStatus.FORBIDDEN),
     ALREADY_REMOVED_MEMBER("G006", "이미 제거된 멤버입니다.", HttpStatus.CONFLICT),
-    INVITATION_CODE_GENERATION_FAILED("G007", "초대 코드 생성에 실패했습니다. 다시 시도해주세요.", HttpStatus.INTERNAL_SERVER_ERROR);
+    INVITATION_CODE_GENERATION_FAILED("G007", "초대 코드 생성에 실패했습니다. 다시 시도해주세요.", HttpStatus.INTERNAL_SERVER_ERROR),
+    ALREADY_GATHERING_MEMBER("G008", "이미 가입된 모임입니다.", HttpStatus.CONFLICT),
+    JOIN_REQUEST_ALREADY_PENDING("G009", "이미 가입 요청이 진행 중입니다.", HttpStatus.CONFLICT);
 
     private final String code;
     private final String message;

--- a/src/main/java/com/dokdok/gathering/repository/GatheringMemberRepository.java
+++ b/src/main/java/com/dokdok/gathering/repository/GatheringMemberRepository.java
@@ -46,9 +46,10 @@ public interface GatheringMemberRepository extends JpaRepository<GatheringMember
     int countActiveMembers(@Param("gatheringId") Long gatheringId);
 
     /**
-     * 특정 유저가 특정 모임의 멤버인지 확인
+     * 특정 유저가 특정 모임의 멤버인지 확인 (Gathering fetch join)
      */
     @Query("SELECT gm FROM GatheringMember gm " +
+            "JOIN FETCH gm.gathering g " +
             "WHERE gm.gathering.id = :gatheringId " +
             "AND gm.user.id = :userId " +
             "AND gm.removedAt IS NULL")

--- a/src/main/java/com/dokdok/gathering/repository/GatheringRepository.java
+++ b/src/main/java/com/dokdok/gathering/repository/GatheringRepository.java
@@ -2,10 +2,22 @@ package com.dokdok.gathering.repository;
 
 import com.dokdok.gathering.entity.Gathering;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
 
 @Repository
 public interface GatheringRepository extends JpaRepository<Gathering, Long> {
 
     boolean existsByInvitationLink(String invitationLink);
+
+    @Query("""
+            SELECT g
+            FROM Gathering g
+            JOIN FETCH g.gatheringLeader
+            WHERE g.invitationLink = :invitationLink
+            """)
+    Optional<Gathering> findGatheringByInvitationLink(@Param("invitationLink") String invitationLink);
 }

--- a/src/main/java/com/dokdok/gathering/service/GatheringService.java
+++ b/src/main/java/com/dokdok/gathering/service/GatheringService.java
@@ -3,10 +3,7 @@ package com.dokdok.gathering.service;
 import com.dokdok.gathering.dto.request.GatheringCreateRequest;
 import com.dokdok.gathering.dto.request.GatheringUpdateRequest;
 import com.dokdok.gathering.dto.response.*;
-import com.dokdok.gathering.entity.Gathering;
-import com.dokdok.gathering.entity.GatheringMember;
-import com.dokdok.gathering.entity.GatheringRole;
-import com.dokdok.gathering.entity.GatheringStatus;
+import com.dokdok.gathering.entity.*;
 import com.dokdok.gathering.exception.GatheringErrorCode;
 import com.dokdok.gathering.exception.GatheringException;
 import com.dokdok.gathering.repository.GatheringMemberRepository;
@@ -48,10 +45,25 @@ public class GatheringService {
         Gathering gathering = Gathering.of(request.gatheringName(), request.gatheringDescription(), invitationLink, user);
         Gathering savedGathering = gatheringRepository.save(gathering);
 
-        GatheringMember gatheringMember = GatheringMember.of(savedGathering, user);
-        gatheringMemberRepository.save(gatheringMember);
+        saveGatheringMember(savedGathering, user, GatheringRole.LEADER, GatheringMemberStatus.ACTIVE);
 
         return GatheringCreateResponse.from(savedGathering);
+    }
+
+    /**
+     * 초대링크를 통해 들어온 사용자가 모임에 가입 요청을 합니다.
+     */
+    @Transactional
+    public GatheringJoinResponse joinGathering(String invitationLink) {
+
+        User user = SecurityUtil.getCurrentUserEntity();
+
+        Gathering gathering = gatheringValidator.validateInvitationLink(invitationLink);
+        gatheringValidator.validateJoinedGathering(gathering.getId(), user.getId());
+
+        GatheringMember member = saveGatheringMember(gathering, user, GatheringRole.MEMBER, GatheringMemberStatus.PENDING);
+
+        return GatheringJoinResponse.from(member);
     }
 
 	public MyGatheringListResponse getMyGatherings(Pageable pageable) {
@@ -164,4 +176,14 @@ public class GatheringService {
 
 		throw new GatheringException(GatheringErrorCode.INVITATION_CODE_GENERATION_FAILED);
 	}
+
+    /**
+     * 공통 메서드
+     * 모임 멤버를 추가합니다.
+     */
+    private GatheringMember saveGatheringMember(Gathering gathering,  User user, GatheringRole role, GatheringMemberStatus status) {
+
+        GatheringMember gatheringMember = GatheringMember.of(gathering, user, role, status);
+        return gatheringMemberRepository.save(gatheringMember);
+    }
 }

--- a/src/main/java/com/dokdok/gathering/service/GatheringValidator.java
+++ b/src/main/java/com/dokdok/gathering/service/GatheringValidator.java
@@ -3,6 +3,7 @@ package com.dokdok.gathering.service;
 import com.dokdok.gathering.entity.Gathering;
 import com.dokdok.gathering.entity.GatheringMember;
 import com.dokdok.gathering.entity.GatheringRole;
+import com.dokdok.gathering.entity.GatheringMemberStatus;
 import com.dokdok.gathering.exception.GatheringErrorCode;
 import com.dokdok.gathering.exception.GatheringException;
 import com.dokdok.gathering.repository.GatheringMemberRepository;
@@ -59,4 +60,27 @@ public class GatheringValidator {
 				.orElseThrow(() -> new GatheringException(GatheringErrorCode.NOT_GATHERING_MEMBER));
 	}
 
+    /**
+     * 초대링크와 일치하는 모임이 있는지 검증합니다.
+     * 추후 초대링크 갱신기능 추가 시 만료 여부도 검증하도록 추가될 수 있습니다.
+     */
+    public Gathering validateInvitationLink(String invitationLink) {
+        return gatheringRepository.findGatheringByInvitationLink(invitationLink)
+                .orElseThrow(() -> new GatheringException(GatheringErrorCode.GATHERING_NOT_FOUND));
+    }
+
+    /**
+     * 이미 모임에 가입했거나 가입 신청을 했는지 검증합니다.
+     */
+	public void validateJoinedGathering(Long gatheringId, Long userId) {
+		gatheringMemberRepository
+				.findByGatheringIdAndUserId(gatheringId, userId)
+				.ifPresent(member -> {
+					if (member.getMemberStatus() == GatheringMemberStatus.ACTIVE) {
+						throw new GatheringException(GatheringErrorCode.ALREADY_GATHERING_MEMBER);
+					} else if (member.getMemberStatus() == GatheringMemberStatus.PENDING) {
+						throw new GatheringException(GatheringErrorCode.JOIN_REQUEST_ALREADY_PENDING);
+					}
+				});
+	}
 }

--- a/src/test/java/com/dokdok/gathering/service/GatheringServiceTest.java
+++ b/src/test/java/com/dokdok/gathering/service/GatheringServiceTest.java
@@ -3,12 +3,14 @@ package com.dokdok.gathering.service;
 import com.dokdok.gathering.dto.request.GatheringCreateRequest;
 import com.dokdok.gathering.dto.response.GatheringCreateResponse;
 import com.dokdok.gathering.dto.response.GatheringDetailResponse;
+import com.dokdok.gathering.dto.response.GatheringJoinResponse;
 import com.dokdok.gathering.dto.response.GatheringSimpleResponse;
 import com.dokdok.gathering.dto.request.GatheringUpdateRequest;
 import com.dokdok.gathering.dto.response.GatheringUpdateResponse;
 import com.dokdok.gathering.dto.response.MyGatheringListResponse;
 import com.dokdok.gathering.entity.Gathering;
 import com.dokdok.gathering.entity.GatheringMember;
+import com.dokdok.gathering.entity.GatheringMemberStatus;
 import com.dokdok.gathering.entity.GatheringStatus;
 import com.dokdok.gathering.exception.GatheringErrorCode;
 import com.dokdok.gathering.exception.GatheringException;
@@ -72,10 +74,13 @@ class GatheringServiceTest {
 
 	private User leader;
 	private User member;
+	private User newUser;
+	private User pendingUser;
 	private Gathering gathering1;
 	private Gathering gathering2;
 	private GatheringMember leaderMember;
 	private GatheringMember normalMember;
+	private GatheringMember pendingMember;
 
 	@BeforeEach
 	void setUp() {
@@ -91,6 +96,18 @@ class GatheringServiceTest {
 				.id(2L)
 				.nickname("멤버닉네임")
 				.profileImageUrl("member.jpg")
+				.build();
+
+		newUser = User.builder()
+				.id(3L)
+				.nickname("신규유저")
+				.profileImageUrl("new.jpg")
+				.build();
+
+		pendingUser = User.builder()
+				.id(4L)
+				.nickname("대기유저")
+				.profileImageUrl("pending.jpg")
 				.build();
 
 		gathering1 = Gathering.builder()
@@ -129,7 +146,18 @@ class GatheringServiceTest {
 				.user(member)
 				.isFavorite(false)
 				.role(MEMBER)
+				.memberStatus(GatheringMemberStatus.ACTIVE)
 				.joinedAt(LocalDateTime.now().minusDays(10))
+				.build();
+
+		pendingMember = GatheringMember.builder()
+				.id(3L)
+				.gathering(gathering1)
+				.user(pendingUser)
+				.isFavorite(false)
+				.role(MEMBER)
+				.memberStatus(GatheringMemberStatus.PENDING)
+				.joinedAt(LocalDateTime.now().minusDays(1))
 				.build();
 	}
 
@@ -709,5 +737,110 @@ class GatheringServiceTest {
 		verify(gatheringValidator, times(1)).validateAndGetGathering(gatheringId);
 		verify(gatheringValidator, times(1)).validateLeader(gatheringId, memberId);
 		verify(gatheringValidator, times(0)).validateAndGetMember(any(), any());
+	}
+
+	@Test
+	@DisplayName("모임 가입 성공 - 신규 사용자가 초대링크로 가입 요청")
+	void joinGathering_Success() {
+		// given
+		String invitationLink = "https://invite.link/abc123";
+
+		securityUtilMock.when(SecurityUtil::getCurrentUserEntity).thenReturn(newUser);
+
+		given(gatheringValidator.validateInvitationLink(invitationLink)).willReturn(gathering1);
+		given(gatheringMemberRepository.save(any(GatheringMember.class))).willAnswer(invocation -> {
+			GatheringMember savedMember = invocation.getArgument(0);
+			return GatheringMember.builder()
+					.id(5L)
+					.gathering(savedMember.getGathering())
+					.user(savedMember.getUser())
+					.role(savedMember.getRole())
+					.memberStatus(savedMember.getMemberStatus())
+					.isFavorite(false)
+					.joinedAt(LocalDateTime.now())
+					.build();
+		});
+
+		// when
+		GatheringJoinResponse response = gatheringService.joinGathering(invitationLink);
+
+		// then
+		assertThat(response).isNotNull();
+		assertThat(response.gatheringId()).isEqualTo(1L);
+		assertThat(response.gatheringName()).isEqualTo("독서 모임");
+		assertThat(response.memberStatus()).isEqualTo(GatheringMemberStatus.PENDING);
+
+		securityUtilMock.verify(SecurityUtil::getCurrentUserEntity, times(1));
+		verify(gatheringValidator, times(1)).validateInvitationLink(invitationLink);
+		verify(gatheringValidator, times(1)).validateJoinedGathering(1L, 3L);
+		verify(gatheringMemberRepository, times(1)).save(any(GatheringMember.class));
+	}
+
+	@Test
+	@DisplayName("모임 가입 실패 - 유효하지 않은 초대링크")
+	void joinGathering_Fail_InvalidInvitationLink() {
+		// given
+		String invalidLink = "https://invite.link/invalid";
+
+		securityUtilMock.when(SecurityUtil::getCurrentUserEntity).thenReturn(newUser);
+
+		doThrow(new GatheringException(GatheringErrorCode.GATHERING_NOT_FOUND))
+				.when(gatheringValidator).validateInvitationLink(invalidLink);
+
+		// when & then
+		assertThatThrownBy(() -> gatheringService.joinGathering(invalidLink))
+				.isInstanceOf(GatheringException.class)
+				.hasMessage(GatheringErrorCode.GATHERING_NOT_FOUND.getMessage());
+
+		securityUtilMock.verify(SecurityUtil::getCurrentUserEntity, times(1));
+		verify(gatheringValidator, times(1)).validateInvitationLink(invalidLink);
+		verify(gatheringValidator, times(0)).validateJoinedGathering(any(), any());
+		verify(gatheringMemberRepository, times(0)).save(any());
+	}
+
+	@Test
+	@DisplayName("모임 가입 실패 - 이미 활성 멤버인 경우")
+	void joinGathering_Fail_AlreadyActiveMember() {
+		// given
+		String invitationLink = "https://invite.link/abc123";
+
+		securityUtilMock.when(SecurityUtil::getCurrentUserEntity).thenReturn(member);
+
+		given(gatheringValidator.validateInvitationLink(invitationLink)).willReturn(gathering1);
+		doThrow(new GatheringException(GatheringErrorCode.ALREADY_GATHERING_MEMBER))
+				.when(gatheringValidator).validateJoinedGathering(1L, 2L);
+
+		// when & then
+		assertThatThrownBy(() -> gatheringService.joinGathering(invitationLink))
+				.isInstanceOf(GatheringException.class)
+				.hasMessage(GatheringErrorCode.ALREADY_GATHERING_MEMBER.getMessage());
+
+		securityUtilMock.verify(SecurityUtil::getCurrentUserEntity, times(1));
+		verify(gatheringValidator, times(1)).validateInvitationLink(invitationLink);
+		verify(gatheringValidator, times(1)).validateJoinedGathering(1L, 2L);
+		verify(gatheringMemberRepository, times(0)).save(any());
+	}
+
+	@Test
+	@DisplayName("모임 가입 실패 - 이미 가입 요청이 진행 중인 경우")
+	void joinGathering_Fail_AlreadyPendingRequest() {
+		// given
+		String invitationLink = "https://invite.link/abc123";
+
+		securityUtilMock.when(SecurityUtil::getCurrentUserEntity).thenReturn(pendingUser);
+
+		given(gatheringValidator.validateInvitationLink(invitationLink)).willReturn(gathering1);
+		doThrow(new GatheringException(GatheringErrorCode.JOIN_REQUEST_ALREADY_PENDING))
+				.when(gatheringValidator).validateJoinedGathering(1L, 4L);
+
+		// when & then
+		assertThatThrownBy(() -> gatheringService.joinGathering(invitationLink))
+				.isInstanceOf(GatheringException.class)
+				.hasMessage(GatheringErrorCode.JOIN_REQUEST_ALREADY_PENDING.getMessage());
+
+		securityUtilMock.verify(SecurityUtil::getCurrentUserEntity, times(1));
+		verify(gatheringValidator, times(1)).validateInvitationLink(invitationLink);
+		verify(gatheringValidator, times(1)).validateJoinedGathering(1L, 4L);
+		verify(gatheringMemberRepository, times(0)).save(any());
 	}
 }


### PR DESCRIPTION
## PR 요약
> 이 PR이 어떤 변경을 하는지 간단히 설명하고, 체크 표시는 괄호 사이에 소문자 'x'를 삽입하세요.

- [x] 기능 추가
- [ ] 버그 수정
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 기타 (설명)

---

## 이슈 번호
- #85

---

## 주요 변경 사항
- `src/main/java/com/dokdok/gathering/entity/GatheringMemberStatus.java`: 가입 상태(PENDING/ACTIVE/REJECTED) enum 추가
- `src/main/java/com/dokdok/gathering/entity/GatheringMember.java`: 멤버 상태 컬럼 추가, 생성 시 상태 설정
- `src/main/java/com/dokdok/gathering/service/GatheringService.java`: 초대 링크 가입 시 PENDING 상태로 저장, 리더는 ACTIVE로 저장
- `src/main/java/com/dokdok/gathering/exception/GatheringErrorCode.java`: 가입 중복/대기 관련 에러 코드 정비
- `src/main/java/com/dokdok/gathering/repository/GatheringRepository.java`: 초대 코드 조회 JPQL(fetch join)으로 변경
- `src/test/java/com/dokdok/gathering/service/GatheringServiceTest.java`: 초대 코드 생성 및 가입 테스트 케이스 추가/보완

---

## 참고 사항
- 테스트: 로컬에서 실행하지 않음 (`./gradlew test` 권장)
- 승인/거절 처리는 추후 단계에서 추가 필요
