### PR TITLE
[#82][FEAT] 책 상세 조회, 목록 조회 기능 구현

### DIFF
--- a/src/main/java/com/dokdok/book/api/BookApi.java
+++ b/src/main/java/com/dokdok/book/api/BookApi.java
@@ -126,6 +126,7 @@ public interface BookApi {
                                               "data": {
                                                 "content": [
                                                   {
+                                                    "bookId": 1,
                                                     "title": "예제 도서명",
                                                     "publisher": "예제 출판사",
                                                     "authors": "저자A, 저자B",
@@ -189,6 +190,7 @@ public interface BookApi {
                                               "code": "SUCCESS",
                                               "message": "책 상세 정보 조회 성공",
                                               "data": {
+                                                "bookId": 1,
                                                 "title": "예제 도서명",
                                                 "publisher": "예제 출판사",
                                                 "authors": "저자A, 저자B",

--- a/src/main/java/com/dokdok/book/api/BookApi.java
+++ b/src/main/java/com/dokdok/book/api/BookApi.java
@@ -129,7 +129,8 @@ public interface BookApi {
                                                     "title": "예제 도서명",
                                                     "publisher": "예제 출판사",
                                                     "authors": "저자A, 저자B",
-                                                    "bookReadingStatus": "READING"
+                                                    "bookReadingStatus": "READING",
+                                                    "thumbnail": "https://example.com/thumb.jpg"
                                                   }
                                                 ],
                                                 "pageable": "INSTANCE",

--- a/src/main/java/com/dokdok/book/api/BookApi.java
+++ b/src/main/java/com/dokdok/book/api/BookApi.java
@@ -3,6 +3,8 @@ package com.dokdok.book.api;
 import com.dokdok.book.dto.request.BookCreateRequest;
 import com.dokdok.book.dto.response.KakaoBookResponse;
 import com.dokdok.book.dto.response.PersonalBookCreateResponse;
+import com.dokdok.book.dto.response.PersonalBookDetailResponse;
+import com.dokdok.book.dto.response.PersonalBookListResponse;
 import com.dokdok.global.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -11,13 +13,14 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "책 관리", description = "책 검색 및 내 책장 관리 API")
 @RequestMapping("/api/book")
@@ -100,4 +103,108 @@ public interface BookApi {
     })
     @PostMapping
     ResponseEntity<ApiResponse<PersonalBookCreateResponse>> createBook(@Valid @RequestBody BookCreateRequest bookCreateRequest);
+
+    @Operation(
+            summary = "내 책장 목록 조회",
+            description = """
+                    내 책장에 등록된 책을 페이징으로 조회합니다.
+                    - 로그인한 사용자 기준으로 조회합니다.
+                    - page/size/sort 파라미터로 페이징과 정렬을 제어할 수 있습니다.
+                    """
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "책 리스트 조회 성공",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = ApiResponse.class),
+                            examples = @io.swagger.v3.oas.annotations.media.ExampleObject(
+                                    value = """
+                                            {
+                                              "code": "SUCCESS",
+                                              "message": "책 리스트 조회 성공",
+                                              "data": {
+                                                "content": [
+                                                  {
+                                                    "title": "예제 도서명",
+                                                    "publisher": "예제 출판사",
+                                                    "authors": "저자A, 저자B",
+                                                    "bookReadingStatus": "READING"
+                                                  }
+                                                ],
+                                                "pageable": "INSTANCE",
+                                                "last": true,
+                                                "totalPages": 1,
+                                                "totalElements": 1,
+                                                "size": 10,
+                                                "number": 0,
+                                                "sort": {
+                                                  "empty": false,
+                                                  "sorted": true,
+                                                  "unsorted": false
+                                                },
+                                                "first": true,
+                                                "numberOfElements": 1,
+                                                "empty": false
+                                              }
+                                            }
+                                            """
+                            ))
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 실패 - 로그인이 필요합니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 오류")
+    })
+    @GetMapping
+    ResponseEntity<ApiResponse<Page<PersonalBookListResponse>>> getMyBooks(
+            @ParameterObject
+            @Parameter(
+                    description = "페이징 정보 (page: 페이지 번호, size: 페이지 크기, sort: 정렬 기준)",
+                    example = "page=0&size=10&sort=book_name,asc"
+            )
+            @PageableDefault(
+                    size = 10,
+                    sort = "added_at",
+                    direction = Sort.Direction.DESC
+            ) Pageable pageable
+    );
+
+    @Operation(
+            summary = "내 책장 단일 조회",
+            description = """
+                    내 책장에 등록된 책 한 권의 상세 정보를 조회합니다.
+                    - 로그인한 사용자 소유의 책만 조회됩니다.
+                    """
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "책 상세 조회 성공",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = ApiResponse.class),
+                            examples = @io.swagger.v3.oas.annotations.media.ExampleObject(
+                                    value = """
+                                            {
+                                              "code": "SUCCESS",
+                                              "message": "책 상세 정보 조회 성공",
+                                              "data": {
+                                                "title": "예제 도서명",
+                                                "publisher": "예제 출판사",
+                                                "authors": "저자A, 저자B",
+                                                "bookReadingStatus": "READING"
+                                              }
+                                            }
+                                            """
+                            ))
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 실패 - 로그인이 필요합니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "책을 찾을 수 없음"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 오류")
+    })
+    @GetMapping("/{bookId}")
+    ResponseEntity<ApiResponse<PersonalBookDetailResponse>> getMyBook(
+            @Parameter(description = "조회할 책 ID", required = true, example = "1")
+            @PathVariable Long bookId
+    );
 }

--- a/src/main/java/com/dokdok/book/controller/BookController.java
+++ b/src/main/java/com/dokdok/book/controller/BookController.java
@@ -38,13 +38,15 @@ public class BookController implements BookApi {
     }
 
     @Override
+    @GetMapping
     public ResponseEntity<ApiResponse<Page<PersonalBookListResponse>>> getMyBooks(Pageable pageable) {
         Page<PersonalBookListResponse> personalBookList = personalBookService.getPersonalBookList(pageable);
         return ApiResponse.success(personalBookList, "책 리스트 조회 성공");
     }
 
     @Override
-    public ResponseEntity<ApiResponse<PersonalBookDetailResponse>> getMyBook(Long bookId) {
+    @GetMapping("/{bookId}")
+    public ResponseEntity<ApiResponse<PersonalBookDetailResponse>> getMyBook(@PathVariable Long bookId) {
         PersonalBookDetailResponse personalBook = personalBookService.getPersonalBook(bookId);
         return ApiResponse.success(personalBook, "책 상세 정보 조회 성공");
     }

--- a/src/main/java/com/dokdok/book/controller/BookController.java
+++ b/src/main/java/com/dokdok/book/controller/BookController.java
@@ -4,11 +4,15 @@ import com.dokdok.book.api.BookApi;
 import com.dokdok.book.dto.request.BookCreateRequest;
 import com.dokdok.book.dto.response.KakaoBookResponse;
 import com.dokdok.book.dto.response.PersonalBookCreateResponse;
+import com.dokdok.book.dto.response.PersonalBookDetailResponse;
+import com.dokdok.book.dto.response.PersonalBookListResponse;
 import com.dokdok.book.service.BookService;
 import com.dokdok.book.service.PersonalBookService;
 import com.dokdok.global.response.ApiResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -31,5 +35,17 @@ public class BookController implements BookApi {
     public ResponseEntity<ApiResponse<PersonalBookCreateResponse>> createBook(@Valid @RequestBody BookCreateRequest bookCreateRequest) {
         PersonalBookCreateResponse book = personalBookService.createBook(bookCreateRequest);
         return ApiResponse.created(book, "내 책장에 책 등록 성공");
+    }
+
+    @Override
+    public ResponseEntity<ApiResponse<Page<PersonalBookListResponse>>> getMyBooks(Pageable pageable) {
+        Page<PersonalBookListResponse> personalBookList = personalBookService.getPersonalBookList(pageable);
+        return ApiResponse.success(personalBookList, "책 리스트 조회 성공");
+    }
+
+    @Override
+    public ResponseEntity<ApiResponse<PersonalBookDetailResponse>> getMyBook(Long bookId) {
+        PersonalBookDetailResponse personalBook = personalBookService.getPersonalBook(bookId);
+        return ApiResponse.success(personalBook, "책 상세 정보 조회 성공");
     }
 }

--- a/src/main/java/com/dokdok/book/dto/response/PersonalBookDetailResponse.java
+++ b/src/main/java/com/dokdok/book/dto/response/PersonalBookDetailResponse.java
@@ -1,0 +1,23 @@
+package com.dokdok.book.dto.response;
+
+import com.dokdok.book.entity.BookReadingStatus;
+import com.dokdok.book.entity.PersonalBook;
+import lombok.Builder;
+
+
+@Builder
+public record PersonalBookDetailResponse(
+        String title,
+        String publisher,
+        String authors,
+        BookReadingStatus bookReadingStatus
+) {
+    public static PersonalBookDetailResponse from(PersonalBook entity) {
+        return PersonalBookDetailResponse.builder()
+                .title(entity.getBook().getBookName())
+                .publisher(entity.getBook().getPublisher())
+                .authors(entity.getBook().getAuthor())
+                .bookReadingStatus(entity.getReadingStatus())
+                .build();
+    }
+}

--- a/src/main/java/com/dokdok/book/dto/response/PersonalBookDetailResponse.java
+++ b/src/main/java/com/dokdok/book/dto/response/PersonalBookDetailResponse.java
@@ -7,6 +7,7 @@ import lombok.Builder;
 
 @Builder
 public record PersonalBookDetailResponse(
+        Long bookId,
         String title,
         String publisher,
         String authors,
@@ -14,6 +15,7 @@ public record PersonalBookDetailResponse(
 ) {
     public static PersonalBookDetailResponse from(PersonalBook entity) {
         return PersonalBookDetailResponse.builder()
+                .bookId(entity.getId())
                 .title(entity.getBook().getBookName())
                 .publisher(entity.getBook().getPublisher())
                 .authors(entity.getBook().getAuthor())

--- a/src/main/java/com/dokdok/book/dto/response/PersonalBookListResponse.java
+++ b/src/main/java/com/dokdok/book/dto/response/PersonalBookListResponse.java
@@ -9,14 +9,17 @@ public record PersonalBookListResponse(
         String title,
         String publisher,
         String authors,
-        BookReadingStatus bookReadingStatus
+        BookReadingStatus bookReadingStatus,
+        String thumbnail
 ) {
     public static PersonalBookListResponse from(PersonalBook entity) {
+        // TODO: 참여한 약속(모임) 수 계산 후 응답에 포함한다.
         return PersonalBookListResponse.builder()
                 .title(entity.getBook().getBookName())
                 .publisher(entity.getBook().getPublisher())
                 .authors(entity.getBook().getAuthor())
                 .bookReadingStatus(entity.getReadingStatus())
+                .thumbnail(entity.getBook().getThumbnail())
                 .build();
     }
 }

--- a/src/main/java/com/dokdok/book/dto/response/PersonalBookListResponse.java
+++ b/src/main/java/com/dokdok/book/dto/response/PersonalBookListResponse.java
@@ -1,0 +1,22 @@
+package com.dokdok.book.dto.response;
+
+import com.dokdok.book.entity.BookReadingStatus;
+import com.dokdok.book.entity.PersonalBook;
+import lombok.Builder;
+
+@Builder
+public record PersonalBookListResponse(
+        String title,
+        String publisher,
+        String authors,
+        BookReadingStatus bookReadingStatus
+) {
+    public static PersonalBookListResponse from(PersonalBook entity) {
+        return PersonalBookListResponse.builder()
+                .title(entity.getBook().getBookName())
+                .publisher(entity.getBook().getPublisher())
+                .authors(entity.getBook().getAuthor())
+                .bookReadingStatus(entity.getReadingStatus())
+                .build();
+    }
+}

--- a/src/main/java/com/dokdok/book/dto/response/PersonalBookListResponse.java
+++ b/src/main/java/com/dokdok/book/dto/response/PersonalBookListResponse.java
@@ -6,6 +6,7 @@ import lombok.Builder;
 
 @Builder
 public record PersonalBookListResponse(
+        Long bookId,
         String title,
         String publisher,
         String authors,
@@ -15,6 +16,7 @@ public record PersonalBookListResponse(
     public static PersonalBookListResponse from(PersonalBook entity) {
         // TODO: 참여한 약속(모임) 수 계산 후 응답에 포함한다.
         return PersonalBookListResponse.builder()
+                .bookId(entity.getId())
                 .title(entity.getBook().getBookName())
                 .publisher(entity.getBook().getPublisher())
                 .authors(entity.getBook().getAuthor())

--- a/src/main/java/com/dokdok/book/exception/BookErrorCode.java
+++ b/src/main/java/com/dokdok/book/exception/BookErrorCode.java
@@ -10,7 +10,8 @@ import org.springframework.http.HttpStatus;
 public enum BookErrorCode implements BaseErrorCode {
 
     BOOK_NOT_FOUND("B001", "책을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
-    BOOK_ALREADY_EXISTS("B002", "이미 등록된 책입니다.", HttpStatus.CONFLICT);
+    BOOK_ALREADY_EXISTS("B002", "이미 등록된 책입니다.", HttpStatus.CONFLICT),
+    BOOK_NOT_IN_SHELF("B003", "책장에 해당 책이 존재하지 않습니다.", HttpStatus.NOT_FOUND);
 
     private final String code;
     private final String message;

--- a/src/main/java/com/dokdok/book/repository/PersonalBookRepository.java
+++ b/src/main/java/com/dokdok/book/repository/PersonalBookRepository.java
@@ -1,6 +1,8 @@
 package com.dokdok.book.repository;
 
 import com.dokdok.book.entity.PersonalBook;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -9,4 +11,5 @@ import java.util.Optional;
 @Repository
 public interface PersonalBookRepository extends JpaRepository<PersonalBook, Long> {
     Optional<PersonalBook> findByUserIdAndBookId(Long userId, Long bookId);
+    Page<PersonalBook> findByUserId(Long userId, Pageable pageable);
 }

--- a/src/main/java/com/dokdok/book/service/PersonalBookService.java
+++ b/src/main/java/com/dokdok/book/service/PersonalBookService.java
@@ -2,6 +2,8 @@ package com.dokdok.book.service;
 
 import com.dokdok.book.dto.request.BookCreateRequest;
 import com.dokdok.book.dto.response.PersonalBookCreateResponse;
+import com.dokdok.book.dto.response.PersonalBookDetailResponse;
+import com.dokdok.book.dto.response.PersonalBookListResponse;
 import com.dokdok.book.entity.Book;
 import com.dokdok.book.entity.BookReadingStatus;
 import com.dokdok.book.entity.PersonalBook;
@@ -15,6 +17,8 @@ import com.dokdok.user.exception.UserErrorCode;
 import com.dokdok.user.exception.UserException;
 import com.dokdok.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -31,8 +35,7 @@ public class PersonalBookService {
     @Transactional
     public PersonalBookCreateResponse createBook(BookCreateRequest bookCreateRequest) {
         // 사용자 유효성 검증
-        User userEntity = userRepository.findById(SecurityUtil.getCurrentUserId())
-                .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
+        User userEntity = getCurrentUser();
 
         // 책 유효성 검증 && 없으면 book entity에 저장
         Book entity = bookRepository.findByIsbn(bookCreateRequest.isbn())
@@ -46,11 +49,38 @@ public class PersonalBookService {
         return PersonalBookCreateResponse.from(personalBookEntity);
     }
 
+    // List
+    public Page<PersonalBookListResponse> getPersonalBookList(Pageable pageable) {
+        User userEntity = getCurrentUser();
+        Page<PersonalBook> page= personalBookRepository.findByUserId(userEntity.getId(), pageable);
+
+
+        if (page.isEmpty()) {
+            throw new BookException(BookErrorCode.BOOK_NOT_IN_SHELF);
+        }
+
+        return page.map(PersonalBookListResponse::from);
+    }
+
+    public PersonalBookDetailResponse getPersonalBook(Long bookId) {
+        User userEntity = getCurrentUser();
+        // 책 정보 GET Logic
+        PersonalBook entity = personalBookRepository.findByUserIdAndBookId(userEntity.getId(), bookId)
+                .orElseThrow(() -> new BookException(BookErrorCode.BOOK_NOT_IN_SHELF));
+
+        return PersonalBookDetailResponse.from(entity);
+    }
+
     private void validateDuplicatePersonalBook(Long userId, Long bookId) {
        personalBookRepository.findByUserIdAndBookId(userId, bookId)
                .ifPresent(personalBook ->
                {
                    throw new BookException(BookErrorCode.BOOK_ALREADY_EXISTS);
                });
+   }
+
+   private User getCurrentUser() {
+        return userRepository.findById(SecurityUtil.getCurrentUserId())
+               .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
    }
 }

--- a/src/main/java/com/dokdok/book/service/PersonalBookService.java
+++ b/src/main/java/com/dokdok/book/service/PersonalBookService.java
@@ -13,9 +13,7 @@ import com.dokdok.book.repository.BookRepository;
 import com.dokdok.book.repository.PersonalBookRepository;
 import com.dokdok.global.util.SecurityUtil;
 import com.dokdok.user.entity.User;
-import com.dokdok.user.exception.UserErrorCode;
-import com.dokdok.user.exception.UserException;
-import com.dokdok.user.repository.UserRepository;
+import com.dokdok.user.service.UserValidator;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -29,14 +27,13 @@ public class PersonalBookService {
 
     private final PersonalBookRepository personalBookRepository;
     private final BookRepository bookRepository;
-    private final UserRepository userRepository;
+    private final UserValidator userValidator;
 
     // 생성
     @Transactional
     public PersonalBookCreateResponse createBook(BookCreateRequest bookCreateRequest) {
         // 사용자 유효성 검증
-        User userEntity = getCurrentUser();
-
+        User userEntity = userValidator.findUserOrThrow(SecurityUtil.getCurrentUserId());
         // 책 유효성 검증 && 없으면 book entity에 저장
         Book entity = bookRepository.findByIsbn(bookCreateRequest.isbn())
                 .orElseGet(() -> bookRepository.save(bookCreateRequest.of()));
@@ -51,7 +48,7 @@ public class PersonalBookService {
 
     // List
     public Page<PersonalBookListResponse> getPersonalBookList(Pageable pageable) {
-        User userEntity = getCurrentUser();
+        User userEntity = userValidator.findUserOrThrow(SecurityUtil.getCurrentUserId());
         Page<PersonalBook> page= personalBookRepository.findByUserId(userEntity.getId(), pageable);
 
 
@@ -63,7 +60,7 @@ public class PersonalBookService {
     }
 
     public PersonalBookDetailResponse getPersonalBook(Long bookId) {
-        User userEntity = getCurrentUser();
+        User userEntity = userValidator.findUserOrThrow(SecurityUtil.getCurrentUserId());
         // 책 정보 GET Logic
         PersonalBook entity = personalBookRepository.findByUserIdAndBookId(userEntity.getId(), bookId)
                 .orElseThrow(() -> new BookException(BookErrorCode.BOOK_NOT_IN_SHELF));
@@ -77,10 +74,5 @@ public class PersonalBookService {
                {
                    throw new BookException(BookErrorCode.BOOK_ALREADY_EXISTS);
                });
-   }
-
-   private User getCurrentUser() {
-        return userRepository.findById(SecurityUtil.getCurrentUserId())
-               .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
    }
 }

--- a/src/test/java/com/dokdok/book/service/PersonalBookServiceTest.java
+++ b/src/test/java/com/dokdok/book/service/PersonalBookServiceTest.java
@@ -2,6 +2,8 @@ package com.dokdok.book.service;
 
 import com.dokdok.book.dto.request.BookCreateRequest;
 import com.dokdok.book.dto.response.PersonalBookCreateResponse;
+import com.dokdok.book.dto.response.PersonalBookDetailResponse;
+import com.dokdok.book.dto.response.PersonalBookListResponse;
 import com.dokdok.book.entity.Book;
 import com.dokdok.book.entity.BookReadingStatus;
 import com.dokdok.book.entity.PersonalBook;
@@ -24,7 +26,12 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -238,5 +245,155 @@ class PersonalBookServiceTest {
         verify(bookRepository, times(1)).findByIsbn(request.isbn());
         verify(personalBookRepository, times(1)).findByUserIdAndBookId(userId, bookId);
         verify(personalBookRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("내 책장 목록 조회 시 PersonalBookListResponse로 매핑")
+    void getPersonalBookList_Success() {
+        // given
+        Long userId = 1L;
+        Pageable pageable = PageRequest.of(0, 10);
+
+        User user = User.builder()
+                .id(userId)
+                .kakaoId(12345L)
+                .nickname("tester")
+                .build();
+
+        Book book = Book.builder()
+                .id(10L)
+                .bookName("테스트 책")
+                .publisher("테스트 출판사")
+                .author("테스트 저자")
+                .build();
+
+        PersonalBook personalBook = PersonalBook.builder()
+                .id(100L)
+                .user(user)
+                .book(book)
+                .readingStatus(BookReadingStatus.READING)
+                .build();
+
+        Page<PersonalBook> page = new PageImpl<>(List.of(personalBook), pageable, 1);
+
+        securityUtilMock.when(SecurityUtil::getCurrentUserId).thenReturn(userId);
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        when(personalBookRepository.findByUserId(userId, pageable)).thenReturn(page);
+
+        // when
+        Page<PersonalBookListResponse> responses = personalBookService.getPersonalBookList(pageable);
+
+        // then
+        assertThat(responses.getContent()).hasSize(1);
+        PersonalBookListResponse response = responses.getContent().getFirst();
+        assertThat(response.title()).isEqualTo(book.getBookName());
+        assertThat(response.publisher()).isEqualTo(book.getPublisher());
+        assertThat(response.authors()).isEqualTo(book.getAuthor());
+        assertThat(response.bookReadingStatus()).isEqualTo(BookReadingStatus.READING);
+
+        securityUtilMock.verify(SecurityUtil::getCurrentUserId, times(1));
+        verify(userRepository, times(1)).findById(userId);
+        verify(personalBookRepository, times(1)).findByUserId(userId, pageable);
+    }
+
+    @Test
+    @DisplayName("내 책장 목록이 비어있으면 BookException 발생")
+    void getPersonalBookList_Empty() {
+        // given
+        Long userId = 1L;
+        Pageable pageable = PageRequest.of(0, 10);
+
+        User user = User.builder()
+                .id(userId)
+                .kakaoId(12345L)
+                .nickname("tester")
+                .build();
+
+        Page<PersonalBook> emptyPage = new PageImpl<>(List.of(), pageable, 0);
+
+        securityUtilMock.when(SecurityUtil::getCurrentUserId).thenReturn(userId);
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        when(personalBookRepository.findByUserId(userId, pageable)).thenReturn(emptyPage);
+
+        // when & then
+        assertThatThrownBy(() -> personalBookService.getPersonalBookList(pageable))
+                .isInstanceOf(BookException.class)
+                .hasFieldOrPropertyWithValue("errorCode", BookErrorCode.BOOK_NOT_IN_SHELF);
+
+        securityUtilMock.verify(SecurityUtil::getCurrentUserId, times(1));
+        verify(userRepository, times(1)).findById(userId);
+        verify(personalBookRepository, times(1)).findByUserId(userId, pageable);
+    }
+
+    @Test
+    @DisplayName("내 책장 단일 조회 시 PersonalBookDetailResponse로 매핑")
+    void getPersonalBookDetail_Success() {
+        // given
+        Long userId = 1L;
+        Long bookId = 10L;
+
+        User user = User.builder()
+                .id(userId)
+                .kakaoId(12345L)
+                .nickname("tester")
+                .build();
+
+        Book book = Book.builder()
+                .id(bookId)
+                .bookName("테스트 책")
+                .publisher("테스트 출판사")
+                .author("테스트 저자")
+                .build();
+
+        PersonalBook personalBook = PersonalBook.builder()
+                .id(100L)
+                .user(user)
+                .book(book)
+                .readingStatus(BookReadingStatus.COMPLETED)
+                .build();
+
+        securityUtilMock.when(SecurityUtil::getCurrentUserId).thenReturn(userId);
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        when(personalBookRepository.findByUserIdAndBookId(userId, bookId)).thenReturn(Optional.of(personalBook));
+
+        // when
+        PersonalBookDetailResponse response = personalBookService.getPersonalBook(bookId);
+
+        // then
+        assertThat(response.title()).isEqualTo(book.getBookName());
+        assertThat(response.publisher()).isEqualTo(book.getPublisher());
+        assertThat(response.authors()).isEqualTo(book.getAuthor());
+        assertThat(response.bookReadingStatus()).isEqualTo(BookReadingStatus.COMPLETED);
+
+        securityUtilMock.verify(SecurityUtil::getCurrentUserId, times(1));
+        verify(userRepository, times(1)).findById(userId);
+        verify(personalBookRepository, times(1)).findByUserIdAndBookId(userId, bookId);
+    }
+
+    @Test
+    @DisplayName("내 책장 단일 조회 시 책이 없으면 BookException 발생")
+    void getPersonalBookDetail_NotFound() {
+        // given
+        Long userId = 1L;
+        Long bookId = 10L;
+
+        User user = User.builder()
+                .id(userId)
+                .kakaoId(12345L)
+                .nickname("tester")
+                .build();
+
+        securityUtilMock.when(SecurityUtil::getCurrentUserId).thenReturn(userId);
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        when(personalBookRepository.findByUserIdAndBookId(userId, bookId)).thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> personalBookService.getPersonalBook(bookId))
+                .isInstanceOf(BookException.class)
+                .hasFieldOrPropertyWithValue("errorCode", BookErrorCode.BOOK_NOT_IN_SHELF);
+
+        securityUtilMock.verify(SecurityUtil::getCurrentUserId, times(1));
+        verify(userRepository, times(1)).findById(userId);
+        verify(personalBookRepository, times(1)).findByUserIdAndBookId(userId, bookId);
     }
 }

--- a/src/test/java/com/dokdok/book/service/PersonalBookServiceTest.java
+++ b/src/test/java/com/dokdok/book/service/PersonalBookServiceTest.java
@@ -15,7 +15,7 @@ import com.dokdok.global.util.SecurityUtil;
 import com.dokdok.user.entity.User;
 import com.dokdok.user.exception.UserErrorCode;
 import com.dokdok.user.exception.UserException;
-import com.dokdok.user.repository.UserRepository;
+import com.dokdok.user.service.UserValidator;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -54,7 +54,7 @@ class PersonalBookServiceTest {
     private BookRepository bookRepository;
 
     @Mock
-    private UserRepository userRepository;
+    private UserValidator userValidator;
 
     private MockedStatic<SecurityUtil> securityUtilMock;
 
@@ -96,7 +96,7 @@ class PersonalBookServiceTest {
                 .build();
 
         securityUtilMock.when(SecurityUtil::getCurrentUserId).thenReturn(userId);
-        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        when(userValidator.findUserOrThrow(userId)).thenReturn(user);
         when(bookRepository.findByIsbn(request.isbn())).thenReturn(Optional.of(book));
         when(personalBookRepository.findByUserIdAndBookId(userId, book.getId())).thenReturn(Optional.empty());
 
@@ -120,7 +120,7 @@ class PersonalBookServiceTest {
         assertThat(response.addedAt()).isEqualTo(savedPersonalBook.getAddedAt());
 
         securityUtilMock.verify(SecurityUtil::getCurrentUserId, times(1));
-        verify(userRepository, times(1)).findById(userId);
+        verify(userValidator, times(1)).findUserOrThrow(userId);
         verify(bookRepository, times(1)).findByIsbn(request.isbn());
         verify(bookRepository, never()).save(any(Book.class));
         verify(personalBookRepository, times(1)).findByUserIdAndBookId(userId, book.getId());
@@ -136,7 +136,7 @@ class PersonalBookServiceTest {
                 .build();
 
         securityUtilMock.when(SecurityUtil::getCurrentUserId).thenReturn(userId);
-        when(userRepository.findById(userId)).thenReturn(Optional.empty());
+        when(userValidator.findUserOrThrow(userId)).thenThrow(new UserException(UserErrorCode.USER_NOT_FOUND));
 
         // when & then
         assertThatThrownBy(() -> personalBookService.createBook(request))
@@ -144,7 +144,7 @@ class PersonalBookServiceTest {
                 .hasFieldOrPropertyWithValue("errorCode", UserErrorCode.USER_NOT_FOUND);
 
         securityUtilMock.verify(SecurityUtil::getCurrentUserId, times(1));
-        verify(userRepository, times(1)).findById(userId);
+        verify(userValidator, times(1)).findUserOrThrow(userId);
         verify(bookRepository, never()).findByIsbn(anyString());
         verify(personalBookRepository, never()).save(any());
     }
@@ -178,7 +178,7 @@ class PersonalBookServiceTest {
                 .build();
 
         securityUtilMock.when(SecurityUtil::getCurrentUserId).thenReturn(userId);
-        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        when(userValidator.findUserOrThrow(userId)).thenReturn(user);
         when(bookRepository.findByIsbn(request.isbn())).thenReturn(Optional.empty());
         when(bookRepository.save(any(Book.class))).thenReturn(savedBook);
         when(personalBookRepository.findByUserIdAndBookId(userId, savedBook.getId())).thenReturn(Optional.empty());
@@ -193,7 +193,7 @@ class PersonalBookServiceTest {
         assertThat(response.addedAt()).isNotNull();
 
         securityUtilMock.verify(SecurityUtil::getCurrentUserId, times(1));
-        verify(userRepository, times(1)).findById(userId);
+        verify(userValidator, times(1)).findUserOrThrow(userId);
         verify(bookRepository, times(1)).findByIsbn(request.isbn());
         verify(bookRepository, times(1)).save(any(Book.class));
         verify(personalBookRepository, times(1)).findByUserIdAndBookId(userId, savedBook.getId());
@@ -231,7 +231,7 @@ class PersonalBookServiceTest {
         PersonalBook existing = PersonalBook.create(user, book, BookReadingStatus.READING);
 
         securityUtilMock.when(SecurityUtil::getCurrentUserId).thenReturn(userId);
-        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        when(userValidator.findUserOrThrow(userId)).thenReturn(user);
         when(bookRepository.findByIsbn(request.isbn())).thenReturn(Optional.of(book));
         when(personalBookRepository.findByUserIdAndBookId(userId, bookId)).thenReturn(Optional.of(existing));
 
@@ -241,7 +241,7 @@ class PersonalBookServiceTest {
                 .hasFieldOrPropertyWithValue("errorCode", BookErrorCode.BOOK_ALREADY_EXISTS);
 
         securityUtilMock.verify(SecurityUtil::getCurrentUserId, times(1));
-        verify(userRepository, times(1)).findById(userId);
+        verify(userValidator, times(1)).findUserOrThrow(userId);
         verify(bookRepository, times(1)).findByIsbn(request.isbn());
         verify(personalBookRepository, times(1)).findByUserIdAndBookId(userId, bookId);
         verify(personalBookRepository, never()).save(any());
@@ -277,7 +277,7 @@ class PersonalBookServiceTest {
         Page<PersonalBook> page = new PageImpl<>(List.of(personalBook), pageable, 1);
 
         securityUtilMock.when(SecurityUtil::getCurrentUserId).thenReturn(userId);
-        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        when(userValidator.findUserOrThrow(userId)).thenReturn(user);
         when(personalBookRepository.findByUserId(userId, pageable)).thenReturn(page);
 
         // when
@@ -292,7 +292,7 @@ class PersonalBookServiceTest {
         assertThat(response.bookReadingStatus()).isEqualTo(BookReadingStatus.READING);
 
         securityUtilMock.verify(SecurityUtil::getCurrentUserId, times(1));
-        verify(userRepository, times(1)).findById(userId);
+        verify(userValidator, times(1)).findUserOrThrow(userId);
         verify(personalBookRepository, times(1)).findByUserId(userId, pageable);
     }
 
@@ -312,7 +312,7 @@ class PersonalBookServiceTest {
         Page<PersonalBook> emptyPage = new PageImpl<>(List.of(), pageable, 0);
 
         securityUtilMock.when(SecurityUtil::getCurrentUserId).thenReturn(userId);
-        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        when(userValidator.findUserOrThrow(userId)).thenReturn(user);
         when(personalBookRepository.findByUserId(userId, pageable)).thenReturn(emptyPage);
 
         // when & then
@@ -321,7 +321,7 @@ class PersonalBookServiceTest {
                 .hasFieldOrPropertyWithValue("errorCode", BookErrorCode.BOOK_NOT_IN_SHELF);
 
         securityUtilMock.verify(SecurityUtil::getCurrentUserId, times(1));
-        verify(userRepository, times(1)).findById(userId);
+        verify(userValidator, times(1)).findUserOrThrow(userId);
         verify(personalBookRepository, times(1)).findByUserId(userId, pageable);
     }
 
@@ -353,7 +353,7 @@ class PersonalBookServiceTest {
                 .build();
 
         securityUtilMock.when(SecurityUtil::getCurrentUserId).thenReturn(userId);
-        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        when(userValidator.findUserOrThrow(userId)).thenReturn(user);
         when(personalBookRepository.findByUserIdAndBookId(userId, bookId)).thenReturn(Optional.of(personalBook));
 
         // when
@@ -366,7 +366,7 @@ class PersonalBookServiceTest {
         assertThat(response.bookReadingStatus()).isEqualTo(BookReadingStatus.COMPLETED);
 
         securityUtilMock.verify(SecurityUtil::getCurrentUserId, times(1));
-        verify(userRepository, times(1)).findById(userId);
+        verify(userValidator, times(1)).findUserOrThrow(userId);
         verify(personalBookRepository, times(1)).findByUserIdAndBookId(userId, bookId);
     }
 
@@ -384,7 +384,7 @@ class PersonalBookServiceTest {
                 .build();
 
         securityUtilMock.when(SecurityUtil::getCurrentUserId).thenReturn(userId);
-        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        when(userValidator.findUserOrThrow(userId)).thenReturn(user);
         when(personalBookRepository.findByUserIdAndBookId(userId, bookId)).thenReturn(Optional.empty());
 
         // when & then
@@ -393,7 +393,7 @@ class PersonalBookServiceTest {
                 .hasFieldOrPropertyWithValue("errorCode", BookErrorCode.BOOK_NOT_IN_SHELF);
 
         securityUtilMock.verify(SecurityUtil::getCurrentUserId, times(1));
-        verify(userRepository, times(1)).findById(userId);
+        verify(userValidator, times(1)).findUserOrThrow(userId);
         verify(personalBookRepository, times(1)).findByUserIdAndBookId(userId, bookId);
     }
 }


### PR DESCRIPTION
 ## PR 요약

  > 이 PR이 어떤 변경을 하는지 간단히 설명하고, 체크 표시는 괄호 사이에 소문자 'x'를 삽입하세요.                                                                                                                                                                                                                            

  - [x] 기능 추가
  - [ ] 버그 수정
  - [ ] 코드 리팩토링
  - [ ] 문서 수정
  - [ ] 기타 (설명)

  ———

  ## 이슈 번호

  - #82 

  ———

  ## 주요 변경 사항

  > 주요 파일, 로직, 컴포넌트 등을 구체적으로 적어주세요.                                                                                                                                                                                                                                                                   

  - src/main/java/com/dokdok/book/api/BookApi.java: 내 책장 목록/단일 조회 API 스펙 및 Swagger 예시 추가
  - src/main/java/com/dokdok/book/service/PersonalBookService.java: 사용자 기준 목록·상세 조회 로직 구현 및 빈 책장/미존재 도서 시 BOOK_NOT_IN_SHELF 예외 처리
  - src/main/java/com/dokdok/book/dto/response/PersonalBookListResponse.java / PersonalBookDetailResponse.java: 책장 목록·상세 응답 DTO 신규 추가
  - src/main/java/com/dokdok/book/repository/PersonalBookRepository.java: 사용자별 책장 조회용 메서드 추가
  - src/main/java/com/dokdok/book/exception/BookErrorCode.java: 책장에 도서가 없을 때 사용할 에러 코드(B003) 추가
  - src/test/java/com/dokdok/book/service/PersonalBookServiceTest.java: 등록/중복/조회/예외 흐름을 검증하는 단위 테스트 추가

  ———

  ## 참고 사항

  > 리뷰어가 알아야 할 추가 정보, 테스트 방법 등을 작성해주세요.                                                                                                                                                                                                                                                            

  - 내 책장 목록이 비어 있으면 빈 페이지 대신 BOOK_NOT_IN_SHELF(B003) 예외를 반환하도록 설계

