### PR TITLE
[#116][FIX] 모임 정보 응답 수정 (daysFromCreation, totalMembers)

### DIFF
--- a/src/main/java/com/dokdok/gathering/dto/response/GatheringCreateResponse.java
+++ b/src/main/java/com/dokdok/gathering/dto/response/GatheringCreateResponse.java
@@ -11,10 +11,10 @@ public record GatheringCreateResponse(
         Integer totalMeetings,
         String invitationLink
 ) {
-    public static GatheringCreateResponse from(Gathering gathering) {
+    public static GatheringCreateResponse from(Gathering gathering, int activeMembers) {
         return GatheringCreateResponse.builder()
                 .gatheringName(gathering.getGatheringName())
-                .totalMembers(1)
+                .totalMembers(activeMembers)
                 .daysFromCreation(gathering.getDaysFromCreation())
                 .totalMeetings(1)
                 .invitationLink(gathering.getInvitationLink())

--- a/src/main/java/com/dokdok/gathering/dto/response/GatheringCreateResponse.java
+++ b/src/main/java/com/dokdok/gathering/dto/response/GatheringCreateResponse.java
@@ -11,12 +11,12 @@ public record GatheringCreateResponse(
         Integer totalMeetings,
         String invitationLink
 ) {
-    public static GatheringCreateResponse from(Gathering gathering, int activeMembers) {
+    public static GatheringCreateResponse from(Gathering gathering, int activeMembers, int totalMeetings) {
         return GatheringCreateResponse.builder()
                 .gatheringName(gathering.getGatheringName())
                 .totalMembers(activeMembers)
                 .daysFromCreation(gathering.getDaysFromCreation())
-                .totalMeetings(1)
+                .totalMeetings(totalMeetings)
                 .invitationLink(gathering.getInvitationLink())
                 .build();
     }

--- a/src/main/java/com/dokdok/gathering/entity/Gathering.java
+++ b/src/main/java/com/dokdok/gathering/entity/Gathering.java
@@ -54,7 +54,7 @@ public class Gathering extends BaseTimeEntity {
     }
 
     /**
-     * 생성일일로부터 경과한 일수를 계산합니다.
+     * 생성일로부터 경과한 일수를 계산합니다. (1일차부터 시작)
      */
     public Integer getDaysFromCreation(){
         if(this.getCreatedAt()== null){
@@ -62,7 +62,7 @@ public class Gathering extends BaseTimeEntity {
         }
         return (int) ChronoUnit.DAYS.between(
                 this.getCreatedAt().toLocalDate(), LocalDate.now()
-        );
+        ) + 1;
     }
 
     /**

--- a/src/main/java/com/dokdok/gathering/repository/GatheringMemberRepository.java
+++ b/src/main/java/com/dokdok/gathering/repository/GatheringMemberRepository.java
@@ -67,4 +67,13 @@ public interface GatheringMemberRepository extends JpaRepository<GatheringMember
             "WHERE gm.gathering.id = :gatheringId " +
             "AND gm.removedAt IS NULL")
     List<GatheringMember> findAllMembersByGatheringId(@Param("gatheringId") Long gatheringId);
+
+    /**
+     * 특정 모임의 ACTIVE 상태 멤버 수 조회
+     */
+    @Query("SELECT count(gm) FROM GatheringMember gm " +
+            "WHERE gm.gathering.id = :gatheringId " +
+            "AND gm.memberStatus = 'ACTIVE' " +
+            "AND gm.removedAt IS NULL")
+    int countActiveMembersByStatus(@Param("gatheringId") Long gatheringId);
 }

--- a/src/main/java/com/dokdok/gathering/repository/GatheringMemberRepository.java
+++ b/src/main/java/com/dokdok/gathering/repository/GatheringMemberRepository.java
@@ -38,14 +38,6 @@ public interface GatheringMemberRepository extends JpaRepository<GatheringMember
     );
 
     /**
-     * 특정 모임의 멤버 수 조회
-     */
-    @Query("SELECT count(gm) FROM GatheringMember gm " +
-            "WHERE gm.gathering.id = :gatheringId " +
-            "AND gm.removedAt IS NULL")
-    int countActiveMembers(@Param("gatheringId") Long gatheringId);
-
-    /**
      * 특정 유저가 특정 모임의 멤버인지 확인 (Gathering fetch join)
      */
     @Query("SELECT gm FROM GatheringMember gm " +

--- a/src/main/java/com/dokdok/gathering/service/GatheringService.java
+++ b/src/main/java/com/dokdok/gathering/service/GatheringService.java
@@ -48,7 +48,11 @@ public class GatheringService {
 
         saveGatheringMember(savedGathering, user, GatheringRole.LEADER, GatheringMemberStatus.ACTIVE);
 
-        return GatheringCreateResponse.from(savedGathering, getActiveMemberCount(savedGathering.getId()));
+        return GatheringCreateResponse.from(
+                savedGathering,
+                getActiveMemberCount(savedGathering.getId()),
+                getMeetingCount(savedGathering.getId())
+        );
     }
 
     /**
@@ -57,7 +61,11 @@ public class GatheringService {
     public GatheringCreateResponse getJoinGatheringInfo(String invitationLink) {
 
         Gathering gathering = gatheringValidator.validateInvitationLink(invitationLink);
-        return GatheringCreateResponse.from(gathering, getActiveMemberCount(gathering.getId()));
+        return GatheringCreateResponse.from(
+                gathering,
+                getActiveMemberCount(gathering.getId()),
+                getMeetingCount(gathering.getId())
+        );
     }
 
     /**
@@ -227,5 +235,13 @@ public class GatheringService {
      */
     private int getActiveMemberCount(Long gatheringId) {
         return gatheringMemberRepository.countActiveMembersByStatus(gatheringId);
+    }
+
+    /**
+     * 공통 메서드
+     * 완료된 모임(미팅) 수를 조회합니다.
+     */
+    private int getMeetingCount(Long gatheringId) {
+        return meetingRepository.countByGatheringIdAndMeetingStatus(gatheringId, MeetingStatus.DONE);
     }
 }

--- a/src/main/java/com/dokdok/gathering/service/GatheringService.java
+++ b/src/main/java/com/dokdok/gathering/service/GatheringService.java
@@ -48,7 +48,7 @@ public class GatheringService {
 
         saveGatheringMember(savedGathering, user, GatheringRole.LEADER, GatheringMemberStatus.ACTIVE);
 
-        return GatheringCreateResponse.from(savedGathering);
+        return GatheringCreateResponse.from(savedGathering, getActiveMemberCount(savedGathering.getId()));
     }
 
     /**
@@ -57,7 +57,7 @@ public class GatheringService {
     public GatheringCreateResponse getJoinGatheringInfo(String invitationLink) {
 
         Gathering gathering = gatheringValidator.validateInvitationLink(invitationLink);
-        return GatheringCreateResponse.from(gathering);
+        return GatheringCreateResponse.from(gathering, getActiveMemberCount(gathering.getId()));
     }
 
     /**
@@ -219,5 +219,13 @@ public class GatheringService {
 
         GatheringMember gatheringMember = GatheringMember.of(gathering, user, role, status);
         return gatheringMemberRepository.save(gatheringMember);
+    }
+
+    /**
+     * 공통 메서드
+     * ACTIVE 상태인 모임 멤버 수를 조회합니다.
+     */
+    private int getActiveMemberCount(Long gatheringId) {
+        return gatheringMemberRepository.countActiveMembersByStatus(gatheringId);
     }
 }

--- a/src/main/java/com/dokdok/gathering/service/GatheringService.java
+++ b/src/main/java/com/dokdok/gathering/service/GatheringService.java
@@ -116,7 +116,7 @@ public class GatheringService {
 		List<GatheringSimpleResponse> gatheringResponses = gatheringMemberPage.getContent()
 				.stream()
 				.map(gatheringMember -> {
-					int totalMembers = gatheringMemberRepository.countActiveMembers(gatheringMember.getGathering().getId());
+					int totalMembers = gatheringMemberRepository.countActiveMembersByStatus(gatheringMember.getGathering().getId());
 					int totalMeetings = meetingRepository.countByGatheringIdAndMeetingStatus(gatheringMember.getGathering().getId(), MeetingStatus.DONE);
 
 					return GatheringSimpleResponse.from(gatheringMember, totalMembers,totalMeetings, gatheringMember.getRole());

--- a/src/test/java/com/dokdok/gathering/service/GatheringServiceTest.java
+++ b/src/test/java/com/dokdok/gathering/service/GatheringServiceTest.java
@@ -285,8 +285,8 @@ class GatheringServiceTest {
 		Page<GatheringMember> memberPage = new PageImpl<>(members, pageable, members.size());
 
 		given(gatheringMemberRepository.findActiveGatheringsByUserId(userId, pageable)).willReturn(memberPage);
-		given(gatheringMemberRepository.countActiveMembers(1L)).willReturn(1);
-		given(gatheringMemberRepository.countActiveMembers(2L)).willReturn(1);
+		given(gatheringMemberRepository.countActiveMembersByStatus(1L)).willReturn(1);
+		given(gatheringMemberRepository.countActiveMembersByStatus(2L)).willReturn(1);
 		given(meetingRepository.countByGatheringIdAndMeetingStatus(1L, MeetingStatus.DONE)).willReturn(3);
 		given(meetingRepository.countByGatheringIdAndMeetingStatus(2L, MeetingStatus.DONE)).willReturn(5);
 
@@ -322,8 +322,8 @@ class GatheringServiceTest {
 
 		securityUtilMock.verify(SecurityUtil::getCurrentUserId, times(1));
 		verify(gatheringMemberRepository, times(1)).findActiveGatheringsByUserId(eq(userId), any(Pageable.class));
-		verify(gatheringMemberRepository, times(1)).countActiveMembers(1L);
-		verify(gatheringMemberRepository, times(1)).countActiveMembers(2L);
+		verify(gatheringMemberRepository, times(1)).countActiveMembersByStatus(1L);
+		verify(gatheringMemberRepository, times(1)).countActiveMembersByStatus(2L);
 		verify(meetingRepository, times(1)).countByGatheringIdAndMeetingStatus(1L, MeetingStatus.DONE);
 		verify(meetingRepository, times(1)).countByGatheringIdAndMeetingStatus(2L, MeetingStatus.DONE);
 	}

--- a/src/test/java/com/dokdok/gathering/service/GatheringServiceTest.java
+++ b/src/test/java/com/dokdok/gathering/service/GatheringServiceTest.java
@@ -181,6 +181,7 @@ class GatheringServiceTest {
 			given(gatheringRepository.save(any(Gathering.class))).willAnswer(invocation -> invocation.getArgument(0));
 			given(gatheringMemberRepository.save(any(GatheringMember.class))).willAnswer(invocation -> invocation.getArgument(0));
 			given(gatheringMemberRepository.countActiveMembersByStatus(any())).willReturn(1);
+			given(meetingRepository.countByGatheringIdAndMeetingStatus(any(), eq(MeetingStatus.DONE))).willReturn(0);
 
 			// when
 			GatheringCreateResponse response = gatheringService.createGathering(request);
@@ -190,7 +191,7 @@ class GatheringServiceTest {
 			assertThat(response.gatheringName()).isEqualTo("새 모임");
 			assertThat(response.invitationLink()).isEqualTo("INVITE_CODE");
 			assertThat(response.totalMembers()).isEqualTo(1);
-			assertThat(response.totalMeetings()).isEqualTo(1);
+			assertThat(response.totalMeetings()).isEqualTo(0);
 
 			securityUtilMock.verify(SecurityUtil::getCurrentUserEntity, times(1));
 			verify(gatheringRepository, times(1)).existsByInvitationLink("INVITE_CODE");
@@ -216,6 +217,7 @@ class GatheringServiceTest {
 			given(gatheringRepository.save(any(Gathering.class))).willAnswer(invocation -> invocation.getArgument(0));
 			given(gatheringMemberRepository.save(any(GatheringMember.class))).willAnswer(invocation -> invocation.getArgument(0));
 			given(gatheringMemberRepository.countActiveMembersByStatus(any())).willReturn(1);
+			given(meetingRepository.countByGatheringIdAndMeetingStatus(any(), eq(MeetingStatus.DONE))).willReturn(0);
 
 			// when
 			GatheringCreateResponse response = gatheringService.createGathering(request);
@@ -750,6 +752,7 @@ class GatheringServiceTest {
 
 		given(gatheringValidator.validateInvitationLink(invitationLink)).willReturn(gathering1);
 		given(gatheringMemberRepository.countActiveMembersByStatus(gathering1.getId())).willReturn(2);
+		given(meetingRepository.countByGatheringIdAndMeetingStatus(gathering1.getId(), MeetingStatus.DONE)).willReturn(5);
 
 		// when
 		GatheringCreateResponse response = gatheringService.getJoinGatheringInfo(invitationLink);
@@ -759,11 +762,12 @@ class GatheringServiceTest {
 		assertThat(response.gatheringName()).isEqualTo("독서 모임");
 		assertThat(response.invitationLink()).isEqualTo("https://invite.link/abc123");
 		assertThat(response.totalMembers()).isEqualTo(2);
-		assertThat(response.totalMeetings()).isEqualTo(1);
+		assertThat(response.totalMeetings()).isEqualTo(5);
 		assertThat(response.daysFromCreation()).isEqualTo(gathering1.getDaysFromCreation());
 
 		verify(gatheringValidator, times(1)).validateInvitationLink(invitationLink);
 		verify(gatheringMemberRepository, times(1)).countActiveMembersByStatus(gathering1.getId());
+		verify(meetingRepository, times(1)).countByGatheringIdAndMeetingStatus(gathering1.getId(), MeetingStatus.DONE);
 	}
 
 	@Test

--- a/src/test/java/com/dokdok/gathering/service/GatheringServiceTest.java
+++ b/src/test/java/com/dokdok/gathering/service/GatheringServiceTest.java
@@ -180,6 +180,7 @@ class GatheringServiceTest {
 			given(gatheringRepository.existsByInvitationLink("INVITE_CODE")).willReturn(false);
 			given(gatheringRepository.save(any(Gathering.class))).willAnswer(invocation -> invocation.getArgument(0));
 			given(gatheringMemberRepository.save(any(GatheringMember.class))).willAnswer(invocation -> invocation.getArgument(0));
+			given(gatheringMemberRepository.countActiveMembersByStatus(any())).willReturn(1);
 
 			// when
 			GatheringCreateResponse response = gatheringService.createGathering(request);
@@ -214,6 +215,7 @@ class GatheringServiceTest {
 			given(gatheringRepository.existsByInvitationLink("UNIQUE_CODE")).willReturn(false);
 			given(gatheringRepository.save(any(Gathering.class))).willAnswer(invocation -> invocation.getArgument(0));
 			given(gatheringMemberRepository.save(any(GatheringMember.class))).willAnswer(invocation -> invocation.getArgument(0));
+			given(gatheringMemberRepository.countActiveMembersByStatus(any())).willReturn(1);
 
 			// when
 			GatheringCreateResponse response = gatheringService.createGathering(request);
@@ -747,6 +749,7 @@ class GatheringServiceTest {
 		String invitationLink = "https://invite.link/abc123";
 
 		given(gatheringValidator.validateInvitationLink(invitationLink)).willReturn(gathering1);
+		given(gatheringMemberRepository.countActiveMembersByStatus(gathering1.getId())).willReturn(2);
 
 		// when
 		GatheringCreateResponse response = gatheringService.getJoinGatheringInfo(invitationLink);
@@ -755,11 +758,12 @@ class GatheringServiceTest {
 		assertThat(response).isNotNull();
 		assertThat(response.gatheringName()).isEqualTo("독서 모임");
 		assertThat(response.invitationLink()).isEqualTo("https://invite.link/abc123");
-		assertThat(response.totalMembers()).isEqualTo(1);
+		assertThat(response.totalMembers()).isEqualTo(2);
 		assertThat(response.totalMeetings()).isEqualTo(1);
 		assertThat(response.daysFromCreation()).isEqualTo(gathering1.getDaysFromCreation());
 
 		verify(gatheringValidator, times(1)).validateInvitationLink(invitationLink);
+		verify(gatheringMemberRepository, times(1)).countActiveMembersByStatus(gathering1.getId());
 	}
 
 	@Test


### PR DESCRIPTION
## PR 요약
> 모임 정보 응답 시 daysFromCreation과 totalMembers 값 계산 방식 수정

- [ ] 기능 추가
- [x] 버그 수정
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 기타 (설명)

---

## 이슈 번호
- #116

---

## 주요 변경 사항

- `Gathering.java`: getDaysFromCreation() 메서드에 +1 추가 (1일차부터 시작)
- `GatheringMemberRepository.java`: countActiveMembersByStatus() 메서드 추가 (ACTIVE 상태 멤버만 카운트)
- `GatheringCreateResponse.java`: from() 메서드에 activeMembers 파라미터 추가
- `GatheringService.java`: getActiveMemberCount() 공통 메서드 추가, createGathering/getJoinGatheringInfo에 적용
- `GatheringServiceTest.java`: 변경된 메서드에 맞게 mock 추가

---

## 참고 사항

### 변경 전/후 비교

| 항목 | 변경 전 | 변경 후 |
|------|---------|---------|
| daysFromCreation | 0일부터 시작 | 1일부터 시작 |
| totalMembers | 하드코딩 또는 전체 멤버 | ACTIVE 상태 멤버만 카운트 |

### 영향 범위
- `POST /api/gatherings` (모임 생성)
- `GET /api/gatherings/join-request/{invitationLink}` (초대링크 모임 정보 조회)