### PR TITLE
[#114][FEAT] 모임원 가입 요청 승인/거절 API

### DIFF
--- a/src/main/java/com/dokdok/gathering/api/GatheringApi.java
+++ b/src/main/java/com/dokdok/gathering/api/GatheringApi.java
@@ -28,7 +28,9 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
+import com.dokdok.gathering.dto.request.JoinGatheringMemberRequest;
 import com.dokdok.gathering.dto.response.GatheringJoinResponse;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 
 @Tag(name = "모임", description = "모임 관련 API")
 @RequestMapping("/api/gatherings")
@@ -374,5 +376,126 @@ public interface GatheringApi {
             @PathVariable Long gatheringId,
             @Parameter(description = "강퇴할 유저 ID", required = true, example = "456")
             @PathVariable Long userId
+    );
+
+    @Operation(
+            summary = "가입 요청 승인/거절",
+            description = """
+                모임장이 가입 요청한 멤버를 승인하거나 거절합니다.
+                - 모임장만 처리할 수 있습니다.
+                - PENDING 상태의 멤버만 처리할 수 있습니다.
+                - approve_type은 ACTIVE(승인) 또는 REJECTED(거절)만 허용됩니다.
+                - 승인 시 joinedAt이 현재 시간으로 설정됩니다.
+                """
+    )
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "처리 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = {
+                                    @ExampleObject(
+                                            name = "승인 성공",
+                                            value = """
+                                                {
+                                                    "success": true,
+                                                    "message": "해당 멤버가 가입승인 되었습니다.",
+                                                    "data": null
+                                                }
+                                                """
+                                    ),
+                                    @ExampleObject(
+                                            name = "거절 성공",
+                                            value = """
+                                                {
+                                                    "success": true,
+                                                    "message": "해당 멤버가 가입거절 되었습니다.",
+                                                    "data": null
+                                                }
+                                                """
+                                    )
+                            }
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "400",
+                    description = "잘못된 요청 - approve_type이 PENDING이거나, 대상 멤버가 PENDING 상태가 아님",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = {
+                                    @ExampleObject(
+                                            name = "잘못된 approve_type",
+                                            value = """
+                                                {
+                                                    "success": false,
+                                                    "message": "승인 상태는 ACTIVE 또는 REJECTED만 가능합니다.",
+                                                    "data": null
+                                                }
+                                                """
+                                    ),
+                                    @ExampleObject(
+                                            name = "PENDING 상태 아님",
+                                            value = """
+                                                {
+                                                    "success": false,
+                                                    "message": "대기 중인 가입 요청만 처리할 수 있습니다.",
+                                                    "data": null
+                                                }
+                                                """
+                                    )
+                            }
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "401",
+                    description = "인증 실패 - 로그인이 필요합니다."
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "403",
+                    description = "권한 없음 - 모임장만 가입 요청을 처리할 수 있습니다."
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "모임 또는 멤버를 찾을 수 없음"
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "500",
+                    description = "서버 오류"
+            )
+    })
+    @PatchMapping("/{gatheringId}/join-requests/{memberId}")
+    ResponseEntity<ApiResponse<Void>> handleJoinRequest(
+            @Parameter(description = "모임 ID", required = true, example = "1")
+            @PathVariable("gatheringId") Long gatheringId,
+            @Parameter(description = "처리할 멤버의 유저 ID", required = true, example = "5")
+            @PathVariable("memberId") Long memberId,
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    description = "승인/거절 요청",
+                    required = true,
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = JoinGatheringMemberRequest.class),
+                            examples = {
+                                    @ExampleObject(
+                                            name = "승인 요청",
+                                            value = """
+                                                {
+                                                    "approve_type": "ACTIVE"
+                                                }
+                                                """
+                                    ),
+                                    @ExampleObject(
+                                            name = "거절 요청",
+                                            value = """
+                                                {
+                                                    "approve_type": "REJECTED"
+                                                }
+                                                """
+                                    )
+                            }
+                    )
+            )
+            @Valid @RequestBody JoinGatheringMemberRequest request
     );
 }

--- a/src/main/java/com/dokdok/gathering/controller/GatheringController.java
+++ b/src/main/java/com/dokdok/gathering/controller/GatheringController.java
@@ -50,10 +50,12 @@ public class GatheringController implements GatheringApi {
         return ApiResponse.success(response);
     }
 
-    @PatchMapping("{gathering-id}/join-requests/{member-id}")
-    public ResponseEntity<ApiResponse<Void>> handleJoinRequest(@PathVariable("gathering-id") Long gatheringId,
-                                                               @PathVariable("member-id") Long memberId,
-                                                               @RequestBody @Valid JoinGatheringMemberRequest request) {
+    @Override
+    @PatchMapping("/{gatheringId}/join-requests/{memberId}")
+    public ResponseEntity<ApiResponse<Void>> handleJoinRequest(
+            @PathVariable("gatheringId") Long gatheringId,
+            @PathVariable("memberId") Long memberId,
+            @Valid @RequestBody JoinGatheringMemberRequest request) {
 
         gatheringService.handleJoinRequest(gatheringId, memberId, request);
         return ApiResponse.success("해당 멤버가 " + request.approve_type().getDescription() + " 되었습니다.");

--- a/src/main/java/com/dokdok/gathering/controller/GatheringController.java
+++ b/src/main/java/com/dokdok/gathering/controller/GatheringController.java
@@ -2,6 +2,7 @@ package com.dokdok.gathering.controller;
 
 import com.dokdok.gathering.api.GatheringApi;
 import com.dokdok.gathering.dto.request.GatheringCreateRequest;
+import com.dokdok.gathering.dto.request.JoinGatheringMemberRequest;
 import com.dokdok.gathering.dto.response.*;
 import com.dokdok.gathering.dto.request.GatheringUpdateRequest;
 import com.dokdok.gathering.service.GatheringService;
@@ -47,6 +48,15 @@ public class GatheringController implements GatheringApi {
     ) {
         GatheringJoinResponse response = gatheringService.joinGathering(invitationLink);
         return ApiResponse.success(response);
+    }
+
+    @PatchMapping("{gathering-id}/join-requests/{member-id}")
+    public ResponseEntity<ApiResponse<Void>> handleJoinRequest(@PathVariable("gathering-id") Long gatheringId,
+                                                               @PathVariable("member-id") Long memberId,
+                                                               @RequestBody @Valid JoinGatheringMemberRequest request) {
+
+        gatheringService.handleJoinRequest(gatheringId, memberId, request);
+        return ApiResponse.success("해당 멤버가 " + request.approve_type().getDescription() + " 되었습니다.");
     }
 
     @Override

--- a/src/main/java/com/dokdok/gathering/dto/request/JoinGatheringMemberRequest.java
+++ b/src/main/java/com/dokdok/gathering/dto/request/JoinGatheringMemberRequest.java
@@ -1,0 +1,11 @@
+package com.dokdok.gathering.dto.request;
+
+import com.dokdok.gathering.entity.GatheringMemberStatus;
+import jakarta.validation.constraints.NotNull;
+
+public record JoinGatheringMemberRequest(
+
+        @NotNull(message = "승인상태는 빈 값일 수 없습니다.")
+        GatheringMemberStatus approve_type
+) {
+}

--- a/src/main/java/com/dokdok/gathering/entity/Gathering.java
+++ b/src/main/java/com/dokdok/gathering/entity/Gathering.java
@@ -1,7 +1,5 @@
 package com.dokdok.gathering.entity;
 
-import com.dokdok.gathering.exception.GatheringErrorCode;
-import com.dokdok.gathering.exception.GatheringException;
 import com.dokdok.global.BaseTimeEntity;
 import com.dokdok.user.entity.User;
 import jakarta.persistence.*;

--- a/src/main/java/com/dokdok/gathering/entity/GatheringMember.java
+++ b/src/main/java/com/dokdok/gathering/entity/GatheringMember.java
@@ -2,6 +2,7 @@ package com.dokdok.gathering.entity;
 
 import com.dokdok.user.entity.User;
 import jakarta.persistence.*;
+import jakarta.validation.constraints.NotBlank;
 import lombok.*;
 import org.hibernate.annotations.SQLRestriction;
 import org.springframework.data.annotation.CreatedDate;
@@ -49,8 +50,7 @@ import java.time.temporal.ChronoUnit;
     @Builder.Default
     private GatheringRole role = GatheringRole.MEMBER;
 
-    @CreatedDate
-    @Column(name = "joined_at", nullable = false, updatable = false)
+    @Column(name = "joined_at")
     private LocalDateTime joinedAt;
 
     @LastModifiedDate
@@ -85,5 +85,12 @@ import java.time.temporal.ChronoUnit;
 
     public void remove() {
         this.removedAt = LocalDateTime.now();
+    }
+
+    public void handleJoinRequest(GatheringMemberStatus status) {
+        if (status == GatheringMemberStatus.ACTIVE) {
+            this.joinedAt = LocalDateTime.now();
+        }
+        this.memberStatus = status;
     }
 }

--- a/src/main/java/com/dokdok/gathering/entity/GatheringMemberStatus.java
+++ b/src/main/java/com/dokdok/gathering/entity/GatheringMemberStatus.java
@@ -1,7 +1,22 @@
 package com.dokdok.gathering.entity;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
 public enum GatheringMemberStatus {
-    PENDING,
-    ACTIVE,
-    REJECTED
+    PENDING("PENDING", "가입요청"),
+    ACTIVE("ACTIVE", "가입승인"),
+    REJECTED("REJECTED", "가입거절");
+
+    private final String code;
+    private final String description;
+
+    // 소문자 -> 대문자로 변환합니다.
+    @JsonCreator
+    public static GatheringMemberStatus from(String value) {
+        return GatheringMemberStatus.valueOf(value.toUpperCase());
+    }
 }

--- a/src/main/java/com/dokdok/gathering/exception/GatheringErrorCode.java
+++ b/src/main/java/com/dokdok/gathering/exception/GatheringErrorCode.java
@@ -18,7 +18,9 @@ public enum GatheringErrorCode implements BaseErrorCode {
     INVITATION_CODE_GENERATION_FAILED("G007", "초대 코드 생성에 실패했습니다. 다시 시도해주세요.", HttpStatus.INTERNAL_SERVER_ERROR),
     ALREADY_GATHERING_MEMBER("G008", "이미 가입된 모임입니다.", HttpStatus.CONFLICT),
     JOIN_REQUEST_ALREADY_PENDING("G009", "이미 가입 요청이 진행 중입니다.", HttpStatus.CONFLICT),
-    INVALID_INVITATION_LINK("G010", "초대링크는 필수입니다.", HttpStatus.BAD_REQUEST);
+    INVALID_INVITATION_LINK("G010", "초대링크는 필수입니다.", HttpStatus.BAD_REQUEST),
+    NOT_PENDING_STATUS("G011", "대기 중인 가입 요청만 처리할 수 있습니다.", HttpStatus.BAD_REQUEST),
+    INVALID_APPROVE_TYPE("G012", "승인 상태는 ACTIVE 또는 REJECTED만 가능합니다.", HttpStatus.BAD_REQUEST);
 
     private final String code;
     private final String message;

--- a/src/main/java/com/dokdok/gathering/service/GatheringService.java
+++ b/src/main/java/com/dokdok/gathering/service/GatheringService.java
@@ -2,6 +2,7 @@ package com.dokdok.gathering.service;
 
 import com.dokdok.gathering.dto.request.GatheringCreateRequest;
 import com.dokdok.gathering.dto.request.GatheringUpdateRequest;
+import com.dokdok.gathering.dto.request.JoinGatheringMemberRequest;
 import com.dokdok.gathering.dto.response.*;
 import com.dokdok.gathering.entity.*;
 import com.dokdok.gathering.exception.GatheringErrorCode;
@@ -53,7 +54,6 @@ public class GatheringService {
     /**
      * 초대링크로 진입한 모임의 정보를 Summery정보를 보여줍니다.
      */
-    @Transactional(readOnly = true)
     public GatheringCreateResponse getJoinGatheringInfo(String invitationLink) {
 
         Gathering gathering = gatheringValidator.validateInvitationLink(invitationLink);
@@ -74,6 +74,30 @@ public class GatheringService {
         GatheringMember member = saveGatheringMember(gathering, user, GatheringRole.MEMBER, GatheringMemberStatus.PENDING);
 
         return GatheringJoinResponse.from(member);
+    }
+
+    /**
+     * 모임장이 가입 요청을 한 멤버에 대해 승인|거절을 처리합니다.
+     */
+    @Transactional
+    public void handleJoinRequest(Long gatheringId, Long memberId, JoinGatheringMemberRequest request) {
+
+        User user = SecurityUtil.getCurrentUserEntity();
+        gatheringValidator.validateLeader(gatheringId, user.getId());
+
+        GatheringMemberStatus approveType = request.approve_type();
+        if (approveType == GatheringMemberStatus.PENDING) {
+            throw new GatheringException(GatheringErrorCode.INVALID_APPROVE_TYPE);
+        }
+
+        GatheringMember gatheringMember = gatheringMemberRepository.findByGatheringIdAndUserId(gatheringId, memberId)
+                .orElseThrow(() -> new GatheringException(GatheringErrorCode.NOT_GATHERING_MEMBER));
+
+        if (gatheringMember.getMemberStatus() != GatheringMemberStatus.PENDING) {
+            throw new GatheringException(GatheringErrorCode.NOT_PENDING_STATUS);
+        }
+
+        gatheringMember.handleJoinRequest(approveType);
     }
 
 	public MyGatheringListResponse getMyGatherings(Pageable pageable) {

--- a/src/main/java/com/dokdok/gathering/service/GatheringValidator.java
+++ b/src/main/java/com/dokdok/gathering/service/GatheringValidator.java
@@ -25,7 +25,7 @@ public class GatheringValidator {
 		boolean isGathering = gatheringRepository.existsById(gatheringId);
 
 		if (!isGathering) {
-			throw new GatheringException(GatheringErrorCode.NOT_GATHERING_MEMBER);
+			throw new GatheringException(GatheringErrorCode.GATHERING_NOT_FOUND);
 		}
 	}
 
@@ -45,7 +45,10 @@ public class GatheringValidator {
      * 모임의 모임장인지 검증한다.
      */
 	public void validateLeader(Long gatheringId, Long userId) {
-		GatheringMember member = gatheringMemberRepository
+
+        validateGathering(gatheringId);
+
+        GatheringMember member = gatheringMemberRepository
 				.findByGatheringIdAndUserId(gatheringId, userId)
 				.orElseThrow(() -> new GatheringException(GatheringErrorCode.NOT_GATHERING_MEMBER));
 

--- a/src/test/java/com/dokdok/gathering/service/GatheringServiceTest.java
+++ b/src/test/java/com/dokdok/gathering/service/GatheringServiceTest.java
@@ -1,6 +1,7 @@
 package com.dokdok.gathering.service;
 
 import com.dokdok.gathering.dto.request.GatheringCreateRequest;
+import com.dokdok.gathering.dto.request.JoinGatheringMemberRequest;
 import com.dokdok.gathering.dto.response.GatheringCreateResponse;
 import com.dokdok.gathering.dto.response.GatheringDetailResponse;
 import com.dokdok.gathering.dto.response.GatheringJoinResponse;
@@ -37,6 +38,7 @@ import org.springframework.data.domain.Pageable;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 import static com.dokdok.gathering.entity.GatheringRole.LEADER;
 import static com.dokdok.gathering.entity.GatheringRole.MEMBER;
@@ -157,7 +159,6 @@ class GatheringServiceTest {
 				.isFavorite(false)
 				.role(MEMBER)
 				.memberStatus(GatheringMemberStatus.PENDING)
-				.joinedAt(LocalDateTime.now().minusDays(1))
 				.build();
 	}
 
@@ -915,5 +916,176 @@ class GatheringServiceTest {
 		verify(gatheringValidator, times(1)).validateInvitationLink(invitationLink);
 		verify(gatheringValidator, times(1)).validateJoinedGathering(1L, 4L);
 		verify(gatheringMemberRepository, times(0)).save(any());
+	}
+
+	@Test
+	@DisplayName("가입 요청 승인 성공 - 리더가 PENDING 멤버를 ACTIVE로 승인")
+	void handleJoinRequest_Success_Approve() {
+		// given
+		Long gatheringId = 1L;
+		Long targetUserId = 4L;
+		JoinGatheringMemberRequest request = new JoinGatheringMemberRequest(GatheringMemberStatus.ACTIVE);
+
+		securityUtilMock.when(SecurityUtil::getCurrentUserEntity).thenReturn(leader);
+
+		given(gatheringMemberRepository.findByGatheringIdAndUserId(gatheringId, targetUserId))
+				.willReturn(Optional.of(pendingMember));
+
+		// when
+		gatheringService.handleJoinRequest(gatheringId, targetUserId, request);
+
+		// then
+		assertThat(pendingMember.getMemberStatus()).isEqualTo(GatheringMemberStatus.ACTIVE);
+		assertThat(pendingMember.getJoinedAt()).isNotNull();
+
+		securityUtilMock.verify(SecurityUtil::getCurrentUserEntity, times(1));
+		verify(gatheringValidator, times(1)).validateLeader(gatheringId, leader.getId());
+		verify(gatheringMemberRepository, times(1)).findByGatheringIdAndUserId(gatheringId, targetUserId);
+	}
+
+	@Test
+	@DisplayName("가입 요청 거절 성공 - 리더가 PENDING 멤버를 REJECTED로 거절")
+	void handleJoinRequest_Success_Reject() {
+		// given
+		Long gatheringId = 1L;
+		Long targetUserId = 4L;
+		JoinGatheringMemberRequest request = new JoinGatheringMemberRequest(GatheringMemberStatus.REJECTED);
+
+		securityUtilMock.when(SecurityUtil::getCurrentUserEntity).thenReturn(leader);
+
+		given(gatheringMemberRepository.findByGatheringIdAndUserId(gatheringId, targetUserId))
+				.willReturn(Optional.of(pendingMember));
+
+		// when
+		gatheringService.handleJoinRequest(gatheringId, targetUserId, request);
+
+		// then
+		assertThat(pendingMember.getMemberStatus()).isEqualTo(GatheringMemberStatus.REJECTED);
+		assertThat(pendingMember.getJoinedAt()).isNull();
+
+		securityUtilMock.verify(SecurityUtil::getCurrentUserEntity, times(1));
+		verify(gatheringValidator, times(1)).validateLeader(gatheringId, leader.getId());
+		verify(gatheringMemberRepository, times(1)).findByGatheringIdAndUserId(gatheringId, targetUserId);
+	}
+
+	@Test
+	@DisplayName("가입 요청 처리 실패 - 리더가 아닌 멤버가 처리 시도")
+	void handleJoinRequest_Fail_NotLeader() {
+		// given
+		Long gatheringId = 1L;
+		Long targetUserId = 4L;
+		JoinGatheringMemberRequest request = new JoinGatheringMemberRequest(GatheringMemberStatus.ACTIVE);
+
+		securityUtilMock.when(SecurityUtil::getCurrentUserEntity).thenReturn(member);
+
+		doThrow(new GatheringException(GatheringErrorCode.NOT_GATHERING_LEADER))
+				.when(gatheringValidator).validateLeader(gatheringId, member.getId());
+
+		// when & then
+		assertThatThrownBy(() -> gatheringService.handleJoinRequest(gatheringId, targetUserId, request))
+				.isInstanceOf(GatheringException.class)
+				.hasMessage(GatheringErrorCode.NOT_GATHERING_LEADER.getMessage());
+
+		securityUtilMock.verify(SecurityUtil::getCurrentUserEntity, times(1));
+		verify(gatheringValidator, times(1)).validateLeader(gatheringId, member.getId());
+		verify(gatheringMemberRepository, times(0)).findByGatheringIdAndUserId(any(), any());
+	}
+
+	@Test
+	@DisplayName("가입 요청 처리 실패 - 대상 멤버가 존재하지 않음")
+	void handleJoinRequest_Fail_MemberNotFound() {
+		// given
+		Long gatheringId = 1L;
+		Long targetUserId = 999L;
+		JoinGatheringMemberRequest request = new JoinGatheringMemberRequest(GatheringMemberStatus.ACTIVE);
+
+		securityUtilMock.when(SecurityUtil::getCurrentUserEntity).thenReturn(leader);
+
+		given(gatheringMemberRepository.findByGatheringIdAndUserId(gatheringId, targetUserId))
+				.willReturn(Optional.empty());
+
+		// when & then
+		assertThatThrownBy(() -> gatheringService.handleJoinRequest(gatheringId, targetUserId, request))
+				.isInstanceOf(GatheringException.class)
+				.hasMessage(GatheringErrorCode.NOT_GATHERING_MEMBER.getMessage());
+
+		securityUtilMock.verify(SecurityUtil::getCurrentUserEntity, times(1));
+		verify(gatheringValidator, times(1)).validateLeader(gatheringId, leader.getId());
+		verify(gatheringMemberRepository, times(1)).findByGatheringIdAndUserId(gatheringId, targetUserId);
+	}
+
+	@Test
+	@DisplayName("가입 요청 처리 실패 - 대상 멤버가 PENDING 상태가 아님 (이미 ACTIVE)")
+	void handleJoinRequest_Fail_NotPendingStatus_AlreadyActive() {
+		// given
+		Long gatheringId = 1L;
+		Long targetUserId = 2L;
+		JoinGatheringMemberRequest request = new JoinGatheringMemberRequest(GatheringMemberStatus.ACTIVE);
+
+		securityUtilMock.when(SecurityUtil::getCurrentUserEntity).thenReturn(leader);
+
+		given(gatheringMemberRepository.findByGatheringIdAndUserId(gatheringId, targetUserId))
+				.willReturn(Optional.of(normalMember));
+
+		// when & then
+		assertThatThrownBy(() -> gatheringService.handleJoinRequest(gatheringId, targetUserId, request))
+				.isInstanceOf(GatheringException.class)
+				.hasMessage(GatheringErrorCode.NOT_PENDING_STATUS.getMessage());
+
+		securityUtilMock.verify(SecurityUtil::getCurrentUserEntity, times(1));
+		verify(gatheringValidator, times(1)).validateLeader(gatheringId, leader.getId());
+		verify(gatheringMemberRepository, times(1)).findByGatheringIdAndUserId(gatheringId, targetUserId);
+	}
+
+	@Test
+	@DisplayName("가입 요청 처리 실패 - 대상 멤버가 PENDING 상태가 아님 (이미 REJECTED)")
+	void handleJoinRequest_Fail_NotPendingStatus_AlreadyRejected() {
+		// given
+		Long gatheringId = 1L;
+		Long targetUserId = 5L;
+		JoinGatheringMemberRequest request = new JoinGatheringMemberRequest(GatheringMemberStatus.ACTIVE);
+
+		GatheringMember rejectedMember = GatheringMember.builder()
+				.id(5L)
+				.gathering(gathering1)
+				.user(newUser)
+				.isFavorite(false)
+				.role(MEMBER)
+				.memberStatus(GatheringMemberStatus.REJECTED)
+				.build();
+
+		securityUtilMock.when(SecurityUtil::getCurrentUserEntity).thenReturn(leader);
+
+		given(gatheringMemberRepository.findByGatheringIdAndUserId(gatheringId, targetUserId))
+				.willReturn(Optional.of(rejectedMember));
+
+		// when & then
+		assertThatThrownBy(() -> gatheringService.handleJoinRequest(gatheringId, targetUserId, request))
+				.isInstanceOf(GatheringException.class)
+				.hasMessage(GatheringErrorCode.NOT_PENDING_STATUS.getMessage());
+
+		securityUtilMock.verify(SecurityUtil::getCurrentUserEntity, times(1));
+		verify(gatheringValidator, times(1)).validateLeader(gatheringId, leader.getId());
+		verify(gatheringMemberRepository, times(1)).findByGatheringIdAndUserId(gatheringId, targetUserId);
+	}
+
+	@Test
+	@DisplayName("가입 요청 처리 실패 - approve_type이 PENDING인 경우")
+	void handleJoinRequest_Fail_InvalidApproveType_Pending() {
+		// given
+		Long gatheringId = 1L;
+		Long targetUserId = 4L;
+		JoinGatheringMemberRequest request = new JoinGatheringMemberRequest(GatheringMemberStatus.PENDING);
+
+		securityUtilMock.when(SecurityUtil::getCurrentUserEntity).thenReturn(leader);
+
+		// when & then
+		assertThatThrownBy(() -> gatheringService.handleJoinRequest(gatheringId, targetUserId, request))
+				.isInstanceOf(GatheringException.class)
+				.hasMessage(GatheringErrorCode.INVALID_APPROVE_TYPE.getMessage());
+
+		securityUtilMock.verify(SecurityUtil::getCurrentUserEntity, times(1));
+		verify(gatheringValidator, times(1)).validateLeader(gatheringId, leader.getId());
+		verify(gatheringMemberRepository, times(0)).findByGatheringIdAndUserId(any(), any());
 	}
 }


### PR DESCRIPTION
## PR 요약
> 모임장이 가입 요청한 멤버를 승인하거나 거절할 수 있는 API 구현

- [x] 기능 추가
- [ ] 버그 수정
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 기타 (설명)

---

## 이슈 번호
- #114

---

## 주요 변경 사항

- `GatheringController`: handleJoinRequest 엔드포인트 추가
- `GatheringService`: 가입 요청 승인/거절 로직 구현 (PENDING 검증, approve_type 검증 포함)
- `GatheringMember`: handleJoinRequest 메서드 수정 (ACTIVE일 때만 joinedAt 설정)
- `GatheringMemberStatus`: @JsonCreator 추가 (소문자 -> 대문자 변환)
- `GatheringErrorCode`: NOT_PENDING_STATUS, INVALID_APPROVE_TYPE 에러 코드 추가
- `JoinGatheringMemberRequest`: DTO 추가 (@NotNull 검증)
- `GatheringServiceTest`: handleJoinRequest 테스트 7개 추가

---

## 참고 사항

### API 엔드포인트
- `PATCH /api/gatherings/{gathering-id}/join-requests/{member-id}`

### Request Body
```json
{
  "approve_type": "ACTIVE" | "REJECTED"
}
```

### 검증 로직
1. 모임장만 처리 가능
2. PENDING 상태의 멤버만 처리 가능
3. approve_type은 ACTIVE 또는 REJECTED만 허용 (PENDING 불가)

### 테스트
- 총 7개 테스트 케이스 추가
- 승인/거절 성공 및 각종 실패 케이스 검증