### PR TITLE
[#99][FEAT] 모임 가입 페이지 정보 요청 API

### DIFF
--- a/src/main/java/com/dokdok/gathering/api/GatheringApi.java
+++ b/src/main/java/com/dokdok/gathering/api/GatheringApi.java
@@ -100,7 +100,7 @@ public interface GatheringApi {
                     description = "서버 오류"
             )
     })
-    @GetMapping("/join/{invitationLink}")
+    @GetMapping("/join-request/{invitationLink}")
     ResponseEntity<ApiResponse<GatheringCreateResponse>> joinGatheringInfo(
             @Parameter(
                     description = "모임 초대링크",
@@ -148,7 +148,7 @@ public interface GatheringApi {
                     description = "서버 오류"
             )
     })
-    @PostMapping("/join/{invitationLink}")
+    @PostMapping("/join-request/{invitationLink}")
     ResponseEntity<ApiResponse<GatheringJoinResponse>> joinGathering(
             @Parameter(
                     description = "모임 초대링크",

--- a/src/main/java/com/dokdok/gathering/api/GatheringApi.java
+++ b/src/main/java/com/dokdok/gathering/api/GatheringApi.java
@@ -27,6 +27,8 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import com.dokdok.gathering.dto.response.GatheringJoinResponse;
 
 @Tag(name = "모임", description = "모임 관련 API")
 @RequestMapping("/api/gatherings")
@@ -66,6 +68,94 @@ public interface GatheringApi {
     ResponseEntity<ApiResponse<GatheringCreateResponse>> createGathering(
             @Parameter(description = "모임 생성 요청", required = true)
             @Valid @RequestBody GatheringCreateRequest request
+    );
+
+    @Operation(
+            summary = "초대링크로 모임 정보 조회",
+            description = """
+              초대링크를 통해 모임의 기본 정보를 조회합니다.
+              - 모임 가입 전 모임 정보를 미리 확인할 수 있습니다.
+              - 로그인 없이도 조회 가능합니다.
+              """
+    )
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "조회 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = GatheringCreateResponse.class)
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "400",
+                    description = "잘못된 요청 - 초대링크가 비어있음"
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "모임을 찾을 수 없음 - 유효하지 않은 초대링크"
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "500",
+                    description = "서버 오류"
+            )
+    })
+    @GetMapping("/join/{invitationLink}")
+    ResponseEntity<ApiResponse<GatheringCreateResponse>> joinGatheringInfo(
+            @Parameter(
+                    description = "모임 초대링크",
+                    required = true,
+                    example = "ABC123XYZ"
+            )
+            @PathVariable @NotBlank(message = "초대링크는 필수입니다") String invitationLink
+    );
+
+    @Operation(
+            summary = "모임 가입 요청",
+            description = """
+              초대링크를 통해 모임에 가입을 요청합니다.
+              - 가입 요청 후 모임장의 승인을 기다려야 합니다.
+              - 이미 가입된 모임이거나 가입 요청 중인 경우 실패합니다.
+              """
+    )
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "가입 요청 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = GatheringJoinResponse.class)
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "400",
+                    description = "잘못된 요청 - 초대링크가 비어있음"
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "401",
+                    description = "인증 실패 - 로그인이 필요합니다."
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "모임을 찾을 수 없음 - 유효하지 않은 초대링크"
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "409",
+                    description = "이미 가입된 모임이거나 가입 요청 중"
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "500",
+                    description = "서버 오류"
+            )
+    })
+    @PostMapping("/join/{invitationLink}")
+    ResponseEntity<ApiResponse<GatheringJoinResponse>> joinGathering(
+            @Parameter(
+                    description = "모임 초대링크",
+                    required = true,
+                    example = "ABC123XYZ"
+            )
+            @PathVariable @NotBlank(message = "초대링크는 필수입니다") String invitationLink
     );
 
     @Operation(

--- a/src/main/java/com/dokdok/gathering/controller/GatheringController.java
+++ b/src/main/java/com/dokdok/gathering/controller/GatheringController.java
@@ -32,7 +32,7 @@ public class GatheringController implements GatheringApi {
     }
 
     @Override
-    @GetMapping("/join/{invitationLink}")
+    @GetMapping("/join-request/{invitationLink}")
     public ResponseEntity<ApiResponse<GatheringCreateResponse>> joinGatheringInfo(
             @PathVariable("invitationLink") @NotBlank(message = "초대링크는 필수입니다") String invitationLink
     ) {
@@ -41,7 +41,7 @@ public class GatheringController implements GatheringApi {
     }
 
     @Override
-    @PostMapping("/join/{invitationLink}")
+    @PostMapping("/join-request/{invitationLink}")
     public ResponseEntity<ApiResponse<GatheringJoinResponse>> joinGathering(
             @PathVariable("invitationLink") @NotBlank(message = "초대링크는 필수입니다") String invitationLink
     ) {

--- a/src/main/java/com/dokdok/gathering/controller/GatheringController.java
+++ b/src/main/java/com/dokdok/gathering/controller/GatheringController.java
@@ -7,14 +7,17 @@ import com.dokdok.gathering.dto.request.GatheringUpdateRequest;
 import com.dokdok.gathering.service.GatheringService;
 import com.dokdok.global.response.ApiResponse;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/gatherings")
 @RequiredArgsConstructor
+@Validated
 public class GatheringController implements GatheringApi {
 
     private final GatheringService gatheringService;
@@ -28,9 +31,20 @@ public class GatheringController implements GatheringApi {
         return ApiResponse.created(response, "모임 생성에 성공하였습니다.");
     }
 
-    @PostMapping("/join/{invitationLink}")
-    public ResponseEntity<ApiResponse<GatheringJoinResponse>> joinGathering(@PathVariable("invitationLink")  String invitationLink) {
+    @Override
+    @GetMapping("/join/{invitationLink}")
+    public ResponseEntity<ApiResponse<GatheringCreateResponse>> joinGatheringInfo(
+            @PathVariable("invitationLink") @NotBlank(message = "초대링크는 필수입니다") String invitationLink
+    ) {
+        GatheringCreateResponse response = gatheringService.getJoinGatheringInfo(invitationLink);
+        return ApiResponse.success(response);
+    }
 
+    @Override
+    @PostMapping("/join/{invitationLink}")
+    public ResponseEntity<ApiResponse<GatheringJoinResponse>> joinGathering(
+            @PathVariable("invitationLink") @NotBlank(message = "초대링크는 필수입니다") String invitationLink
+    ) {
         GatheringJoinResponse response = gatheringService.joinGathering(invitationLink);
         return ApiResponse.success(response);
     }

--- a/src/main/java/com/dokdok/gathering/exception/GatheringErrorCode.java
+++ b/src/main/java/com/dokdok/gathering/exception/GatheringErrorCode.java
@@ -17,7 +17,8 @@ public enum GatheringErrorCode implements BaseErrorCode {
     ALREADY_REMOVED_MEMBER("G006", "이미 제거된 멤버입니다.", HttpStatus.CONFLICT),
     INVITATION_CODE_GENERATION_FAILED("G007", "초대 코드 생성에 실패했습니다. 다시 시도해주세요.", HttpStatus.INTERNAL_SERVER_ERROR),
     ALREADY_GATHERING_MEMBER("G008", "이미 가입된 모임입니다.", HttpStatus.CONFLICT),
-    JOIN_REQUEST_ALREADY_PENDING("G009", "이미 가입 요청이 진행 중입니다.", HttpStatus.CONFLICT);
+    JOIN_REQUEST_ALREADY_PENDING("G009", "이미 가입 요청이 진행 중입니다.", HttpStatus.CONFLICT),
+    INVALID_INVITATION_LINK("G010", "초대링크는 필수입니다.", HttpStatus.BAD_REQUEST);
 
     private final String code;
     private final String message;

--- a/src/main/java/com/dokdok/gathering/service/GatheringService.java
+++ b/src/main/java/com/dokdok/gathering/service/GatheringService.java
@@ -51,6 +51,16 @@ public class GatheringService {
     }
 
     /**
+     * 초대링크로 진입한 모임의 정보를 Summery정보를 보여줍니다.
+     */
+    @Transactional(readOnly = true)
+    public GatheringCreateResponse getJoinGatheringInfo(String invitationLink) {
+
+        Gathering gathering = gatheringValidator.validateInvitationLink(invitationLink);
+        return GatheringCreateResponse.from(gathering);
+    }
+
+    /**
      * 초대링크를 통해 들어온 사용자가 모임에 가입 요청을 합니다.
      */
     @Transactional

--- a/src/main/java/com/dokdok/gathering/service/GatheringValidator.java
+++ b/src/main/java/com/dokdok/gathering/service/GatheringValidator.java
@@ -76,6 +76,9 @@ public class GatheringValidator {
      * 추후 초대링크 갱신기능 추가 시 만료 여부도 검증하도록 추가될 수 있습니다.
      */
     public Gathering validateInvitationLink(String invitationLink) {
+        if (invitationLink == null || invitationLink.isBlank()) {
+            throw new GatheringException(GatheringErrorCode.INVALID_INVITATION_LINK);
+        }
         return gatheringRepository.findGatheringByInvitationLink(invitationLink)
                 .orElseThrow(() -> new GatheringException(GatheringErrorCode.GATHERING_NOT_FOUND));
     }

--- a/src/test/java/com/dokdok/gathering/service/GatheringServiceTest.java
+++ b/src/test/java/com/dokdok/gathering/service/GatheringServiceTest.java
@@ -740,6 +740,79 @@ class GatheringServiceTest {
 	}
 
 	@Test
+	@DisplayName("모임 정보 조회 성공 - 유효한 초대링크로 모임 정보 조회")
+	void getJoinGatheringInfo_Success() {
+		// given
+		String invitationLink = "https://invite.link/abc123";
+
+		given(gatheringValidator.validateInvitationLink(invitationLink)).willReturn(gathering1);
+
+		// when
+		GatheringCreateResponse response = gatheringService.getJoinGatheringInfo(invitationLink);
+
+		// then
+		assertThat(response).isNotNull();
+		assertThat(response.gatheringName()).isEqualTo("독서 모임");
+		assertThat(response.invitationLink()).isEqualTo("https://invite.link/abc123");
+		assertThat(response.totalMembers()).isEqualTo(1);
+		assertThat(response.totalMeetings()).isEqualTo(1);
+		assertThat(response.daysFromCreation()).isEqualTo(gathering1.getDaysFromCreation());
+
+		verify(gatheringValidator, times(1)).validateInvitationLink(invitationLink);
+	}
+
+	@Test
+	@DisplayName("모임 정보 조회 실패 - 유효하지 않은 초대링크")
+	void getJoinGatheringInfo_Fail_InvalidInvitationLink() {
+		// given
+		String invalidLink = "https://invite.link/invalid";
+
+		doThrow(new GatheringException(GatheringErrorCode.GATHERING_NOT_FOUND))
+				.when(gatheringValidator).validateInvitationLink(invalidLink);
+
+		// when & then
+		assertThatThrownBy(() -> gatheringService.getJoinGatheringInfo(invalidLink))
+				.isInstanceOf(GatheringException.class)
+				.hasMessage(GatheringErrorCode.GATHERING_NOT_FOUND.getMessage());
+
+		verify(gatheringValidator, times(1)).validateInvitationLink(invalidLink);
+	}
+
+	@Test
+	@DisplayName("모임 정보 조회 실패 - 빈 초대링크")
+	void getJoinGatheringInfo_Fail_EmptyInvitationLink() {
+		// given
+		String emptyLink = "";
+
+		doThrow(new GatheringException(GatheringErrorCode.GATHERING_NOT_FOUND))
+				.when(gatheringValidator).validateInvitationLink(emptyLink);
+
+		// when & then
+		assertThatThrownBy(() -> gatheringService.getJoinGatheringInfo(emptyLink))
+				.isInstanceOf(GatheringException.class)
+				.hasMessage(GatheringErrorCode.GATHERING_NOT_FOUND.getMessage());
+
+		verify(gatheringValidator, times(1)).validateInvitationLink(emptyLink);
+	}
+
+	@Test
+	@DisplayName("모임 정보 조회 실패 - null 초대링크")
+	void getJoinGatheringInfo_Fail_NullInvitationLink() {
+		// given
+		String nullLink = null;
+
+		doThrow(new GatheringException(GatheringErrorCode.GATHERING_NOT_FOUND))
+				.when(gatheringValidator).validateInvitationLink(nullLink);
+
+		// when & then
+		assertThatThrownBy(() -> gatheringService.getJoinGatheringInfo(nullLink))
+				.isInstanceOf(GatheringException.class)
+				.hasMessage(GatheringErrorCode.GATHERING_NOT_FOUND.getMessage());
+
+		verify(gatheringValidator, times(1)).validateInvitationLink(nullLink);
+	}
+
+	@Test
 	@DisplayName("모임 가입 성공 - 신규 사용자가 초대링크로 가입 요청")
 	void joinGathering_Success() {
 		// given


### PR DESCRIPTION
## PR 요약
> 초대링크를 통해 모임 정보를 조회하고 가입 요청하는 API 구현

- [x] 기능 추가
- [ ] 버그 수정
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 기타 (설명)

---

## 이슈 번호
- #99

---

## 주요 변경 사항

- `GatheringApi.java`: 초대링크로 모임 정보 조회/가입 요청 API 명세 추가
- `GatheringController.java`: @Validated 추가, @NotBlank 검증 적용
- `GatheringService.java`: getJoinGatheringInfo 메서드 추가
- `GatheringValidator.java`: 초대링크 null/공백 검증 로직 추가
- `GatheringErrorCode.java`: INVALID_INVITATION_LINK 에러코드 추가
- `GatheringServiceTest.java`: getJoinGatheringInfo 테스트 케이스 4개 추가

---

## 참고 사항

### API 엔드포인트
- `GET /api/gatherings/join/{invitationLink}` - 모임 정보 조회
- `POST /api/gatherings/join/{invitationLink}` - 모임 가입 요청

### 검증 로직
- Controller: @NotBlank로 빈 문자열 검증
- Validator: null/공백 방어 코드 추가

---