### PR TITLE
[#112][FEAT] 공동 회고 조회

### DIFF
--- a/src/main/java/com/dokdok/meeting/entity/Meeting.java
+++ b/src/main/java/com/dokdok/meeting/entity/Meeting.java
@@ -15,6 +15,7 @@ import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.SQLRestriction;
 
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 
 @Entity
 @Table(name = "meeting")
@@ -128,4 +129,10 @@ public class Meeting extends BaseTimeEntity {
             this.maxParticipants = request.maxParticipants();
         }
     }
+
+    public String getFormattedTime() {
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("HH:mm");
+        return meetingStartDate.format(formatter) + "-" + meetingEndDate.format(formatter);
+    }
+
 }

--- a/src/main/java/com/dokdok/retrospective/api/MeetingRetrospectiveApi.java
+++ b/src/main/java/com/dokdok/retrospective/api/MeetingRetrospectiveApi.java
@@ -1,0 +1,42 @@
+package com.dokdok.retrospective.api;
+
+import com.dokdok.global.response.ApiResponse;
+import com.dokdok.retrospective.dto.response.MeetingRetrospectiveResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@Tag(name = "공동 회고", description = "공동 회고 관련 API")
+public interface MeetingRetrospectiveApi {
+
+    @Operation(
+            summary = "공동 회고 조회",
+            description = "약속에 대한 공동 회고를 조회합니다.",
+            parameters = {
+                    @Parameter(name = "meetingId", description = "약속 식별자", in = ParameterIn.PATH, required = true)
+            }
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "공동 회고 조회 성공",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = MeetingRetrospectiveResponse.class))
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "접근 권한 없음"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "약속을 찾을 수 없음"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 오류")
+    })
+    @GetMapping(produces = MediaType.APPLICATION_JSON_VALUE)
+    ResponseEntity<ApiResponse<MeetingRetrospectiveResponse>> getMeetingRetrospective(
+            @PathVariable Long meetingId
+    );
+}

--- a/src/main/java/com/dokdok/retrospective/controller/MeetingRetrospectiveController.java
+++ b/src/main/java/com/dokdok/retrospective/controller/MeetingRetrospectiveController.java
@@ -1,0 +1,28 @@
+package com.dokdok.retrospective.controller;
+
+import com.dokdok.global.response.ApiResponse;
+import com.dokdok.retrospective.api.MeetingRetrospectiveApi;
+import com.dokdok.retrospective.dto.response.MeetingRetrospectiveResponse;
+import com.dokdok.retrospective.service.MeetingRetrospectiveService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/meetings/{meetingId}/retrospectives")
+public class MeetingRetrospectiveController implements MeetingRetrospectiveApi {
+
+    private final MeetingRetrospectiveService meetingRetrospectiveService;
+
+    @Override
+    @GetMapping
+    public ResponseEntity<ApiResponse<MeetingRetrospectiveResponse>> getMeetingRetrospective(@PathVariable Long meetingId) {
+        MeetingRetrospectiveResponse response = meetingRetrospectiveService.getMeetingRetrospective(meetingId);
+
+        return ApiResponse.success(response,"공동 회고 조회 성공");
+    }
+}

--- a/src/main/java/com/dokdok/retrospective/dto/response/MeetingRetrospectiveResponse.java
+++ b/src/main/java/com/dokdok/retrospective/dto/response/MeetingRetrospectiveResponse.java
@@ -1,0 +1,77 @@
+package com.dokdok.retrospective.dto.response;
+
+import com.dokdok.meeting.entity.Meeting;
+import com.dokdok.retrospective.entity.MeetingRetrospective;
+import com.dokdok.retrospective.entity.TopicRetrospectiveSummary;
+import com.dokdok.topic.entity.Topic;
+import lombok.Builder;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+
+@Builder
+public record MeetingRetrospectiveResponse(
+        Long meetingId,
+        String meetingName,
+        LocalDate meetingDate,
+        String meetingTime,
+        List<TopicResponse> topics
+) {
+    public static MeetingRetrospectiveResponse from (
+            Meeting meeting,
+            List<TopicResponse> topics
+    ){
+        return MeetingRetrospectiveResponse.builder()
+                .meetingId(meeting.getId())
+                .meetingName(meeting.getMeetingName())
+                .meetingDate(meeting.getMeetingStartDate().toLocalDate())
+                .meetingTime(meeting.getFormattedTime())
+                .topics(topics)
+                .build();
+    }
+
+    @Builder
+    public record TopicResponse(
+            Long topicId,
+            String topicName,
+            List<String> summarizedOpinions,
+            List<CommentResponse> comments
+    ){
+        public static TopicResponse from(
+                Topic topic,
+                TopicRetrospectiveSummary summary,
+                List<CommentResponse> comments
+        ) {
+            return TopicResponse.builder()
+                    .topicId(topic.getId())
+                    .topicName(topic.getTitle())
+                    .summarizedOpinions(summary.getSummarizedOpinions())
+                    .comments(comments)
+                    .build();
+        }
+    }
+
+    @Builder
+    public record CommentResponse(
+            Long meetingRetrospectiveId,
+            Long userId,
+            String nickname,
+            String profileImageUrl,
+            String comment,
+            LocalDateTime createdAt
+    ) {
+
+        public static CommentResponse from(MeetingRetrospective retrospective) {
+            return CommentResponse.builder()
+                    .meetingRetrospectiveId(retrospective.getId())
+                    .userId(retrospective.getCreatedBy().getId())
+                    .nickname(retrospective.getCreatedBy().getNickname())
+                    .profileImageUrl(retrospective.getCreatedBy().getProfileImageUrl())
+                    .comment(retrospective.getComment())
+                    .createdAt(retrospective.getCreatedAt())
+                    .build();
+        }
+    }
+}

--- a/src/main/java/com/dokdok/retrospective/entity/MeetingRetrospective.java
+++ b/src/main/java/com/dokdok/retrospective/entity/MeetingRetrospective.java
@@ -1,0 +1,44 @@
+package com.dokdok.retrospective.entity;
+
+import com.dokdok.global.BaseTimeEntity;
+import com.dokdok.meeting.entity.Meeting;
+import com.dokdok.topic.entity.Topic;
+import com.dokdok.user.entity.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
+
+@Entity
+@Table(name = "meeting_retrospective")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@SuperBuilder
+@SQLDelete(sql = "UPDATE meeting_retrospective SET deleted_at = CURRENT_TIMESTAMP WHERE meeting_retrospective_id = ?")
+@SQLRestriction("deleted_at IS NULL")
+public class MeetingRetrospective extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "meeting_retrospective_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "meeting_id", nullable = false)
+    private Meeting meeting;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "created_by", nullable = false)
+    private User createdBy;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "topic_id")
+    private Topic topic;
+
+    @Column(name = "comment", columnDefinition = "TEXT")
+    private String comment;
+}

--- a/src/main/java/com/dokdok/retrospective/entity/TopicRetrospectiveSummary.java
+++ b/src/main/java/com/dokdok/retrospective/entity/TopicRetrospectiveSummary.java
@@ -1,0 +1,41 @@
+package com.dokdok.retrospective.entity;
+
+import com.dokdok.global.BaseTimeEntity;
+import com.dokdok.topic.entity.Topic;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
+import org.hibernate.type.SqlTypes;
+
+import java.util.List;
+import java.util.Map;
+
+@Entity
+@Table(name = "topic_retrospective_summary")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@SuperBuilder
+@SQLDelete(sql = "UPDATE topic_retrospective_summary SET deleted_at = CURRENT_TIMESTAMP WHERE topic_retrospective_summary_id = ?")
+@SQLRestriction("deleted_at IS NULL")
+public class TopicRetrospectiveSummary extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "topic_retrospective_summary_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "topic_id")
+    private Topic topic;
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "summarized_opinions", columnDefinition = "jsonb")
+    private List<String> summarizedOpinions;
+}

--- a/src/main/java/com/dokdok/retrospective/repository/RetrospectiveRepository.java
+++ b/src/main/java/com/dokdok/retrospective/repository/RetrospectiveRepository.java
@@ -1,0 +1,15 @@
+package com.dokdok.retrospective.repository;
+
+import com.dokdok.retrospective.entity.MeetingRetrospective;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface RetrospectiveRepository extends JpaRepository<MeetingRetrospective, Long> {
+
+    List<MeetingRetrospective> findAllByMeetingId(Long meetingId);
+
+    List<MeetingRetrospective> findAllByTopicId(Long topicId);
+}

--- a/src/main/java/com/dokdok/retrospective/repository/TopicRetrospectiveSummaryRepository.java
+++ b/src/main/java/com/dokdok/retrospective/repository/TopicRetrospectiveSummaryRepository.java
@@ -1,0 +1,17 @@
+package com.dokdok.retrospective.repository;
+
+import com.dokdok.retrospective.entity.TopicRetrospectiveSummary;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface TopicRetrospectiveSummaryRepository extends JpaRepository<TopicRetrospectiveSummary, Long> {
+
+    Optional<TopicRetrospectiveSummary> findByTopicId(Long topicId);
+
+    List<TopicRetrospectiveSummary> findAllByTopicIdIn(Collection<Long> topicIds);
+}

--- a/src/main/java/com/dokdok/retrospective/service/MeetingRetrospectiveService.java
+++ b/src/main/java/com/dokdok/retrospective/service/MeetingRetrospectiveService.java
@@ -33,8 +33,9 @@ public class MeetingRetrospectiveService {
     private final RetrospectiveRepository retrospectiveRepository;
 
     public MeetingRetrospectiveResponse getMeetingRetrospective(Long meetingId){
-        // Meeting 조회
         Long userId = SecurityUtil.getCurrentUserId();
+
+        // Meeting 조회
         Meeting meeting = meetingRepository.findById(meetingId)
                 .orElseThrow(() -> new MeetingException(MeetingErrorCode.MEETING_NOT_FOUND));
 

--- a/src/main/java/com/dokdok/retrospective/service/MeetingRetrospectiveService.java
+++ b/src/main/java/com/dokdok/retrospective/service/MeetingRetrospectiveService.java
@@ -1,0 +1,87 @@
+package com.dokdok.retrospective.service;
+
+import com.dokdok.global.util.SecurityUtil;
+import com.dokdok.meeting.entity.Meeting;
+import com.dokdok.meeting.exception.MeetingErrorCode;
+import com.dokdok.meeting.exception.MeetingException;
+import com.dokdok.meeting.repository.MeetingRepository;
+import com.dokdok.retrospective.dto.response.MeetingRetrospectiveResponse;
+import com.dokdok.retrospective.entity.MeetingRetrospective;
+import com.dokdok.retrospective.entity.TopicRetrospectiveSummary;
+import com.dokdok.retrospective.repository.RetrospectiveRepository;
+import com.dokdok.retrospective.repository.TopicRetrospectiveSummaryRepository;
+import com.dokdok.topic.entity.Topic;
+import com.dokdok.topic.entity.TopicStatus;
+import com.dokdok.topic.repository.TopicRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MeetingRetrospectiveService {
+
+    private final MeetingRepository meetingRepository;
+    private final TopicRepository topicRepository;
+    private final RetrospectiveValidator retrospectiveValidator;
+    private final TopicRetrospectiveSummaryRepository topicRetrospectiveSummaryRepository;
+    private final RetrospectiveRepository retrospectiveRepository;
+
+    public MeetingRetrospectiveResponse getMeetingRetrospective(Long meetingId){
+        // Meeting 조회
+        Long userId = SecurityUtil.getCurrentUserId();
+        Meeting meeting = meetingRepository.findById(meetingId)
+                .orElseThrow(() -> new MeetingException(MeetingErrorCode.MEETING_NOT_FOUND));
+
+        // 권한 검증
+        retrospectiveValidator.validateMeetingRetrospectiveAccess(
+                meeting.getGathering().getId(),
+                meetingId,
+                userId
+        );
+
+        // 확정된 토픽 조회 (confirmOrder 순)
+        List<Topic> topics = topicRepository.findByMeetingIdAndTopicStatusOrderByConfirmOrderAsc(meetingId, TopicStatus.CONFIRMED);
+
+        // 토픽별 요약 조회
+        List<Long> topicIds = topics.stream()
+                .map(Topic::getId)
+                .toList();
+
+        Map<Long, TopicRetrospectiveSummary> summaryMap = topicRetrospectiveSummaryRepository
+                .findAllByTopicIdIn(topicIds)
+                .stream()
+                .collect(Collectors.toMap(s-> s.getTopic().getId(), s->s));
+
+        // 토픽별 회고 조회
+        List<MeetingRetrospective> allComments = retrospectiveRepository.findAllByMeetingId(meetingId);
+
+        Map<Long, List<MeetingRetrospective>> commentsByTopic = allComments.stream()
+                .filter(r-> r.getTopic() != null)
+                .collect(Collectors.groupingBy(r-> r.getTopic().getId()));
+
+        List<MeetingRetrospectiveResponse.TopicResponse> topicResponses = topics.stream()
+                .map(topic -> MeetingRetrospectiveResponse.TopicResponse.from(
+                        topic,
+                        summaryMap.get(topic.getId()),
+                        buildCommentResponses(commentsByTopic.get(topic.getId()))
+                ))
+                .toList();
+
+        return MeetingRetrospectiveResponse.from(meeting,topicResponses);
+    }
+
+    private List<MeetingRetrospectiveResponse.CommentResponse> buildCommentResponses(List<MeetingRetrospective> comments) {
+        if (comments == null || comments.isEmpty()) {
+            return List.of();
+        }
+        return comments.stream()
+                .map(MeetingRetrospectiveResponse.CommentResponse::from)
+                .toList();
+    }
+}

--- a/src/main/java/com/dokdok/retrospective/service/RetrospectiveValidator.java
+++ b/src/main/java/com/dokdok/retrospective/service/RetrospectiveValidator.java
@@ -3,10 +3,12 @@ package com.dokdok.retrospective.service;
 import com.dokdok.gathering.exception.GatheringErrorCode;
 import com.dokdok.gathering.exception.GatheringException;
 import com.dokdok.gathering.repository.GatheringMemberRepository;
+import com.dokdok.gathering.service.GatheringValidator;
 import com.dokdok.meeting.exception.MeetingErrorCode;
 import com.dokdok.meeting.exception.MeetingException;
 import com.dokdok.meeting.repository.MeetingMemberRepository;
 import com.dokdok.meeting.repository.MeetingRepository;
+import com.dokdok.meeting.service.MeetingValidator;
 import com.dokdok.retrospective.exception.RetrospectiveErrorCode;
 import com.dokdok.retrospective.exception.RetrospectiveException;
 import com.dokdok.retrospective.repository.PersonalRetrospectiveRepository;
@@ -18,8 +20,8 @@ import org.springframework.stereotype.Service;
 public class RetrospectiveValidator {
 
     private final PersonalRetrospectiveRepository personalRetrospectiveRepository;
-    private final GatheringMemberRepository gatheringMemberRepository;
-    private final MeetingMemberRepository meetingMemberRepository;
+    private final GatheringValidator gatheringValidator;
+    private final MeetingValidator meetingValidator;
 
     public void validateRetrospective(Long meetingId, Long userId){
         boolean exists = personalRetrospectiveRepository.existsByMeetingIdAndUserId(meetingId, userId);
@@ -30,11 +32,9 @@ public class RetrospectiveValidator {
     }
 
     public void validateMeetingRetrospectiveAccess(Long gatheringId, Long meetingId, Long userId) {
-        gatheringMemberRepository.findByGatheringIdAndUserId(gatheringId, userId)
-                .orElseThrow(() -> new GatheringException(GatheringErrorCode.NOT_GATHERING_MEMBER));
+        gatheringValidator.validateMembership(gatheringId, userId);
 
-        meetingMemberRepository.findByMeetingIdAndUserId(meetingId, userId)
-                .orElseThrow(() -> new MeetingException(MeetingErrorCode.NOT_GATHERING_MEETING));
+        meetingValidator.validateMeetingInGathering(meetingId, gatheringId);
     }
 
     public void validateRetrospective(Long retrospectiveId){

--- a/src/main/java/com/dokdok/retrospective/service/RetrospectiveValidator.java
+++ b/src/main/java/com/dokdok/retrospective/service/RetrospectiveValidator.java
@@ -29,12 +29,14 @@ public class RetrospectiveValidator {
         }
     }
 
-    public void validateMeetingRetrospectiveAccess(Long gatheringId, Long meetingId, Long userId){
-        gatheringMemberRepository.findByGatheringIdAndUserId(gatheringId,userId)
+    public void validateMeetingRetrospectiveAccess(Long gatheringId, Long meetingId, Long userId) {
+        gatheringMemberRepository.findByGatheringIdAndUserId(gatheringId, userId)
                 .orElseThrow(() -> new GatheringException(GatheringErrorCode.NOT_GATHERING_MEMBER));
 
         meetingMemberRepository.findByMeetingIdAndUserId(meetingId, userId)
                 .orElseThrow(() -> new MeetingException(MeetingErrorCode.NOT_GATHERING_MEETING));
+    }
+
     public void validateRetrospective(Long retrospectiveId){
         boolean exists = personalRetrospectiveRepository.existsById(retrospectiveId);
 

--- a/src/main/java/com/dokdok/retrospective/service/RetrospectiveValidator.java
+++ b/src/main/java/com/dokdok/retrospective/service/RetrospectiveValidator.java
@@ -1,5 +1,12 @@
 package com.dokdok.retrospective.service;
 
+import com.dokdok.gathering.exception.GatheringErrorCode;
+import com.dokdok.gathering.exception.GatheringException;
+import com.dokdok.gathering.repository.GatheringMemberRepository;
+import com.dokdok.meeting.exception.MeetingErrorCode;
+import com.dokdok.meeting.exception.MeetingException;
+import com.dokdok.meeting.repository.MeetingMemberRepository;
+import com.dokdok.meeting.repository.MeetingRepository;
 import com.dokdok.retrospective.exception.RetrospectiveErrorCode;
 import com.dokdok.retrospective.exception.RetrospectiveException;
 import com.dokdok.retrospective.repository.PersonalRetrospectiveRepository;
@@ -11,6 +18,8 @@ import org.springframework.stereotype.Service;
 public class RetrospectiveValidator {
 
     private final PersonalRetrospectiveRepository personalRetrospectiveRepository;
+    private final GatheringMemberRepository gatheringMemberRepository;
+    private final MeetingMemberRepository meetingMemberRepository;
 
     public void validateRetrospective(Long meetingId, Long userId){
         boolean exists = personalRetrospectiveRepository.existsByMeetingIdAndUserId(meetingId, userId);
@@ -20,5 +29,12 @@ public class RetrospectiveValidator {
         }
     }
 
+    public void validateMeetingRetrospectiveAccess(Long gatheringId, Long meetingId, Long userId){
+        gatheringMemberRepository.findByGatheringIdAndUserId(gatheringId,userId)
+                .orElseThrow(() -> new GatheringException(GatheringErrorCode.NOT_GATHERING_MEMBER));
+
+        meetingMemberRepository.findByMeetingIdAndUserId(meetingId, userId)
+                .orElseThrow(() -> new MeetingException(MeetingErrorCode.NOT_GATHERING_MEETING));
+    }
 
 }

--- a/src/test/java/com/dokdok/retrospective/service/MeetingRetrospectiveServiceTest.java
+++ b/src/test/java/com/dokdok/retrospective/service/MeetingRetrospectiveServiceTest.java
@@ -1,0 +1,232 @@
+package com.dokdok.retrospective.service;
+
+import com.dokdok.gathering.entity.Gathering;
+import com.dokdok.gathering.exception.GatheringErrorCode;
+import com.dokdok.gathering.exception.GatheringException;
+import com.dokdok.global.exception.GlobalErrorCode;
+import com.dokdok.global.exception.GlobalException;
+import com.dokdok.global.util.SecurityUtil;
+import com.dokdok.meeting.entity.Meeting;
+import com.dokdok.meeting.exception.MeetingErrorCode;
+import com.dokdok.meeting.exception.MeetingException;
+import com.dokdok.meeting.repository.MeetingRepository;
+import com.dokdok.retrospective.dto.response.MeetingRetrospectiveResponse;
+import com.dokdok.retrospective.entity.MeetingRetrospective;
+import com.dokdok.retrospective.entity.TopicRetrospectiveSummary;
+import com.dokdok.retrospective.repository.RetrospectiveRepository;
+import com.dokdok.retrospective.repository.TopicRetrospectiveSummaryRepository;
+import com.dokdok.topic.entity.Topic;
+import com.dokdok.topic.entity.TopicStatus;
+import com.dokdok.topic.repository.TopicRepository;
+import com.dokdok.user.entity.User;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class MeetingRetrospectiveServiceTest {
+
+	@Mock
+	private MeetingRepository meetingRepository;
+
+	@Mock
+	private TopicRepository topicRepository;
+
+	@Mock
+	private RetrospectiveValidator retrospectiveValidator;
+
+	@Mock
+	private TopicRetrospectiveSummaryRepository topicRetrospectiveSummaryRepository;
+
+	@Mock
+	private RetrospectiveRepository retrospectiveRepository;
+
+	@InjectMocks
+	private MeetingRetrospectiveService meetingRetrospectiveService;
+
+	@Test
+	@DisplayName("약속이 없으면 예외가 발생한다")
+	void getMeetingRetrospective_throwsWhenMeetingNotFound() {
+		// given
+		Long meetingId = 999L;
+		Long userId = 1L;
+
+		try (MockedStatic<SecurityUtil> securityUtilMock = mockStatic(SecurityUtil.class)) {
+			securityUtilMock.when(SecurityUtil::getCurrentUserId).thenReturn(userId);
+
+			when(meetingRepository.findById(meetingId)).thenReturn(Optional.empty());
+
+			// when & then
+			assertThatThrownBy(() -> meetingRetrospectiveService.getMeetingRetrospective(meetingId))
+					.isInstanceOf(MeetingException.class)
+					.hasFieldOrPropertyWithValue("errorCode", MeetingErrorCode.MEETING_NOT_FOUND);
+
+			verify(retrospectiveValidator, never()).validateMeetingRetrospectiveAccess(any(), any(), any());
+		}
+	}
+
+	@Test
+	@DisplayName("모임 멤버가 아니면 예외가 발생한다")
+	void getMeetingRetrospective_throwsWhenNotGatheringMember() {
+		// given
+		Long meetingId = 1L;
+		Long userId = 999L;
+		Long gatheringId = 1L;
+
+		Gathering gathering = Gathering.builder().id(gatheringId).build();
+		Meeting meeting = Meeting.builder().id(meetingId).gathering(gathering).build();
+
+		try (MockedStatic<SecurityUtil> securityUtilMock = mockStatic(SecurityUtil.class)) {
+			securityUtilMock.when(SecurityUtil::getCurrentUserId).thenReturn(userId);
+
+			when(meetingRepository.findById(meetingId)).thenReturn(Optional.of(meeting));
+			doThrow(new GatheringException(GatheringErrorCode.NOT_GATHERING_MEMBER))
+					.when(retrospectiveValidator).validateMeetingRetrospectiveAccess(gatheringId, meetingId, userId);
+
+			// when & then
+			assertThatThrownBy(() -> meetingRetrospectiveService.getMeetingRetrospective(meetingId))
+					.isInstanceOf(GatheringException.class)
+					.hasFieldOrPropertyWithValue("errorCode", GatheringErrorCode.NOT_GATHERING_MEMBER);
+
+			verify(topicRepository, never()).findByMeetingIdAndTopicStatusOrderByConfirmOrderAsc(any(), any());
+		}
+	}
+
+	@Test
+	@DisplayName("약속 멤버가 아니면 예외가 발생한다")
+	void getMeetingRetrospective_throwsWhenNotMeetingMember() {
+		// given
+		Long meetingId = 1L;
+		Long userId = 999L;
+		Long gatheringId = 1L;
+
+		Gathering gathering = Gathering.builder().id(gatheringId).build();
+		Meeting meeting = Meeting.builder().id(meetingId).gathering(gathering).build();
+
+		try (MockedStatic<SecurityUtil> securityUtilMock = mockStatic(SecurityUtil.class)) {
+			securityUtilMock.when(SecurityUtil::getCurrentUserId).thenReturn(userId);
+
+			when(meetingRepository.findById(meetingId)).thenReturn(Optional.of(meeting));
+			doThrow(new MeetingException(MeetingErrorCode.NOT_GATHERING_MEETING))
+					.when(retrospectiveValidator).validateMeetingRetrospectiveAccess(gatheringId, meetingId, userId);
+
+			// when & then
+			assertThatThrownBy(() -> meetingRetrospectiveService.getMeetingRetrospective(meetingId))
+					.isInstanceOf(MeetingException.class)
+					.hasFieldOrPropertyWithValue("errorCode", MeetingErrorCode.NOT_GATHERING_MEETING);
+
+			verify(topicRepository, never()).findByMeetingIdAndTopicStatusOrderByConfirmOrderAsc(any(), any());
+		}
+	}
+
+	@Test
+	@DisplayName("확정된 토픽이 없으면 빈 목록을 반환한다")
+	void getMeetingRetrospective_withNoTopics_returnsEmptyList() {
+		// given
+		Long meetingId = 1L;
+		Long userId = 1L;
+		Long gatheringId = 1L;
+
+		Gathering gathering = Gathering.builder().id(gatheringId).build();
+		Meeting meeting = Meeting.builder()
+				.id(meetingId)
+				.gathering(gathering)
+				.meetingName("모임")
+				.meetingStartDate(LocalDateTime.of(2026, 1, 15, 19, 0))
+				.meetingEndDate(LocalDateTime.of(2026, 1, 15, 21, 0))
+				.build();
+
+		try (MockedStatic<SecurityUtil> securityUtilMock = mockStatic(SecurityUtil.class)) {
+			securityUtilMock.when(SecurityUtil::getCurrentUserId).thenReturn(userId);
+
+			when(meetingRepository.findById(meetingId)).thenReturn(Optional.of(meeting));
+			doNothing().when(retrospectiveValidator).validateMeetingRetrospectiveAccess(gatheringId, meetingId, userId);
+			when(topicRepository.findByMeetingIdAndTopicStatusOrderByConfirmOrderAsc(meetingId, TopicStatus.CONFIRMED))
+					.thenReturn(List.of());
+			when(topicRetrospectiveSummaryRepository.findAllByTopicIdIn(List.of())).thenReturn(List.of());
+			when(retrospectiveRepository.findAllByMeetingId(meetingId)).thenReturn(List.of());
+
+			// when
+			MeetingRetrospectiveResponse response = meetingRetrospectiveService.getMeetingRetrospective(meetingId);
+
+			// then
+			assertThat(response.meetingId()).isEqualTo(meetingId);
+			assertThat(response.topics()).isEmpty();
+		}
+	}
+
+	@Test
+	@DisplayName("코멘트가 없어도 정상적으로 조회한다")
+	void getMeetingRetrospective_withNoComments_success() {
+		// given
+		Long meetingId = 1L;
+		Long userId = 1L;
+		Long gatheringId = 1L;
+
+		Gathering gathering = Gathering.builder().id(gatheringId).build();
+		Meeting meeting = Meeting.builder()
+				.id(meetingId)
+				.gathering(gathering)
+				.meetingName("모임")
+				.meetingStartDate(LocalDateTime.of(2026, 1, 15, 19, 0))
+				.meetingEndDate(LocalDateTime.of(2026, 1, 15, 21, 0))
+				.build();
+
+		Topic topic = Topic.builder().id(1L).meeting(meeting).title("토픽1").build();
+		TopicRetrospectiveSummary summary = TopicRetrospectiveSummary.builder()
+				.id(1L)
+				.topic(topic)
+				.summarizedOpinions(List.of("요약1"))
+				.build();
+
+		try (MockedStatic<SecurityUtil> securityUtilMock = mockStatic(SecurityUtil.class)) {
+			securityUtilMock.when(SecurityUtil::getCurrentUserId).thenReturn(userId);
+
+			when(meetingRepository.findById(meetingId)).thenReturn(Optional.of(meeting));
+			doNothing().when(retrospectiveValidator).validateMeetingRetrospectiveAccess(gatheringId, meetingId, userId);
+			when(topicRepository.findByMeetingIdAndTopicStatusOrderByConfirmOrderAsc(meetingId, TopicStatus.CONFIRMED))
+					.thenReturn(List.of(topic));
+			when(topicRetrospectiveSummaryRepository.findAllByTopicIdIn(List.of(1L))).thenReturn(List.of(summary));
+			when(retrospectiveRepository.findAllByMeetingId(meetingId)).thenReturn(List.of());
+
+			// when
+			MeetingRetrospectiveResponse response = meetingRetrospectiveService.getMeetingRetrospective(meetingId);
+
+			// then
+			assertThat(response.topics()).hasSize(1);
+			assertThat(response.topics().get(0).summarizedOpinions()).containsExactly("요약1");
+			assertThat(response.topics().get(0).comments()).isEmpty();
+		}
+	}
+
+	@Test
+	@DisplayName("인증 정보가 없으면 예외가 발생한다")
+	void getMeetingRetrospective_throwsWhenUnauthenticated() {
+		// given
+		Long meetingId = 1L;
+
+		try (MockedStatic<SecurityUtil> securityUtilMock = mockStatic(SecurityUtil.class)) {
+			securityUtilMock.when(SecurityUtil::getCurrentUserId)
+					.thenThrow(new GlobalException(GlobalErrorCode.UNAUTHORIZED));
+
+			// when & then
+			assertThatThrownBy(() -> meetingRetrospectiveService.getMeetingRetrospective(meetingId))
+					.isInstanceOf(GlobalException.class)
+					.hasFieldOrPropertyWithValue("errorCode", GlobalErrorCode.UNAUTHORIZED);
+
+			verify(meetingRepository, never()).findById(any());
+		}
+	}
+}

--- a/src/test/java/com/dokdok/retrospective/service/MeetingRetrospectiveServiceTest.java
+++ b/src/test/java/com/dokdok/retrospective/service/MeetingRetrospectiveServiceTest.java
@@ -3,22 +3,18 @@ package com.dokdok.retrospective.service;
 import com.dokdok.gathering.entity.Gathering;
 import com.dokdok.gathering.exception.GatheringErrorCode;
 import com.dokdok.gathering.exception.GatheringException;
-import com.dokdok.global.exception.GlobalErrorCode;
-import com.dokdok.global.exception.GlobalException;
 import com.dokdok.global.util.SecurityUtil;
 import com.dokdok.meeting.entity.Meeting;
 import com.dokdok.meeting.exception.MeetingErrorCode;
 import com.dokdok.meeting.exception.MeetingException;
 import com.dokdok.meeting.repository.MeetingRepository;
 import com.dokdok.retrospective.dto.response.MeetingRetrospectiveResponse;
-import com.dokdok.retrospective.entity.MeetingRetrospective;
 import com.dokdok.retrospective.entity.TopicRetrospectiveSummary;
 import com.dokdok.retrospective.repository.RetrospectiveRepository;
 import com.dokdok.retrospective.repository.TopicRetrospectiveSummaryRepository;
 import com.dokdok.topic.entity.Topic;
 import com.dokdok.topic.entity.TopicStatus;
 import com.dokdok.topic.repository.TopicRepository;
-import com.dokdok.user.entity.User;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -208,25 +204,6 @@ class MeetingRetrospectiveServiceTest {
 			assertThat(response.topics()).hasSize(1);
 			assertThat(response.topics().get(0).summarizedOpinions()).containsExactly("요약1");
 			assertThat(response.topics().get(0).comments()).isEmpty();
-		}
-	}
-
-	@Test
-	@DisplayName("인증 정보가 없으면 예외가 발생한다")
-	void getMeetingRetrospective_throwsWhenUnauthenticated() {
-		// given
-		Long meetingId = 1L;
-
-		try (MockedStatic<SecurityUtil> securityUtilMock = mockStatic(SecurityUtil.class)) {
-			securityUtilMock.when(SecurityUtil::getCurrentUserId)
-					.thenThrow(new GlobalException(GlobalErrorCode.UNAUTHORIZED));
-
-			// when & then
-			assertThatThrownBy(() -> meetingRetrospectiveService.getMeetingRetrospective(meetingId))
-					.isInstanceOf(GlobalException.class)
-					.hasFieldOrPropertyWithValue("errorCode", GlobalErrorCode.UNAUTHORIZED);
-
-			verify(meetingRepository, never()).findById(any());
 		}
 	}
 }


### PR DESCRIPTION
## PR 요약
> 이 PR이 어떤 변경을 하는지 간단히 설명하고, 체크 표시는 괄호 사이에 소문자 'x'를 삽입하세요.
공동회고를 조회합니다.
약속에 참여한 

- [x] 기능 추가
- [ ] 버그 수정
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 기타 (설명)

---

## 이슈 번호
- #112 

---

## 주요 변경 사항
  - MeetingRetrospective.java: 공동 회고 코멘트 엔티티. meeting, createdBy(user), topic, comment 필드 포함
  - TopicRetrospectiveSummary.java: 토픽별 요약 엔티티. topic, summarizedOpinions(JSONB) 필드 포함
  - RetrospectiveRepository.java: MeetingRetrospective 조회용. findAllByMeetingId, findAllByTopicId 메서드
  - TopicRetrospectiveSummaryRepository.java: 토픽 요약 조회용. findByTopicId, findAllByTopicIdIn 메서드
  - MeetingRetrospectiveResponse.java: 공동 회고 조회 응답 DTO. 중첩 record(TopicResponse, CommentResponse) 포함
  - MeetingRetrospectiveService.java: 공동 회고 조회 비즈니스 로직. Meeting/Topic/Summary/Comment 조합하여 응답 생성
  - MeetingRetrospectiveController.java: GET /api/meetings/{meetingId}/retrospectives 엔드포인트
  - MeetingRetrospectiveServiceTest.java: Service 단위 테스트 (8개 케이스)
  - Meeting.java: getFormattedTime() 메서드 추가 (시간 포맷팅 "HH:mm-HH:mm")
  - RetrospectiveValidator.java: validateMeetingRetrospectiveAccess() 메서드 추가 (모임/약속 멤버 권한 검증)
  - MeetingMemberRepository.java: 버그 메서드 Long user(User user) 존재 (삭제 필요)


---

