### PR TITLE
[#103][FEAT] 확정된 주제 api 구현

### DIFF
--- a/src/main/java/com/dokdok/topic/api/ConfirmTopicApi.java
+++ b/src/main/java/com/dokdok/topic/api/ConfirmTopicApi.java
@@ -1,0 +1,45 @@
+package com.dokdok.topic.api;
+
+import com.dokdok.global.response.ApiResponse;
+import com.dokdok.topic.dto.response.ConfirmedTopicsResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@Tag(name = "주제 관리", description = "주제 관련 API")
+public interface ConfirmTopicApi {
+
+    @Operation(
+            summary = "확정된 주제 조회",
+            description = "약속에서 확정된 주제 목록을 조회합니다.",
+            parameters = {
+                    @Parameter(name = "gatheringId", description = "모임 식별자", in = ParameterIn.PATH, required = true),
+                    @Parameter(name = "meetingId", description = "약속 식별자", in = ParameterIn.PATH, required = true)
+            }
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "확정 주제 조회 성공",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = ConfirmedTopicsResponse.class))
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "모임 또는 약속의 멤버가 아님"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "모임 또는 약속을 찾을 수 없음"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 오류")
+    })
+    @GetMapping(value = "/confirm-topics", produces = MediaType.APPLICATION_JSON_VALUE)
+    ResponseEntity<ApiResponse<ConfirmedTopicsResponse>> getConfirmedTopics(
+            @PathVariable Long gatheringId,
+            @PathVariable Long meetingId
+    );
+}

--- a/src/main/java/com/dokdok/topic/controller/ConfirmTopicController.java
+++ b/src/main/java/com/dokdok/topic/controller/ConfirmTopicController.java
@@ -1,0 +1,27 @@
+package com.dokdok.topic.controller;
+
+import com.dokdok.global.response.ApiResponse;
+import com.dokdok.topic.api.ConfirmTopicApi;
+import com.dokdok.topic.dto.response.ConfirmedTopicsResponse;
+import com.dokdok.topic.service.TopicService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/gatherings/{gatheringId}/meetings/{meetingId}")
+public class ConfirmTopicController implements ConfirmTopicApi {
+
+    private final TopicService topicService;
+
+    @Override
+    public ResponseEntity<ApiResponse<ConfirmedTopicsResponse>> getConfirmedTopics(
+            Long gatheringId,
+            Long meetingId
+    ) {
+        ConfirmedTopicsResponse response = topicService.getConfirmedTopics(gatheringId, meetingId);
+        return ApiResponse.success(response, "확정된 주제 조회를 완료했습니다.");
+    }
+}

--- a/src/main/java/com/dokdok/topic/dto/response/ConfirmedTopicsResponse.java
+++ b/src/main/java/com/dokdok/topic/dto/response/ConfirmedTopicsResponse.java
@@ -1,0 +1,39 @@
+package com.dokdok.topic.dto.response;
+
+import com.dokdok.topic.entity.Topic;
+import com.dokdok.topic.entity.TopicType;
+import lombok.Builder;
+
+import java.util.List;
+
+public record ConfirmedTopicsResponse(
+        Long meetingId,
+        List<ConfirmedTopicDto> topics
+) {
+
+    @Builder
+    public record ConfirmedTopicDto(
+            Long topicId,
+            String title,
+            String description,
+            TopicType topicType,
+            Integer confirmOrder
+    ) {
+        public static ConfirmedTopicDto from(Topic topic) {
+            return ConfirmedTopicDto.builder()
+                    .topicId(topic.getId())
+                    .title(topic.getTitle())
+                    .description(topic.getDescription())
+                    .topicType(topic.getTopicType())
+                    .confirmOrder(topic.getConfirmOrder())
+                    .build();
+        }
+    }
+
+    public static ConfirmedTopicsResponse from(
+            Long meetingId,
+            List<ConfirmedTopicDto> topics
+    ) {
+        return new ConfirmedTopicsResponse(meetingId, topics);
+    }
+}

--- a/src/main/java/com/dokdok/topic/repository/TopicRepository.java
+++ b/src/main/java/com/dokdok/topic/repository/TopicRepository.java
@@ -1,6 +1,7 @@
 package com.dokdok.topic.repository;
 
 import com.dokdok.topic.entity.Topic;
+import com.dokdok.topic.entity.TopicStatus;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -19,6 +20,11 @@ public interface TopicRepository extends JpaRepository<Topic, Long> {
     List<Topic> findAllByMeetingId(Long meetingId);
 
     List<Topic> findAllByIdInAndMeetingId(List<Long> topicIds, Long meetingId);
+
+    List<Topic> findByMeetingIdAndTopicStatusOrderByConfirmOrderAsc(
+            Long meetingId,
+            TopicStatus topicStatus
+    );
 
     @Query("SELECT t " +
             "FROM Topic t " +

--- a/src/main/java/com/dokdok/topic/service/TopicService.java
+++ b/src/main/java/com/dokdok/topic/service/TopicService.java
@@ -7,7 +7,11 @@ import com.dokdok.meeting.entity.MeetingMember;
 import com.dokdok.meeting.service.MeetingValidator;
 import com.dokdok.topic.dto.request.ConfirmTopicsRequest;
 import com.dokdok.topic.dto.request.SuggestTopicRequest;
-import com.dokdok.topic.dto.response.*;
+import com.dokdok.topic.dto.response.ConfirmTopicsResponse;
+import com.dokdok.topic.dto.response.ConfirmedTopicsResponse;
+import com.dokdok.topic.dto.response.SuggestTopicResponse;
+import com.dokdok.topic.dto.response.TopicLikeResponse;
+import com.dokdok.topic.dto.response.TopicsPageResponse;
 import com.dokdok.topic.entity.Topic;
 import com.dokdok.topic.entity.TopicLike;
 import com.dokdok.topic.entity.TopicMessage;
@@ -134,6 +138,26 @@ public class TopicService {
         }
 
         return ConfirmTopicsResponse.from(meetingId);
+    }
+
+    @Transactional(readOnly = true)
+    public ConfirmedTopicsResponse getConfirmedTopics(
+            Long gatheringId,
+            Long meetingId
+    ) {
+        gatheringValidator.validateGathering(gatheringId);
+        meetingValidator.validateMeetingInGathering(meetingId, gatheringId);
+
+        List<Topic> topics = topicRepository.findByMeetingIdAndTopicStatusOrderByConfirmOrderAsc(
+                meetingId,
+                TopicStatus.CONFIRMED
+        );
+
+        List<ConfirmedTopicsResponse.ConfirmedTopicDto> topicDtos = topics.stream()
+                .map(ConfirmedTopicsResponse.ConfirmedTopicDto::from)
+                .toList();
+
+        return ConfirmedTopicsResponse.from(meetingId, topicDtos);
     }
 
     @Transactional

--- a/src/test/java/com/dokdok/topic/service/TopicServiceTest.java
+++ b/src/test/java/com/dokdok/topic/service/TopicServiceTest.java
@@ -15,6 +15,7 @@ import com.dokdok.meeting.service.MeetingValidator;
 import com.dokdok.topic.dto.request.ConfirmTopicsRequest;
 import com.dokdok.topic.dto.request.SuggestTopicRequest;
 import com.dokdok.topic.dto.response.ConfirmTopicsResponse;
+import com.dokdok.topic.dto.response.ConfirmedTopicsResponse;
 import com.dokdok.topic.dto.response.SuggestTopicResponse;
 import com.dokdok.topic.dto.response.TopicsPageResponse;
 import com.dokdok.topic.dto.response.TopicLikeResponse;
@@ -195,6 +196,74 @@ class TopicServiceTest {
                     topicService.confirmTopics(gatheringId, meetingId, request))
                     .isInstanceOf(TopicException.class)
                     .hasFieldOrPropertyWithValue("errorCode", TopicErrorCode.TOPIC_NOT_FOUND);
+        }
+    }
+
+    @Nested
+    @DisplayName("getConfirmedTopics - 확정 주제 조회")
+    class GetConfirmedTopicsTest {
+
+        @Test
+        @DisplayName("확정된 주제를 순서대로 조회한다")
+        void getConfirmedTopics_Success() {
+            Long gatheringId = 1L;
+            Long meetingId = 1L;
+
+            Topic topic1 = Topic.builder()
+                    .id(12L)
+                    .meeting(testMeeting)
+                    .title("첫 번째 주제")
+                    .description("첫 번째 설명")
+                    .topicType(TopicType.DISCUSSION)
+                    .topicStatus(TopicStatus.CONFIRMED)
+                    .confirmOrder(1)
+                    .build();
+            Topic topic2 = Topic.builder()
+                    .id(13L)
+                    .meeting(testMeeting)
+                    .title("두 번째 주제")
+                    .description("두 번째 설명")
+                    .topicType(TopicType.DISCUSSION)
+                    .topicStatus(TopicStatus.CONFIRMED)
+                    .confirmOrder(2)
+                    .build();
+
+            doNothing().when(gatheringValidator).validateGathering(gatheringId);
+            doNothing().when(meetingValidator).validateMeetingInGathering(meetingId, gatheringId);
+            given(topicRepository.findByMeetingIdAndTopicStatusOrderByConfirmOrderAsc(
+                    meetingId, TopicStatus.CONFIRMED))
+                    .willReturn(List.of(topic1, topic2));
+
+            ConfirmedTopicsResponse response =
+                    topicService.getConfirmedTopics(gatheringId, meetingId);
+
+            assertThat(response.meetingId()).isEqualTo(meetingId);
+            assertThat(response.topics()).hasSize(2);
+            assertThat(response.topics().get(0).topicId()).isEqualTo(12L);
+            assertThat(response.topics().get(0).topicType()).isEqualTo(TopicType.DISCUSSION);
+            assertThat(response.topics().get(1).confirmOrder()).isEqualTo(2);
+
+            verify(gatheringValidator).validateGathering(gatheringId);
+            verify(meetingValidator).validateMeetingInGathering(meetingId, gatheringId);
+            verify(topicRepository).findByMeetingIdAndTopicStatusOrderByConfirmOrderAsc(
+                    meetingId, TopicStatus.CONFIRMED);
+        }
+
+        @Test
+        @DisplayName("모임이 없으면 예외가 발생한다")
+        void getConfirmedTopics_ThrowsWhenGatheringMissing() {
+            Long gatheringId = 1L;
+            Long meetingId = 1L;
+
+            doThrow(new GatheringException(GatheringErrorCode.GATHERING_NOT_FOUND))
+                    .when(gatheringValidator).validateGathering(gatheringId);
+
+            assertThatThrownBy(() -> topicService.getConfirmedTopics(gatheringId, meetingId))
+                    .isInstanceOf(GatheringException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", GatheringErrorCode.GATHERING_NOT_FOUND);
+
+            verify(topicRepository, never())
+                    .findByMeetingIdAndTopicStatusOrderByConfirmOrderAsc(any(), any());
         }
     }
 


### PR DESCRIPTION
 ## PR 요약

  > 이 PR이 어떤 변경을 하는지 간단히 설명하고, 체크 표시는 괄호 사이에 소문자 'x'를 삽입하세요.                                                                                     

  - [x] 기능 추가
  - [ ] 버그 수정
  - [ ] 코드 리팩토링
  - [ ] 문서 수정
  - [ ] 기타 (설명)

  ———

  ## 이슈 번호

  - #103

  ———

  ## 주요 변경 사항

  > 주요 파일, 로직, 컴포넌트 등을 구체적으로 적어주세요.                                                                                                                            

  - src/main/java/com/dokdok/topic/dto/response/ConfirmedTopicsResponse.java: 확정 주제 조회 응답 DTO 추가
  - src/main/java/com/dokdok/topic/repository/TopicRepository.java: 확정 주제 조회용 쿼리 메서드 추가
  - src/main/java/com/dokdok/topic/service/TopicService.java: 확정 주제 조회 서비스 로직 추가
  - src/main/java/com/dokdok/topic/api/ConfirmTopicApi.java: 확정 주제 조회 API 스펙 추가
  - src/main/java/com/dokdok/topic/controller/ConfirmTopicController.java: 확정 주제 조회 컨트롤러 추가
  - src/test/java/com/dokdok/topic/service/TopicServiceTest.java: 확정 주제 조회 서비스 테스트 추가

  ———

  ## 참고 사항

  > 리뷰어가 알아야 할 추가 정보, 테스트 방법 등을 작성해주세요.                                                                                                                     

  - 관련 API 엔드포인트
      - GET /api/gatherings/{gathering_id}/meetings/{meeting_id}/confirm-topics