### PR TITLE
[#122][FEAT] 개인 기록 수정 API 구현

### DIFF
--- a/src/main/java/com/dokdok/book/api/BookApi.java
+++ b/src/main/java/com/dokdok/book/api/BookApi.java
@@ -2,6 +2,7 @@ package com.dokdok.book.api;
 
 import com.dokdok.book.dto.request.BookCreateRequest;
 import com.dokdok.book.dto.request.PersonalReadingRecordCreateRequest;
+import com.dokdok.book.dto.request.PersonalReadingRecordUpdateRequest;
 import com.dokdok.book.dto.response.*;
 import com.dokdok.global.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -278,6 +279,7 @@ public interface BookApi {
                                               "code": "CREATED",
                                               "message": "기록 등록 성공",
                                               "data": {
+                                                "recordId": 5,
                                                 "recordType": "QUOTE",
                                                 "recordContent": "오늘 기억하고 싶은 문장을 기록합니다.",
                                                 "meta": {
@@ -320,5 +322,74 @@ public interface BookApi {
                     )
             )
             @RequestBody PersonalReadingRecordCreateRequest request
+    );
+
+    @Operation(
+            summary = "독서 기록 수정",
+            description = """
+                    내 책장에 있는 책의 독서 기록을 수정합니다.
+                    - 경로의 personalBookId와 recordId로 대상을 지정합니다.
+                    - 요청 본문: recordType(MEMO/QUOTE), recordContent, recordType이 QUOTE일 경우 meta에 page, excerpt 필수.
+                    - recordType이 MEMO이면 meta는 null로 저장됩니다.
+                    - 로그인한 사용자 기준으로 본인 책에만 기록을 수정할 수 있습니다.
+                    """
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "독서 기록 수정 성공",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = ApiResponse.class),
+                            examples = @io.swagger.v3.oas.annotations.media.ExampleObject(
+                                    value = """
+                                            {
+                                              "code": "SUCCESS",
+                                              "message": "기록 수정 성공",
+                                              "data": {
+                                                "recordId": 5,
+                                                "recordType": "QUOTE",
+                                                "recordContent": "문장을 다시 손봤습니다.",
+                                                "meta": {
+                                                  "page": 30,
+                                                  "excerpt": "수정된 인용문"
+                                                },
+                                                "personalBookId": 10
+                                              }
+                                            }
+                                            """
+                            ))
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청 (recordType 혹은 meta 오류)"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 실패 - 로그인이 필요합니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "책 또는 기록을 찾을 수 없음"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 오류")
+    })
+    @PatchMapping("/{personalBookId}/records/{recordId}")
+    ResponseEntity<ApiResponse<PersonalReadingRecordCreateResponse>> updateMyReadingRecord(
+            @Parameter(description = "수정할 개인 책 ID", required = true, example = "10")
+            @PathVariable Long personalBookId,
+            @Parameter(description = "수정할 기록 ID", required = true, example = "5")
+            @PathVariable Long recordId,
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    description = "수정할 독서 기록 내용 및 유형",
+                    required = true,
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = PersonalReadingRecordUpdateRequest.class),
+                            examples = @io.swagger.v3.oas.annotations.media.ExampleObject(
+                                    value = """
+                                            {
+                                              "recordType": "QUOTE",
+                                              "recordContent": "문장을 다시 손봤습니다.",
+                                              "meta": {
+                                                "page": 30,
+                                                "excerpt": "수정된 인용문"
+                                              }
+                                            }
+                                            """
+                            )
+                    )
+            )
+            @RequestBody PersonalReadingRecordUpdateRequest request
     );
 }

--- a/src/main/java/com/dokdok/book/controller/BookController.java
+++ b/src/main/java/com/dokdok/book/controller/BookController.java
@@ -3,6 +3,7 @@ package com.dokdok.book.controller;
 import com.dokdok.book.api.BookApi;
 import com.dokdok.book.dto.request.BookCreateRequest;
 import com.dokdok.book.dto.request.PersonalReadingRecordCreateRequest;
+import com.dokdok.book.dto.request.PersonalReadingRecordUpdateRequest;
 import com.dokdok.book.dto.response.*;
 import com.dokdok.book.service.BookService;
 import com.dokdok.book.service.PersonalBookService;
@@ -63,5 +64,12 @@ public class BookController implements BookApi {
     public ResponseEntity<ApiResponse<PersonalReadingRecordCreateResponse>> createMyReadingRecord(@PathVariable Long personalBookId, @RequestBody PersonalReadingRecordCreateRequest request) {
         PersonalReadingRecordCreateResponse response = personalReadingRecordService.create(personalBookId, request);
         return ApiResponse.created(response, "기록 등록 성공");
+    }
+
+    @Override
+    @PatchMapping("/{personalBookId}/records/{recordId}")
+    public ResponseEntity<ApiResponse<PersonalReadingRecordCreateResponse>> updateMyReadingRecord(@PathVariable Long personalBookId, @PathVariable Long recordId, @RequestBody PersonalReadingRecordUpdateRequest request) {
+        PersonalReadingRecordCreateResponse response = personalReadingRecordService.update(personalBookId, recordId, request);
+        return ApiResponse.success(response, "기록 수정 성공");
     }
 }

--- a/src/main/java/com/dokdok/book/dto/request/PersonalReadingRecordUpdateRequest.java
+++ b/src/main/java/com/dokdok/book/dto/request/PersonalReadingRecordUpdateRequest.java
@@ -1,0 +1,13 @@
+package com.dokdok.book.dto.request;
+
+import com.dokdok.book.entity.RecordType;
+
+import java.util.Map;
+
+public record PersonalReadingRecordUpdateRequest(
+        RecordType recordType,
+        String recordContent,
+        Map<String, Object> meta
+) {
+}
+

--- a/src/main/java/com/dokdok/book/dto/response/PersonalReadingRecordCreateResponse.java
+++ b/src/main/java/com/dokdok/book/dto/response/PersonalReadingRecordCreateResponse.java
@@ -8,6 +8,7 @@ import java.util.Map;
 
 @Builder
 public record PersonalReadingRecordCreateResponse(
+        Long recordId,
         RecordType recordType,
         String recordContent,
         Map<String, Object> meta,
@@ -16,6 +17,7 @@ public record PersonalReadingRecordCreateResponse(
 
     public static PersonalReadingRecordCreateResponse from(PersonalReadingRecord personalReadingRecordEntity) {
         return PersonalReadingRecordCreateResponse.builder()
+                .recordId(personalReadingRecordEntity.getId())
                 .recordType(personalReadingRecordEntity.getRecordType())
                 .recordContent(personalReadingRecordEntity.getRecordContent())
                 .meta(personalReadingRecordEntity.getMeta())
@@ -23,5 +25,4 @@ public record PersonalReadingRecordCreateResponse(
                 .build();
     }
 }
-
 

--- a/src/main/java/com/dokdok/book/entity/PersonalReadingRecord.java
+++ b/src/main/java/com/dokdok/book/entity/PersonalReadingRecord.java
@@ -61,4 +61,10 @@ public class PersonalReadingRecord extends BaseTimeEntity {
                 .build();
 
     }
+
+    public void update(RecordType recordType, String recordContent, Map<String, Object> meta) {
+        this.recordType = recordType;
+        this.recordContent = recordContent;
+        this.meta = meta;
+    }
 }

--- a/src/main/java/com/dokdok/book/exception/RecordErrorCode.java
+++ b/src/main/java/com/dokdok/book/exception/RecordErrorCode.java
@@ -9,7 +9,8 @@ import org.springframework.http.HttpStatus;
 @Getter
 public enum RecordErrorCode implements BaseErrorCode {
     INVALID_RECORD_REQUEST("R001", "기록 타입에 필요한 입력값이 누락되었습니다.", HttpStatus.BAD_REQUEST),
-    INVALID_RECORD_TYPE("R002", "존재하지 않는 타입입니다.", HttpStatus.BAD_REQUEST);
+    INVALID_RECORD_TYPE("R002", "존재하지 않는 타입입니다.", HttpStatus.BAD_REQUEST),
+    RECORD_NOT_FOUND("R003", "기록을 찾을 수 없습니다.", HttpStatus.NOT_FOUND);
 
     private final String code;
     private final String message;

--- a/src/main/java/com/dokdok/book/repository/PersonalReadingRecordRepository.java
+++ b/src/main/java/com/dokdok/book/repository/PersonalReadingRecordRepository.java
@@ -3,5 +3,8 @@ package com.dokdok.book.repository;
 import com.dokdok.book.entity.PersonalReadingRecord;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface PersonalReadingRecordRepository extends JpaRepository<PersonalReadingRecord, Long> {
+    Optional<PersonalReadingRecord> findByIdAndPersonalBookIdAndUserId(Long id, Long personalBookId, Long userId);
 }

--- a/src/main/java/com/dokdok/book/service/BookValidator.java
+++ b/src/main/java/com/dokdok/book/service/BookValidator.java
@@ -36,7 +36,7 @@ public class BookValidator {
     }
 
     public PersonalBook validateInBookShelf(Long userId, Long personalBookId) {
-        return personalBookRepository.findByUserIdAndBookId(userId, personalBookId)
+        return personalBookRepository.findByUserIdAndId(userId, personalBookId)
                 .orElseThrow(() -> new BookException(BookErrorCode.BOOK_NOT_IN_SHELF));
     }
 

--- a/src/main/java/com/dokdok/book/service/PersonalReadingRecordService.java
+++ b/src/main/java/com/dokdok/book/service/PersonalReadingRecordService.java
@@ -7,6 +7,7 @@ import com.dokdok.book.entity.PersonalReadingRecord;
 import com.dokdok.book.entity.RecordType;
 import com.dokdok.book.exception.RecordErrorCode;
 import com.dokdok.book.exception.RecordException;
+import com.dokdok.book.dto.request.PersonalReadingRecordUpdateRequest;
 import com.dokdok.book.repository.PersonalReadingRecordRepository;
 import com.dokdok.global.util.SecurityUtil;
 import com.dokdok.user.entity.User;
@@ -29,7 +30,9 @@ public class PersonalReadingRecordService {
     @Transactional
     public PersonalReadingRecordCreateResponse create(Long personalBookId, PersonalReadingRecordCreateRequest request) {
         User userEntity = userValidator.findUserOrThrow(SecurityUtil.getCurrentUserId());
-        PersonalBook personalBookEntity = bookValidator.validateInBookShelf(userEntity.getId(),personalBookId);
+        PersonalBook personalBookEntity = bookValidator.validateInBookShelf(userEntity.getId(), personalBookId);
+
+        Map<String, Object> normalizedMeta = normalizeMeta(request.recordType(), request.meta());
 
         PersonalReadingRecord personalReadingRecordEntity =
                 PersonalReadingRecord.create(
@@ -37,14 +40,38 @@ public class PersonalReadingRecordService {
                         userEntity,
                         request.recordType(),
                         request.recordContent(),
-                        normalizeMeta(request.recordType(), request.meta())
+                        normalizedMeta
                         );
         personalReadingRecordRepository.save(personalReadingRecordEntity);
 
         return PersonalReadingRecordCreateResponse.from(personalReadingRecordEntity);
     }
 
+    @Transactional
+    public PersonalReadingRecordCreateResponse update(Long personalBookId, Long recordId, PersonalReadingRecordUpdateRequest request) {
+        User userEntity = userValidator.findUserOrThrow(SecurityUtil.getCurrentUserId());
+        PersonalBook personalBookEntity = bookValidator.validateInBookShelf(userEntity.getId(), personalBookId);
+
+        PersonalReadingRecord personalReadingRecord = personalReadingRecordRepository
+                .findByIdAndPersonalBookIdAndUserId(recordId, personalBookEntity.getId(), userEntity.getId())
+                .orElseThrow(() -> new RecordException(RecordErrorCode.RECORD_NOT_FOUND));
+
+        Map<String, Object> normalizedMeta = normalizeMeta(request.recordType(), request.meta());
+
+        personalReadingRecord.update(
+                request.recordType(),
+                request.recordContent(),
+                normalizedMeta
+        );
+
+        return PersonalReadingRecordCreateResponse.from(personalReadingRecord);
+    }
+
     private Map<String, Object> normalizeMeta(RecordType recordType, Map<String, Object> meta) {
+        if (recordType == null) {
+            throw new RecordException(RecordErrorCode.INVALID_RECORD_TYPE);
+        }
+
         if (recordType == RecordType.MEMO) {
             return null;
         }

--- a/src/test/java/com/dokdok/book/service/PersonalReadingRecordServiceTest.java
+++ b/src/test/java/com/dokdok/book/service/PersonalReadingRecordServiceTest.java
@@ -1,10 +1,12 @@
 package com.dokdok.book.service;
 
 import com.dokdok.book.dto.request.PersonalReadingRecordCreateRequest;
+import com.dokdok.book.dto.request.PersonalReadingRecordUpdateRequest;
 import com.dokdok.book.dto.response.PersonalReadingRecordCreateResponse;
 import com.dokdok.book.entity.Book;
 import com.dokdok.book.entity.BookReadingStatus;
 import com.dokdok.book.entity.PersonalBook;
+import com.dokdok.book.entity.PersonalReadingRecord;
 import com.dokdok.book.entity.RecordType;
 import com.dokdok.book.exception.RecordErrorCode;
 import com.dokdok.book.exception.RecordException;
@@ -25,6 +27,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -218,6 +221,174 @@ class PersonalReadingRecordServiceTest {
                 .isInstanceOf(RecordException.class)
                 .hasFieldOrPropertyWithValue("errorCode", RecordErrorCode.INVALID_RECORD_REQUEST);
 
+        verify(personalReadingRecordRepository, never()).save(any());
+        securityUtilMock.verify(SecurityUtil::getCurrentUserId, times(1));
+        verify(userValidator, times(1)).findUserOrThrow(userId);
+        verify(bookValidator, times(1)).validateInBookShelf(userId, personalBookId);
+    }
+
+    @Test
+    @DisplayName("독서 기록을 수정하면 내용과 meta가 업데이트된다")
+    void updateRecord_Success() {
+        // given
+        Long userId = 1L;
+        Long personalBookId = 40L;
+        Long recordId = 5L;
+
+        Map<String, Object> meta = new HashMap<>();
+        meta.put("page", "30");
+        meta.put("excerpt", "수정된 인용문");
+
+        PersonalReadingRecordUpdateRequest request = new PersonalReadingRecordUpdateRequest(
+                RecordType.QUOTE,
+                "수정된 기록 내용",
+                meta
+        );
+
+        User user = User.builder()
+                .id(userId)
+                .kakaoId(222L)
+                .nickname("editor")
+                .build();
+
+        PersonalBook personalBook = PersonalBook.builder()
+                .id(personalBookId)
+                .user(user)
+                .book(Book.builder().id(400L).isbn("9781111111111").bookName("책").author("저자").publisher("출판").build())
+                .readingStatus(BookReadingStatus.READING)
+                .build();
+
+        PersonalReadingRecord record = PersonalReadingRecord.builder()
+                .id(recordId)
+                .personalBook(personalBook)
+                .user(user)
+                .recordType(RecordType.MEMO)
+                .recordContent("이전 내용")
+                .build();
+
+        securityUtilMock.when(SecurityUtil::getCurrentUserId).thenReturn(userId);
+        when(userValidator.findUserOrThrow(userId)).thenReturn(user);
+        when(bookValidator.validateInBookShelf(userId, personalBookId)).thenReturn(personalBook);
+        when(personalReadingRecordRepository.findByIdAndPersonalBookIdAndUserId(recordId, personalBookId, userId))
+                .thenReturn(Optional.of(record));
+
+        // when
+        PersonalReadingRecordCreateResponse response = personalReadingRecordService.update(personalBookId, recordId, request);
+
+        // then
+        assertThat(response.recordId()).isEqualTo(recordId);
+        assertThat(response.recordContent()).isEqualTo(request.recordContent());
+        assertThat(response.recordType()).isEqualTo(RecordType.QUOTE);
+        assertThat(response.meta()).isNotNull();
+        assertThat(response.meta().get("page")).isEqualTo(30);
+        assertThat(response.meta().get("excerpt")).isEqualTo("수정된 인용문");
+
+        assertThat(record.getRecordContent()).isEqualTo(request.recordContent());
+        assertThat(record.getRecordType()).isEqualTo(RecordType.QUOTE);
+        assertThat(record.getMeta().get("page")).isEqualTo(30);
+
+        verify(personalReadingRecordRepository, times(1))
+                .findByIdAndPersonalBookIdAndUserId(recordId, personalBookId, userId);
+        verify(personalReadingRecordRepository, never()).save(any());
+        securityUtilMock.verify(SecurityUtil::getCurrentUserId, times(1));
+        verify(userValidator, times(1)).findUserOrThrow(userId);
+        verify(bookValidator, times(1)).validateInBookShelf(userId, personalBookId);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 기록을 수정하려 하면 예외가 발생한다")
+    void updateRecord_NotFound() {
+        // given
+        Long userId = 1L;
+        Long personalBookId = 50L;
+        Long recordId = 999L;
+
+        PersonalReadingRecordUpdateRequest request = new PersonalReadingRecordUpdateRequest(
+                RecordType.MEMO,
+                "내용",
+                null
+        );
+
+        User user = User.builder()
+                .id(userId)
+                .kakaoId(333L)
+                .nickname("reader")
+                .build();
+
+        PersonalBook personalBook = PersonalBook.builder()
+                .id(personalBookId)
+                .user(user)
+                .book(Book.builder().id(500L).isbn("9782222222222").bookName("책").author("저자").publisher("출판").build())
+                .readingStatus(BookReadingStatus.READING)
+                .build();
+
+        securityUtilMock.when(SecurityUtil::getCurrentUserId).thenReturn(userId);
+        when(userValidator.findUserOrThrow(userId)).thenReturn(user);
+        when(bookValidator.validateInBookShelf(userId, personalBookId)).thenReturn(personalBook);
+        when(personalReadingRecordRepository.findByIdAndPersonalBookIdAndUserId(recordId, personalBookId, userId))
+                .thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> personalReadingRecordService.update(personalBookId, recordId, request))
+                .isInstanceOf(RecordException.class)
+                .hasFieldOrPropertyWithValue("errorCode", RecordErrorCode.RECORD_NOT_FOUND);
+
+        verify(personalReadingRecordRepository, times(1))
+                .findByIdAndPersonalBookIdAndUserId(recordId, personalBookId, userId);
+        verify(personalReadingRecordRepository, never()).save(any());
+        securityUtilMock.verify(SecurityUtil::getCurrentUserId, times(1));
+        verify(userValidator, times(1)).findUserOrThrow(userId);
+        verify(bookValidator, times(1)).validateInBookShelf(userId, personalBookId);
+    }
+
+    @Test
+    @DisplayName("인용 기록 수정 시 meta가 없으면 RecordException이 발생한다")
+    void updateQuoteRecord_MissingMeta() {
+        // given
+        Long userId = 1L;
+        Long personalBookId = 60L;
+        Long recordId = 7L;
+
+        PersonalReadingRecordUpdateRequest request = new PersonalReadingRecordUpdateRequest(
+                RecordType.QUOTE,
+                "인용 수정",
+                null
+        );
+
+        User user = User.builder()
+                .id(userId)
+                .kakaoId(444L)
+                .nickname("reader")
+                .build();
+
+        PersonalBook personalBook = PersonalBook.builder()
+                .id(personalBookId)
+                .user(user)
+                .book(Book.builder().id(600L).isbn("9783333333333").bookName("책").author("저자").publisher("출판").build())
+                .readingStatus(BookReadingStatus.READING)
+                .build();
+
+        PersonalReadingRecord record = PersonalReadingRecord.builder()
+                .id(recordId)
+                .personalBook(personalBook)
+                .user(user)
+                .recordType(RecordType.QUOTE)
+                .recordContent("기존 내용")
+                .build();
+
+        securityUtilMock.when(SecurityUtil::getCurrentUserId).thenReturn(userId);
+        when(userValidator.findUserOrThrow(userId)).thenReturn(user);
+        when(bookValidator.validateInBookShelf(userId, personalBookId)).thenReturn(personalBook);
+        when(personalReadingRecordRepository.findByIdAndPersonalBookIdAndUserId(recordId, personalBookId, userId))
+                .thenReturn(Optional.of(record));
+
+        // when & then
+        assertThatThrownBy(() -> personalReadingRecordService.update(personalBookId, recordId, request))
+                .isInstanceOf(RecordException.class)
+                .hasFieldOrPropertyWithValue("errorCode", RecordErrorCode.INVALID_RECORD_REQUEST);
+
+        verify(personalReadingRecordRepository, times(1))
+                .findByIdAndPersonalBookIdAndUserId(recordId, personalBookId, userId);
         verify(personalReadingRecordRepository, never()).save(any());
         securityUtilMock.verify(SecurityUtil::getCurrentUserId, times(1));
         verify(userValidator, times(1)).findUserOrThrow(userId);


### PR DESCRIPTION
## PR 요약
  내 책장의 독서 기록 PATCH API를 추가하고 응답/검증 로직을 보완했습니다.
  - [x] 기능 추가
  - [x] 버그 수정
  - [ ] 코드 리팩토링
  - [ ] 문서 수정
  - [ ] 기타 (설명)

  ---

  ## 이슈 번호
  - #122 

  ---

  ## 주요 변경 사항
  - `src/main/java/com/dokdok/book/api/BookApi.java`: 독서 기록 PATCH 스펙 및 예시 응답(기록 ID 포함) 추가
  - `src/main/java/com/dokdok/book/controller/BookController.java`: `/ {personalBookId}/records/{recordId}` PATCH 엔드포인트를 서비스에 연결
  - `src/main/java/com/dokdok/book/service/PersonalReadingRecordService.java`, `src/main/java/com/dokdok/book/entity/PersonalReadingRecord.java`, `src/main/java/com/dokdok/book/exception/RecordErrorCode.java`: 소유자/책 검증 후 기록 수정 로직 구현, recordType null 검증과 meta 정규화, 엔티티 업데이트 메서드 및
  RECORD_NOT_FOUND 에러 추가
  - `src/main/java/com/dokdok/book/dto/response/PersonalReadingRecordCreateResponse.java`: 기록 응답에 `recordId` 포함
  - `src/main/java/com/dokdok/book/repository/PersonalReadingRecordRepository.java`, `src/main/java/com/dokdok/book/service/BookValidator.java`: 사용자·개인책 기준 기록 조회 쿼리 추가 및 개인책 검증 시 PK로 조회하도록 수정
  - `src/test/java/com/dokdok/book/service/PersonalReadingRecordServiceTest.java`: 기록 수정 성공/미존재/메타 누락 시나리오 단위 테스트 추가

  ---

  ## 참고 사항