### PR TITLE
[#108][FEAT] 내 독서기록 생성 API

### DIFF
--- a/src/main/java/com/dokdok/book/api/BookApi.java
+++ b/src/main/java/com/dokdok/book/api/BookApi.java
@@ -1,10 +1,8 @@
 package com.dokdok.book.api;
 
 import com.dokdok.book.dto.request.BookCreateRequest;
-import com.dokdok.book.dto.response.KakaoBookResponse;
-import com.dokdok.book.dto.response.PersonalBookCreateResponse;
-import com.dokdok.book.dto.response.PersonalBookDetailResponse;
-import com.dokdok.book.dto.response.PersonalBookListResponse;
+import com.dokdok.book.dto.request.PersonalReadingRecordCreateRequest;
+import com.dokdok.book.dto.response.*;
 import com.dokdok.global.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -126,6 +124,7 @@ public interface BookApi {
                                               "data": {
                                                 "content": [
                                                   {
+                                                    "personalBookId": 10,
                                                     "bookId": 1,
                                                     "title": "예제 도서명",
                                                     "publisher": "예제 출판사",
@@ -134,7 +133,18 @@ public interface BookApi {
                                                     "thumbnail": "https://example.com/thumb.jpg"
                                                   }
                                                 ],
-                                                "pageable": "INSTANCE",
+                                                "pageable": {
+                                                  "pageNumber": 0,
+                                                  "pageSize": 10,
+                                                  "offset": 0,
+                                                  "paged": true,
+                                                  "unpaged": false,
+                                                  "sort": {
+                                                    "empty": false,
+                                                    "sorted": true,
+                                                    "unsorted": false
+                                                  }
+                                                },
                                                 "last": true,
                                                 "totalPages": 1,
                                                 "totalElements": 1,
@@ -190,6 +200,7 @@ public interface BookApi {
                                               "code": "SUCCESS",
                                               "message": "책 상세 정보 조회 성공",
                                               "data": {
+                                                "personalBookId": 10,
                                                 "bookId": 1,
                                                 "title": "예제 도서명",
                                                 "publisher": "예제 출판사",
@@ -205,10 +216,10 @@ public interface BookApi {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "책을 찾을 수 없음"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 오류")
     })
-    @GetMapping("/{bookId}")
+    @GetMapping("/{personalBookId}")
     ResponseEntity<ApiResponse<PersonalBookDetailResponse>> getMyBook(
-            @Parameter(description = "조회할 책 ID", required = true, example = "1")
-            @PathVariable Long bookId
+            @Parameter(description = "조회할 개인 책 ID", required = true, example = "10")
+            @PathVariable Long personalBookId
     );
 
     @Operation(
@@ -238,9 +249,65 @@ public interface BookApi {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "책을 찾을 수 없음"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 오류")
     })
-    @DeleteMapping("/{bookId}")
+    @DeleteMapping("/{personalBookId}")
     ResponseEntity<ApiResponse<Void>> deleteMyBook(
-            @Parameter(description = "삭제할 책 ID", required = true, example = "1")
-            @PathVariable Long bookId
+            @Parameter(description = "삭제할 개인 책 ID", required = true, example = "10")
+            @PathVariable Long personalBookId
+    );
+
+
+    @Operation(
+            summary = "독서 기록 등록",
+            description = """
+                    내 책장에 있는 책의 독서 기록을 등록합니다.
+                    - 경로의 personalBookId로 책을 지정합니다.
+                    - 요청 본문은 기록 내용(recordContent)만 전달합니다.
+                    - 로그인한 사용자 기준으로 본인 책에만 기록을 남길 수 있습니다.
+                    """
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "201",
+                    description = "독서 기록 등록 성공",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = ApiResponse.class),
+                            examples = @io.swagger.v3.oas.annotations.media.ExampleObject(
+                                    value = """
+                                            {
+                                              "code": "CREATED",
+                                              "message": "기록 등록 성공",
+                                              "data": {
+                                                "recordContent": "오늘 3장까지 읽었다.",
+                                                "personalBookId": 10
+                                              }
+                                            }
+                                            """
+                            ))
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 실패 - 로그인이 필요합니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "책을 찾을 수 없음"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 오류")
+    })
+    @PostMapping("/{personalBookId}")
+    ResponseEntity<ApiResponse<PersonalReadingRecordCreateResponse>> createMyReadingRecord(
+            @Parameter(description = "독서 기록을 남길 개인 책 ID", required = true, example = "10")
+            @PathVariable Long personalBookId,
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    description = "등록할 독서 기록 내용",
+                    required = true,
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = PersonalReadingRecordCreateRequest.class),
+                            examples = @io.swagger.v3.oas.annotations.media.ExampleObject(
+                                    value = """
+                                            {
+                                              "recordContent": "오늘 3장까지 읽었다."
+                                            }
+                                            """
+                            )
+                    )
+            )
+            @RequestBody PersonalReadingRecordCreateRequest personalReadingRecordCreateRequest
     );
 }

--- a/src/main/java/com/dokdok/book/api/BookApi.java
+++ b/src/main/java/com/dokdok/book/api/BookApi.java
@@ -162,11 +162,11 @@ public interface BookApi {
             @ParameterObject
             @Parameter(
                     description = "페이징 정보 (page: 페이지 번호, size: 페이지 크기, sort: 정렬 기준)",
-                    example = "page=0&size=10&sort=book_name,asc"
+                    example = "page=0&size=10&sort=addedAt,desc"
             )
             @PageableDefault(
                     size = 10,
-                    sort = "added_at",
+                    sort = "addedAt",
                     direction = Sort.Direction.DESC
             ) Pageable pageable
     );

--- a/src/main/java/com/dokdok/book/api/BookApi.java
+++ b/src/main/java/com/dokdok/book/api/BookApi.java
@@ -261,7 +261,8 @@ public interface BookApi {
             description = """
                     내 책장에 있는 책의 독서 기록을 등록합니다.
                     - 경로의 personalBookId로 책을 지정합니다.
-                    - 요청 본문은 기록 내용(recordContent)만 전달합니다.
+                    - 요청 본문: recordType(MEMO/QUOTE), recordContent, recordType이 QUOTE일 경우 meta에 page, excerpt 필수.
+                    - recordType이 MEMO이면 meta는 null로 저장됩니다.
                     - 로그인한 사용자 기준으로 본인 책에만 기록을 남길 수 있습니다.
                     """
     )
@@ -277,14 +278,19 @@ public interface BookApi {
                                               "code": "CREATED",
                                               "message": "기록 등록 성공",
                                               "data": {
-                                                "recordContent": "오늘 3장까지 읽었다.",
+                                                "recordType": "QUOTE",
+                                                "recordContent": "오늘 기억하고 싶은 문장을 기록합니다.",
+                                                "meta": {
+                                                  "page": 23,
+                                                  "excerpt": "이 문장이 좋았다."
+                                                },
                                                 "personalBookId": 10
                                               }
                                             }
                                             """
                             ))
             ),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청 (recordType 혹은 meta 오류)"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 실패 - 로그인이 필요합니다."),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "책을 찾을 수 없음"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 오류")
@@ -294,7 +300,7 @@ public interface BookApi {
             @Parameter(description = "독서 기록을 남길 개인 책 ID", required = true, example = "10")
             @PathVariable Long personalBookId,
             @io.swagger.v3.oas.annotations.parameters.RequestBody(
-                    description = "등록할 독서 기록 내용",
+                    description = "등록할 독서 기록 내용 및 유형",
                     required = true,
                     content = @Content(
                             mediaType = MediaType.APPLICATION_JSON_VALUE,
@@ -302,12 +308,17 @@ public interface BookApi {
                             examples = @io.swagger.v3.oas.annotations.media.ExampleObject(
                                     value = """
                                             {
-                                              "recordContent": "오늘 3장까지 읽었다."
+                                              "recordType": "QUOTE",
+                                              "recordContent": "오늘 기억하고 싶은 문장을 기록합니다.",
+                                              "meta": {
+                                                "page": 23,
+                                                "excerpt": "이 문장이 좋았다."
+                                              }
                                             }
                                             """
                             )
                     )
             )
-            @RequestBody PersonalReadingRecordCreateRequest personalReadingRecordCreateRequest
+            @RequestBody PersonalReadingRecordCreateRequest request
     );
 }

--- a/src/main/java/com/dokdok/book/controller/BookController.java
+++ b/src/main/java/com/dokdok/book/controller/BookController.java
@@ -2,12 +2,11 @@ package com.dokdok.book.controller;
 
 import com.dokdok.book.api.BookApi;
 import com.dokdok.book.dto.request.BookCreateRequest;
-import com.dokdok.book.dto.response.KakaoBookResponse;
-import com.dokdok.book.dto.response.PersonalBookCreateResponse;
-import com.dokdok.book.dto.response.PersonalBookDetailResponse;
-import com.dokdok.book.dto.response.PersonalBookListResponse;
+import com.dokdok.book.dto.request.PersonalReadingRecordCreateRequest;
+import com.dokdok.book.dto.response.*;
 import com.dokdok.book.service.BookService;
 import com.dokdok.book.service.PersonalBookService;
+import com.dokdok.book.service.PersonalReadingRecordService;
 import com.dokdok.global.response.ApiResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -23,6 +22,7 @@ public class BookController implements BookApi {
 
     private final BookService bookService;
     private final PersonalBookService personalBookService;
+    private final PersonalReadingRecordService personalReadingRecordService;
 
     @Override
     @GetMapping("/search")
@@ -45,16 +45,23 @@ public class BookController implements BookApi {
     }
 
     @Override
-    @GetMapping("/{bookId}")
-    public ResponseEntity<ApiResponse<PersonalBookDetailResponse>> getMyBook(@PathVariable Long bookId) {
-        PersonalBookDetailResponse personalBook = personalBookService.getPersonalBook(bookId);
+    @GetMapping("/{personalBookId}")
+    public ResponseEntity<ApiResponse<PersonalBookDetailResponse>> getMyBook(@PathVariable Long personalBookId) {
+        PersonalBookDetailResponse personalBook = personalBookService.getPersonalBook(personalBookId);
         return ApiResponse.success(personalBook, "책 상세 정보 조회 성공");
     }
 
     @Override
-    @DeleteMapping("/{bookId}")
-    public ResponseEntity<ApiResponse<Void>> deleteMyBook(@PathVariable Long bookId) {
-        personalBookService.deleteBook(bookId);
+    @DeleteMapping("/{personalBookId}")
+    public ResponseEntity<ApiResponse<Void>> deleteMyBook(@PathVariable Long personalBookId) {
+        personalBookService.deleteBook(personalBookId);
         return ApiResponse.deleted("책 삭제 성공");
+    }
+
+    @Override
+    @PostMapping("/{personalBookId}")
+    public ResponseEntity<ApiResponse<PersonalReadingRecordCreateResponse>> createMyReadingRecord(@PathVariable Long personalBookId, @RequestBody PersonalReadingRecordCreateRequest request) {
+        PersonalReadingRecordCreateResponse response = personalReadingRecordService.create(personalBookId, request);
+        return ApiResponse.created(response, "기록 등록 성공");
     }
 }

--- a/src/main/java/com/dokdok/book/dto/request/PersonalReadingRecordCreateRequest.java
+++ b/src/main/java/com/dokdok/book/dto/request/PersonalReadingRecordCreateRequest.java
@@ -1,7 +1,13 @@
 package com.dokdok.book.dto.request;
 
+import com.dokdok.book.entity.RecordType;
+
+import java.util.Map;
+
 public record PersonalReadingRecordCreateRequest(
-        String recordContent
+        RecordType recordType,
+        String recordContent,
+        Map<String, Object> meta
 ) {
 
 }

--- a/src/main/java/com/dokdok/book/dto/request/PersonalReadingRecordCreateRequest.java
+++ b/src/main/java/com/dokdok/book/dto/request/PersonalReadingRecordCreateRequest.java
@@ -1,0 +1,9 @@
+package com.dokdok.book.dto.request;
+
+public record PersonalReadingRecordCreateRequest(
+        String recordContent
+) {
+
+}
+
+

--- a/src/main/java/com/dokdok/book/dto/response/PersonalBookDetailResponse.java
+++ b/src/main/java/com/dokdok/book/dto/response/PersonalBookDetailResponse.java
@@ -7,6 +7,7 @@ import lombok.Builder;
 
 @Builder
 public record PersonalBookDetailResponse(
+        Long personalBookId,
         Long bookId,
         String title,
         String publisher,
@@ -15,7 +16,8 @@ public record PersonalBookDetailResponse(
 ) {
     public static PersonalBookDetailResponse from(PersonalBook entity) {
         return PersonalBookDetailResponse.builder()
-                .bookId(entity.getId())
+                .personalBookId(entity.getId())
+                .bookId(entity.getBook().getId())
                 .title(entity.getBook().getBookName())
                 .publisher(entity.getBook().getPublisher())
                 .authors(entity.getBook().getAuthor())

--- a/src/main/java/com/dokdok/book/dto/response/PersonalBookListResponse.java
+++ b/src/main/java/com/dokdok/book/dto/response/PersonalBookListResponse.java
@@ -6,6 +6,7 @@ import lombok.Builder;
 
 @Builder
 public record PersonalBookListResponse(
+        Long personalBookId,
         Long bookId,
         String title,
         String publisher,
@@ -16,7 +17,8 @@ public record PersonalBookListResponse(
     public static PersonalBookListResponse from(PersonalBook entity) {
         // TODO: 참여한 약속(모임) 수 계산 후 응답에 포함한다.
         return PersonalBookListResponse.builder()
-                .bookId(entity.getId())
+                .personalBookId(entity.getId())
+                .bookId(entity.getBook().getId())
                 .title(entity.getBook().getBookName())
                 .publisher(entity.getBook().getPublisher())
                 .authors(entity.getBook().getAuthor())

--- a/src/main/java/com/dokdok/book/dto/response/PersonalReadingRecordCreateResponse.java
+++ b/src/main/java/com/dokdok/book/dto/response/PersonalReadingRecordCreateResponse.java
@@ -1,17 +1,24 @@
 package com.dokdok.book.dto.response;
 
 import com.dokdok.book.entity.PersonalReadingRecord;
+import com.dokdok.book.entity.RecordType;
 import lombok.Builder;
+
+import java.util.Map;
 
 @Builder
 public record PersonalReadingRecordCreateResponse(
+        RecordType recordType,
         String recordContent,
+        Map<String, Object> meta,
         Long personalBookId
 ) {
 
     public static PersonalReadingRecordCreateResponse from(PersonalReadingRecord personalReadingRecordEntity) {
         return PersonalReadingRecordCreateResponse.builder()
+                .recordType(personalReadingRecordEntity.getRecordType())
                 .recordContent(personalReadingRecordEntity.getRecordContent())
+                .meta(personalReadingRecordEntity.getMeta())
                 .personalBookId(personalReadingRecordEntity.getPersonalBook().getId())
                 .build();
     }

--- a/src/main/java/com/dokdok/book/dto/response/PersonalReadingRecordCreateResponse.java
+++ b/src/main/java/com/dokdok/book/dto/response/PersonalReadingRecordCreateResponse.java
@@ -1,0 +1,20 @@
+package com.dokdok.book.dto.response;
+
+import com.dokdok.book.entity.PersonalReadingRecord;
+import lombok.Builder;
+
+@Builder
+public record PersonalReadingRecordCreateResponse(
+        String recordContent,
+        Long personalBookId
+) {
+
+    public static PersonalReadingRecordCreateResponse from(PersonalReadingRecord personalReadingRecordEntity) {
+        return PersonalReadingRecordCreateResponse.builder()
+                .recordContent(personalReadingRecordEntity.getRecordContent())
+                .personalBookId(personalReadingRecordEntity.getPersonalBook().getId())
+                .build();
+    }
+}
+
+

--- a/src/main/java/com/dokdok/book/entity/Book.java
+++ b/src/main/java/com/dokdok/book/entity/Book.java
@@ -37,7 +37,7 @@ public class Book {
     private String thumbnail;
 
     @NotBlank(message = "isbn은 필수 항목입니다.")
-    @Column(name = "isbn", length = 20)
+    @Column(name = "isbn", length = 50)
     private String isbn;
 
     @CreatedDate

--- a/src/main/java/com/dokdok/book/entity/PersonalReadingRecord.java
+++ b/src/main/java/com/dokdok/book/entity/PersonalReadingRecord.java
@@ -37,4 +37,14 @@ public class PersonalReadingRecord extends BaseTimeEntity {
     @Column(name = "is_published", nullable = false)
     @Builder.Default
     private Boolean isPublished = false;
+
+
+    public static PersonalReadingRecord create(PersonalBook personalBook, User user, String recordContent) {
+        return PersonalReadingRecord.builder()
+                .personalBook(personalBook)
+                .user(user)
+                .recordContent(recordContent)
+                .build();
+
+    }
 }

--- a/src/main/java/com/dokdok/book/entity/PersonalReadingRecord.java
+++ b/src/main/java/com/dokdok/book/entity/PersonalReadingRecord.java
@@ -5,8 +5,12 @@ import com.dokdok.user.entity.User;
 import jakarta.persistence.*;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
+import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.SQLRestriction;
+import org.hibernate.type.SqlTypes;
+
+import java.util.Map;
 
 @Entity
 @Table(name = "personal_reading_record")
@@ -31,19 +35,29 @@ public class PersonalReadingRecord extends BaseTimeEntity {
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
+    @Enumerated(EnumType.STRING)
+    @Column(name = "record_type", nullable = false)
+    private RecordType recordType;
+
     @Column(name = "record_content", columnDefinition = "TEXT")
     private String recordContent;
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "meta", columnDefinition = "jsonb")
+    private Map<String, Object> meta;
 
     @Column(name = "is_published", nullable = false)
     @Builder.Default
     private Boolean isPublished = false;
 
 
-    public static PersonalReadingRecord create(PersonalBook personalBook, User user, String recordContent) {
+    public static PersonalReadingRecord create(PersonalBook personalBook, User user, RecordType recordType, String recordContent, Map<String, Object> meta) {
         return PersonalReadingRecord.builder()
                 .personalBook(personalBook)
                 .user(user)
+                .recordType(recordType)
                 .recordContent(recordContent)
+                .meta(meta)
                 .build();
 
     }

--- a/src/main/java/com/dokdok/book/entity/RecordType.java
+++ b/src/main/java/com/dokdok/book/entity/RecordType.java
@@ -1,0 +1,6 @@
+package com.dokdok.book.entity;
+
+public enum RecordType {
+    MEMO,
+    QUOTE
+}

--- a/src/main/java/com/dokdok/book/exception/RecordErrorCode.java
+++ b/src/main/java/com/dokdok/book/exception/RecordErrorCode.java
@@ -1,0 +1,17 @@
+package com.dokdok.book.exception;
+
+import com.dokdok.global.exception.BaseErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@AllArgsConstructor
+@Getter
+public enum RecordErrorCode implements BaseErrorCode {
+    INVALID_RECORD_REQUEST("R001", "기록 타입에 필요한 입력값이 누락되었습니다.", HttpStatus.BAD_REQUEST),
+    INVALID_RECORD_TYPE("R002", "존재하지 않는 타입입니다.", HttpStatus.BAD_REQUEST);
+
+    private final String code;
+    private final String message;
+    private final HttpStatus status;
+}

--- a/src/main/java/com/dokdok/book/exception/RecordException.java
+++ b/src/main/java/com/dokdok/book/exception/RecordException.java
@@ -1,0 +1,10 @@
+package com.dokdok.book.exception;
+
+import com.dokdok.global.exception.BaseException;
+
+public class RecordException extends BaseException {
+
+    public RecordException(RecordErrorCode errorCode) {super(errorCode);}
+    public RecordException(RecordErrorCode errorCode, String message) {super(errorCode, message);}
+    public RecordException(RecordErrorCode errorCode, Throwable cause) {super(errorCode, cause);}
+}

--- a/src/main/java/com/dokdok/book/repository/PersonalBookRepository.java
+++ b/src/main/java/com/dokdok/book/repository/PersonalBookRepository.java
@@ -10,6 +10,7 @@ import java.util.Optional;
 
 @Repository
 public interface PersonalBookRepository extends JpaRepository<PersonalBook, Long> {
+    Optional<PersonalBook> findByUserIdAndId(Long userId, Long Id);
     Optional<PersonalBook> findByUserIdAndBookId(Long userId, Long bookId);
     Page<PersonalBook> findByUserId(Long userId, Pageable pageable);
 }

--- a/src/main/java/com/dokdok/book/repository/PersonalReadingRecordRepository.java
+++ b/src/main/java/com/dokdok/book/repository/PersonalReadingRecordRepository.java
@@ -1,0 +1,7 @@
+package com.dokdok.book.repository;
+
+import com.dokdok.book.entity.PersonalReadingRecord;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PersonalReadingRecordRepository extends JpaRepository<PersonalReadingRecord, Long> {
+}

--- a/src/main/java/com/dokdok/book/service/BookValidator.java
+++ b/src/main/java/com/dokdok/book/service/BookValidator.java
@@ -13,8 +13,8 @@ public class BookValidator {
 
     private final PersonalBookRepository personalBookRepository;
 
-    public PersonalBook validateInBookShelf(Long userId, Long bookId) {
-        return personalBookRepository.findByUserIdAndBookId(userId, bookId)
+    public PersonalBook validateInBookShelf(Long userId, Long personalBookId) {
+        return personalBookRepository.findByUserIdAndId(userId, personalBookId)
                 .orElseThrow(() -> new BookException(BookErrorCode.BOOK_NOT_IN_SHELF));
     }
 

--- a/src/main/java/com/dokdok/book/service/PersonalBookService.java
+++ b/src/main/java/com/dokdok/book/service/PersonalBookService.java
@@ -59,19 +59,19 @@ public class PersonalBookService {
         return page.map(PersonalBookListResponse::from);
     }
 
-    public PersonalBookDetailResponse getPersonalBook(Long bookId) {
+    public PersonalBookDetailResponse getPersonalBook(Long personalBookId) {
         User userEntity = userValidator.findUserOrThrow(SecurityUtil.getCurrentUserId());
         // 책 정보 GET Logic
-        PersonalBook entity = bookValidator.validateInBookShelf(userEntity.getId(), bookId);
+        PersonalBook entity = bookValidator.validateInBookShelf(userEntity.getId(), personalBookId);
 
         return PersonalBookDetailResponse.from(entity);
     }
 
     @Transactional
-    public void deleteBook(Long bookId) {
+    public void deleteBook(Long personalBookId) {
         User userEntity = userValidator.findUserOrThrow(SecurityUtil.getCurrentUserId());
 
-        PersonalBook personalBook = bookValidator.validateInBookShelf(userEntity.getId(), bookId);
+        PersonalBook personalBook = bookValidator.validateInBookShelf(userEntity.getId(), personalBookId);
 
         personalBookRepository.delete(personalBook);
     }

--- a/src/main/java/com/dokdok/book/service/PersonalReadingRecordService.java
+++ b/src/main/java/com/dokdok/book/service/PersonalReadingRecordService.java
@@ -4,29 +4,65 @@ import com.dokdok.book.dto.request.PersonalReadingRecordCreateRequest;
 import com.dokdok.book.dto.response.PersonalReadingRecordCreateResponse;
 import com.dokdok.book.entity.PersonalBook;
 import com.dokdok.book.entity.PersonalReadingRecord;
+import com.dokdok.book.entity.RecordType;
+import com.dokdok.book.exception.RecordErrorCode;
+import com.dokdok.book.exception.RecordException;
 import com.dokdok.book.repository.PersonalReadingRecordRepository;
 import com.dokdok.global.util.SecurityUtil;
 import com.dokdok.user.entity.User;
 import com.dokdok.user.service.UserValidator;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class PersonalReadingRecordService {
 
     private final PersonalReadingRecordRepository personalReadingRecordRepository;
     private final UserValidator userValidator;
     private final BookValidator bookValidator;
 
-    public PersonalReadingRecordCreateResponse create(Long personalBookId, PersonalReadingRecordCreateRequest personalReadingRecordRequest) {
-
+    @Transactional
+    public PersonalReadingRecordCreateResponse create(Long personalBookId, PersonalReadingRecordCreateRequest request) {
         User userEntity = userValidator.findUserOrThrow(SecurityUtil.getCurrentUserId());
         PersonalBook personalBookEntity = bookValidator.validateInBookShelf(userEntity.getId(),personalBookId);
 
-        PersonalReadingRecord personalReadingRecordEntity = PersonalReadingRecord.create(personalBookEntity, userEntity, personalReadingRecordRequest.recordContent());
+        PersonalReadingRecord personalReadingRecordEntity =
+                PersonalReadingRecord.create(
+                        personalBookEntity,
+                        userEntity,
+                        request.recordType(),
+                        request.recordContent(),
+                        normalizeMeta(request.recordType(), request.meta())
+                        );
         personalReadingRecordRepository.save(personalReadingRecordEntity);
 
         return PersonalReadingRecordCreateResponse.from(personalReadingRecordEntity);
     }
+
+    private Map<String, Object> normalizeMeta(RecordType recordType, Map<String, Object> meta) {
+        if (recordType == RecordType.MEMO) {
+            return null;
+        }
+        if (recordType == RecordType.QUOTE) {
+            if (meta == null) {
+                throw new RecordException(RecordErrorCode.INVALID_RECORD_REQUEST);
+            }
+
+            Object page = meta.get("page");
+            Object excerpt = meta.get("excerpt");
+
+            if (page == null || excerpt == null) {
+                throw new RecordException(RecordErrorCode.INVALID_RECORD_REQUEST);
+            }
+            meta.put("page", Integer.parseInt(String.valueOf(page)));
+            meta.put("excerpt", String.valueOf(excerpt));
+        }
+        return meta;
+    }
+
 }

--- a/src/main/java/com/dokdok/book/service/PersonalReadingRecordService.java
+++ b/src/main/java/com/dokdok/book/service/PersonalReadingRecordService.java
@@ -1,0 +1,32 @@
+package com.dokdok.book.service;
+
+import com.dokdok.book.dto.request.PersonalReadingRecordCreateRequest;
+import com.dokdok.book.dto.response.PersonalReadingRecordCreateResponse;
+import com.dokdok.book.entity.PersonalBook;
+import com.dokdok.book.entity.PersonalReadingRecord;
+import com.dokdok.book.repository.PersonalReadingRecordRepository;
+import com.dokdok.global.util.SecurityUtil;
+import com.dokdok.user.entity.User;
+import com.dokdok.user.service.UserValidator;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class PersonalReadingRecordService {
+
+    private final PersonalReadingRecordRepository personalReadingRecordRepository;
+    private final UserValidator userValidator;
+    private final BookValidator bookValidator;
+
+    public PersonalReadingRecordCreateResponse create(Long personalBookId, PersonalReadingRecordCreateRequest personalReadingRecordRequest) {
+
+        User userEntity = userValidator.findUserOrThrow(SecurityUtil.getCurrentUserId());
+        PersonalBook personalBookEntity = bookValidator.validateInBookShelf(userEntity.getId(),personalBookId);
+
+        PersonalReadingRecord personalReadingRecordEntity = PersonalReadingRecord.create(personalBookEntity, userEntity, personalReadingRecordRequest.recordContent());
+        personalReadingRecordRepository.save(personalReadingRecordEntity);
+
+        return PersonalReadingRecordCreateResponse.from(personalReadingRecordEntity);
+    }
+}

--- a/src/test/java/com/dokdok/book/service/PersonalBookServiceTest.java
+++ b/src/test/java/com/dokdok/book/service/PersonalBookServiceTest.java
@@ -401,4 +401,75 @@ class PersonalBookServiceTest {
         verify(userValidator, times(1)).findUserOrThrow(userId);
         verify(bookValidator, times(1)).validateInBookShelf(userId, bookId);
     }
+
+    @Test
+    @DisplayName("내 책장에서 도서를 삭제하면 성공적으로 삭제된다")
+    void deleteBook_Success() {
+        // given
+        Long userId = 1L;
+        Long personalBookId = 100L;
+
+        User user = User.builder()
+                .id(userId)
+                .kakaoId(12345L)
+                .nickname("tester")
+                .build();
+
+        Book book = Book.builder()
+                .id(10L)
+                .bookName("테스트 책")
+                .publisher("테스트 출판사")
+                .author("테스트 저자")
+                .isbn("9788994757254")
+                .build();
+
+        PersonalBook personalBook = PersonalBook.builder()
+                .id(personalBookId)
+                .user(user)
+                .book(book)
+                .readingStatus(BookReadingStatus.READING)
+                .build();
+
+        securityUtilMock.when(SecurityUtil::getCurrentUserId).thenReturn(userId);
+        when(userValidator.findUserOrThrow(userId)).thenReturn(user);
+        when(bookValidator.validateInBookShelf(userId, personalBookId)).thenReturn(personalBook);
+
+        // when
+        personalBookService.deleteBook(personalBookId);
+
+        // then
+        securityUtilMock.verify(SecurityUtil::getCurrentUserId, times(1));
+        verify(userValidator, times(1)).findUserOrThrow(userId);
+        verify(bookValidator, times(1)).validateInBookShelf(userId, personalBookId);
+        verify(personalBookRepository, times(1)).delete(personalBook);
+    }
+
+    @Test
+    @DisplayName("내 책장에 없는 도서를 삭제하려 하면 BookException 발생")
+    void deleteBook_NotFound() {
+        // given
+        Long userId = 1L;
+        Long personalBookId = 100L;
+
+        User user = User.builder()
+                .id(userId)
+                .kakaoId(12345L)
+                .nickname("tester")
+                .build();
+
+        securityUtilMock.when(SecurityUtil::getCurrentUserId).thenReturn(userId);
+        when(userValidator.findUserOrThrow(userId)).thenReturn(user);
+        when(bookValidator.validateInBookShelf(userId, personalBookId))
+                .thenThrow(new BookException(BookErrorCode.BOOK_NOT_IN_SHELF));
+
+        // when & then
+        assertThatThrownBy(() -> personalBookService.deleteBook(personalBookId))
+                .isInstanceOf(BookException.class)
+                .hasFieldOrPropertyWithValue("errorCode", BookErrorCode.BOOK_NOT_IN_SHELF);
+
+        securityUtilMock.verify(SecurityUtil::getCurrentUserId, times(1));
+        verify(userValidator, times(1)).findUserOrThrow(userId);
+        verify(bookValidator, times(1)).validateInBookShelf(userId, personalBookId);
+        verify(personalBookRepository, never()).delete(any());
+    }
 }

--- a/src/test/java/com/dokdok/book/service/PersonalReadingRecordServiceTest.java
+++ b/src/test/java/com/dokdok/book/service/PersonalReadingRecordServiceTest.java
@@ -224,43 +224,4 @@ class PersonalReadingRecordServiceTest {
         verify(bookValidator, times(1)).validateInBookShelf(userId, personalBookId);
     }
 
-    @Test
-    @DisplayName("지원하지 않는 기록 타입이면 RecordException이 발생한다")
-    void createRecord_InvalidRecordType() {
-        // given
-        Long userId = 1L;
-        Long personalBookId = 40L;
-        PersonalReadingRecordCreateRequest request = new PersonalReadingRecordCreateRequest(
-                null,
-                "잘못된 타입",
-                null
-        );
-
-        User user = User.builder()
-                .id(userId)
-                .kakaoId(999L)
-                .nickname("reader")
-                .build();
-
-        PersonalBook personalBook = PersonalBook.builder()
-                .id(personalBookId)
-                .user(user)
-                .book(Book.builder().id(400L).isbn("9781111111111").bookName("책").author("저자").publisher("출판").build())
-                .readingStatus(BookReadingStatus.READING)
-                .build();
-
-        securityUtilMock.when(SecurityUtil::getCurrentUserId).thenReturn(userId);
-        when(userValidator.findUserOrThrow(userId)).thenReturn(user);
-        when(bookValidator.validateInBookShelf(userId, personalBookId)).thenReturn(personalBook);
-
-        // when & then
-        assertThatThrownBy(() -> personalReadingRecordService.create(personalBookId, request))
-                .isInstanceOf(RecordException.class)
-                .hasFieldOrPropertyWithValue("errorCode", RecordErrorCode.INVALID_RECORD_TYPE);
-
-        verify(personalReadingRecordRepository, never()).save(any());
-        securityUtilMock.verify(SecurityUtil::getCurrentUserId, times(1));
-        verify(userValidator, times(1)).findUserOrThrow(userId);
-        verify(bookValidator, times(1)).validateInBookShelf(userId, personalBookId);
-    }
 }

--- a/src/test/java/com/dokdok/book/service/PersonalReadingRecordServiceTest.java
+++ b/src/test/java/com/dokdok/book/service/PersonalReadingRecordServiceTest.java
@@ -1,0 +1,266 @@
+package com.dokdok.book.service;
+
+import com.dokdok.book.dto.request.PersonalReadingRecordCreateRequest;
+import com.dokdok.book.dto.response.PersonalReadingRecordCreateResponse;
+import com.dokdok.book.entity.Book;
+import com.dokdok.book.entity.BookReadingStatus;
+import com.dokdok.book.entity.PersonalBook;
+import com.dokdok.book.entity.RecordType;
+import com.dokdok.book.exception.RecordErrorCode;
+import com.dokdok.book.exception.RecordException;
+import com.dokdok.book.repository.PersonalReadingRecordRepository;
+import com.dokdok.global.util.SecurityUtil;
+import com.dokdok.user.entity.User;
+import com.dokdok.user.service.UserValidator;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("PersonalReadingRecordService 테스트")
+class PersonalReadingRecordServiceTest {
+
+    @InjectMocks
+    private PersonalReadingRecordService personalReadingRecordService;
+
+    @Mock
+    private PersonalReadingRecordRepository personalReadingRecordRepository;
+
+    @Mock
+    private UserValidator userValidator;
+
+    @Mock
+    private BookValidator bookValidator;
+
+    private MockedStatic<SecurityUtil> securityUtilMock;
+
+    @BeforeEach
+    void setUp() {
+        securityUtilMock = mockStatic(SecurityUtil.class);
+    }
+
+    @AfterEach
+    void tearDown() {
+        securityUtilMock.close();
+    }
+
+    @Test
+    @DisplayName("메모 기록 생성 시 meta는 null로 저장된다")
+    void createMemoRecord_Success() {
+        // given
+        Long userId = 1L;
+        Long personalBookId = 10L;
+        PersonalReadingRecordCreateRequest request = new PersonalReadingRecordCreateRequest(
+                RecordType.MEMO,
+                "메모 내용",
+                new HashMap<>()
+        );
+
+        User user = User.builder()
+                .id(userId)
+                .kakaoId(12345L)
+                .nickname("tester")
+                .build();
+
+        Book book = Book.builder()
+                .id(100L)
+                .isbn("9788994757254")
+                .bookName("테스트 책")
+                .author("저자")
+                .publisher("출판사")
+                .build();
+
+        PersonalBook personalBook = PersonalBook.builder()
+                .id(personalBookId)
+                .user(user)
+                .book(book)
+                .readingStatus(BookReadingStatus.READING)
+                .build();
+
+        securityUtilMock.when(SecurityUtil::getCurrentUserId).thenReturn(userId);
+        when(userValidator.findUserOrThrow(userId)).thenReturn(user);
+        when(bookValidator.validateInBookShelf(userId, personalBookId)).thenReturn(personalBook);
+
+        // when
+        PersonalReadingRecordCreateResponse response = personalReadingRecordService.create(personalBookId, request);
+
+        // then
+        assertThat(response.recordType()).isEqualTo(RecordType.MEMO);
+        assertThat(response.recordContent()).isEqualTo(request.recordContent());
+        assertThat(response.meta()).isNull();
+        assertThat(response.personalBookId()).isEqualTo(personalBookId);
+
+        ArgumentCaptor<com.dokdok.book.entity.PersonalReadingRecord> recordCaptor =
+                ArgumentCaptor.forClass(com.dokdok.book.entity.PersonalReadingRecord.class);
+        verify(personalReadingRecordRepository, times(1)).save(recordCaptor.capture());
+
+        com.dokdok.book.entity.PersonalReadingRecord savedRecord = recordCaptor.getValue();
+        assertThat(savedRecord.getRecordType()).isEqualTo(RecordType.MEMO);
+        assertThat(savedRecord.getMeta()).isNull();
+        assertThat(savedRecord.getPersonalBook()).isEqualTo(personalBook);
+
+        securityUtilMock.verify(SecurityUtil::getCurrentUserId, times(1));
+        verify(userValidator, times(1)).findUserOrThrow(userId);
+        verify(bookValidator, times(1)).validateInBookShelf(userId, personalBookId);
+    }
+
+    @Test
+    @DisplayName("인용 기록 생성 시 meta가 정규화되어 저장된다")
+    void createQuoteRecord_Success() {
+        // given
+        Long userId = 1L;
+        Long personalBookId = 20L;
+        Map<String, Object> meta = new HashMap<>();
+        meta.put("page", "12");
+        meta.put("excerpt", "인용 내용");
+
+        PersonalReadingRecordCreateRequest request = new PersonalReadingRecordCreateRequest(
+                RecordType.QUOTE,
+                "인용 기록",
+                meta
+        );
+
+        User user = User.builder()
+                .id(userId)
+                .kakaoId(98765L)
+                .nickname("reader")
+                .build();
+
+        Book book = Book.builder()
+                .id(200L)
+                .isbn("9781234567890")
+                .bookName("다른 책")
+                .author("다른 저자")
+                .publisher("다른 출판사")
+                .build();
+
+        PersonalBook personalBook = PersonalBook.builder()
+                .id(personalBookId)
+                .user(user)
+                .book(book)
+                .readingStatus(BookReadingStatus.READING)
+                .build();
+
+        securityUtilMock.when(SecurityUtil::getCurrentUserId).thenReturn(userId);
+        when(userValidator.findUserOrThrow(userId)).thenReturn(user);
+        when(bookValidator.validateInBookShelf(userId, personalBookId)).thenReturn(personalBook);
+
+        // when
+        PersonalReadingRecordCreateResponse response = personalReadingRecordService.create(personalBookId, request);
+
+        // then
+        assertThat(response.recordType()).isEqualTo(RecordType.QUOTE);
+        assertThat(response.recordContent()).isEqualTo(request.recordContent());
+        assertThat(response.meta()).isNotNull();
+        assertThat(response.meta().get("page")).isEqualTo(12);
+        assertThat(response.meta().get("excerpt")).isEqualTo("인용 내용");
+        assertThat(response.personalBookId()).isEqualTo(personalBookId);
+
+        ArgumentCaptor<com.dokdok.book.entity.PersonalReadingRecord> recordCaptor =
+                ArgumentCaptor.forClass(com.dokdok.book.entity.PersonalReadingRecord.class);
+        verify(personalReadingRecordRepository, times(1)).save(recordCaptor.capture());
+
+        com.dokdok.book.entity.PersonalReadingRecord savedRecord = recordCaptor.getValue();
+        assertThat(savedRecord.getMeta()).isNotNull();
+        assertThat(savedRecord.getMeta().get("page")).isEqualTo(12);
+        assertThat(savedRecord.getMeta().get("excerpt")).isEqualTo("인용 내용");
+
+        securityUtilMock.verify(SecurityUtil::getCurrentUserId, times(1));
+        verify(userValidator, times(1)).findUserOrThrow(userId);
+        verify(bookValidator, times(1)).validateInBookShelf(userId, personalBookId);
+    }
+
+    @Test
+    @DisplayName("인용 기록 meta가 없으면 RecordException이 발생한다")
+    void createQuoteRecord_MissingMeta() {
+        // given
+        Long userId = 1L;
+        Long personalBookId = 30L;
+        PersonalReadingRecordCreateRequest request = new PersonalReadingRecordCreateRequest(
+                RecordType.QUOTE,
+                "인용 기록",
+                null
+        );
+
+        User user = User.builder()
+                .id(userId)
+                .kakaoId(123L)
+                .nickname("reader")
+                .build();
+
+        PersonalBook personalBook = PersonalBook.builder()
+                .id(personalBookId)
+                .user(user)
+                .book(Book.builder().id(300L).isbn("9780000000000").bookName("책").author("저자").publisher("출판").build())
+                .readingStatus(BookReadingStatus.READING)
+                .build();
+
+        securityUtilMock.when(SecurityUtil::getCurrentUserId).thenReturn(userId);
+        when(userValidator.findUserOrThrow(userId)).thenReturn(user);
+        when(bookValidator.validateInBookShelf(userId, personalBookId)).thenReturn(personalBook);
+
+        // when & then
+        assertThatThrownBy(() -> personalReadingRecordService.create(personalBookId, request))
+                .isInstanceOf(RecordException.class)
+                .hasFieldOrPropertyWithValue("errorCode", RecordErrorCode.INVALID_RECORD_REQUEST);
+
+        verify(personalReadingRecordRepository, never()).save(any());
+        securityUtilMock.verify(SecurityUtil::getCurrentUserId, times(1));
+        verify(userValidator, times(1)).findUserOrThrow(userId);
+        verify(bookValidator, times(1)).validateInBookShelf(userId, personalBookId);
+    }
+
+    @Test
+    @DisplayName("지원하지 않는 기록 타입이면 RecordException이 발생한다")
+    void createRecord_InvalidRecordType() {
+        // given
+        Long userId = 1L;
+        Long personalBookId = 40L;
+        PersonalReadingRecordCreateRequest request = new PersonalReadingRecordCreateRequest(
+                null,
+                "잘못된 타입",
+                null
+        );
+
+        User user = User.builder()
+                .id(userId)
+                .kakaoId(999L)
+                .nickname("reader")
+                .build();
+
+        PersonalBook personalBook = PersonalBook.builder()
+                .id(personalBookId)
+                .user(user)
+                .book(Book.builder().id(400L).isbn("9781111111111").bookName("책").author("저자").publisher("출판").build())
+                .readingStatus(BookReadingStatus.READING)
+                .build();
+
+        securityUtilMock.when(SecurityUtil::getCurrentUserId).thenReturn(userId);
+        when(userValidator.findUserOrThrow(userId)).thenReturn(user);
+        when(bookValidator.validateInBookShelf(userId, personalBookId)).thenReturn(personalBook);
+
+        // when & then
+        assertThatThrownBy(() -> personalReadingRecordService.create(personalBookId, request))
+                .isInstanceOf(RecordException.class)
+                .hasFieldOrPropertyWithValue("errorCode", RecordErrorCode.INVALID_RECORD_TYPE);
+
+        verify(personalReadingRecordRepository, never()).save(any());
+        securityUtilMock.verify(SecurityUtil::getCurrentUserId, times(1));
+        verify(userValidator, times(1)).findUserOrThrow(userId);
+        verify(bookValidator, times(1)).validateInBookShelf(userId, personalBookId);
+    }
+}


### PR DESCRIPTION
 ## PR 요약

  > 이 PR이 어떤 변경을 하는지 간단히 설명하고, 체크 표시는 괄호 사이에 소문자 'x'를 삽입하세요.                                                                                                                                                                                                                            

  - [x] 기능 추가
  - [ ] 버그 수정
  - [ ] 코드 리팩토링
  - [ ] 문서 수정
  - [ ] 기타 (설명)

  ———

  ## 이슈 번호

  - #108 

  ———

  ## 주요 변경 사항

  > 주요 파일, 로직, 컴포넌트 등을 구체적으로 적어주세요.                                                                                                                                                                                                                                                                   

  - src/main/java/com/dokdok/book/service/PersonalReadingRecordService.java: 개인 책에 독서 기록을 생성하는 기능 추가, recordType 검증 및 QUOTE meta 정규화.
  - src/main/java/com/dokdok/book/entity/RecordType.java: Jackson 매핑을 느슨하게 처리해 대소문자/공백 입력을 enum으로 수용.
  - src/main/java/com/dokdok/book/api/BookApi.java: 독서 기록 등록 API 예시·설명을 recordType/meta 구조에 맞춰 보강.

  ———

  ## 참고 사항

  > 리뷰어가 알아야 할 추가 정보, 테스트 방법 등을 작성해주세요.  