### PR TITLE
[#24][FEAT] 약속 삭제 API, 약속 삭제 테스트 코드

### DIFF
--- a/src/main/java/com/dokdok/meeting/api/MeetingApi.java
+++ b/src/main/java/com/dokdok/meeting/api/MeetingApi.java
@@ -190,6 +190,32 @@ public interface MeetingApi {
     );
 
     @Operation(
+            summary = "약속 삭제",
+            description = """
+            약속을 삭제합니다.
+            - 권한: 모임장
+            - 제약: 종료된 약속은 삭제 불가
+            - 제약: 약속 시작 24시간 이내 삭제 불가
+            - 약속 삭제 시 연관된 데이터도 삭제 처리
+            """
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "약속 삭제 성공",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE)
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "모임장 아님"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "약속을 찾을 수 없음"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 오류")
+    })
+    ResponseEntity<ApiResponse<Void>> deleteMeeting(
+            @Parameter(name = "meetingId", description = "약속 식별자", in = ParameterIn.PATH, required = true)
+            Long meetingId
+    );
+
+    @Operation(
             summary = "약속 탭 카운트 조회",
             description = """
             모임의 약속 탭별 카운트를 조회합니다.

--- a/src/main/java/com/dokdok/meeting/controller/MeetingController.java
+++ b/src/main/java/com/dokdok/meeting/controller/MeetingController.java
@@ -87,6 +87,15 @@ public class MeetingController implements MeetingApi {
     }
 
     @Override
+    @DeleteMapping(value = "/{meetingId}", produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<ApiResponse<Void>> deleteMeeting(
+            @PathVariable Long meetingId
+    ) {
+        meetingService.deleteMeeting(meetingId);
+        return ApiResponse.deleted("약속 삭제에 성공했습니다.");
+    }
+
+    @Override
     @GetMapping(value = "/tab-counts", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<ApiResponse<MeetingTabCountsResponse>> getMeetingTabCounts(
             @RequestParam Long gatheringId

--- a/src/main/java/com/dokdok/meeting/exception/MeetingErrorCode.java
+++ b/src/main/java/com/dokdok/meeting/exception/MeetingErrorCode.java
@@ -23,6 +23,7 @@ public enum MeetingErrorCode implements BaseErrorCode {
     MEETING_ALREADY_JOINED("M010", "이미 참가한 약속입니다.", HttpStatus.BAD_REQUEST),
     MEETING_ALREADY_CANCELED("M011", "이미 취소된 약속입니다.", HttpStatus.BAD_REQUEST),
     MEETING_CANCEL_NOT_ALLOWED("M012", "약속 시작 24시간 이내에는 취소할 수 없습니다.", HttpStatus.BAD_REQUEST),
+    MEETING_DELETE_NOT_ALLOWED("M015", "약속 시작 24시간 이내에는 삭제할 수 없습니다.", HttpStatus.BAD_REQUEST),
 
     INVALID_MAX_PARTICIPANTS("M013", "최대 참가 인원은 1명 이상이어야 하며, 모임 전체 인원을 초과할 수 없습니다.", HttpStatus.BAD_REQUEST),
     MAX_PARTICIPANTS_LESS_THAN_CURRENT("M014", "현재 참가 확정된 인원 수보다 적게 수정할 수 없습니다.", HttpStatus.BAD_REQUEST);

--- a/src/main/java/com/dokdok/meeting/service/MeetingService.java
+++ b/src/main/java/com/dokdok/meeting/service/MeetingService.java
@@ -22,6 +22,7 @@ import com.dokdok.meeting.repository.MeetingMemberRepository;
 import com.dokdok.meeting.repository.MeetingRepository;
 import com.dokdok.topic.entity.Topic;
 import com.dokdok.topic.entity.TopicType;
+import com.dokdok.topic.repository.TopicAnswerRepository;
 import com.dokdok.topic.repository.TopicRepository;
 import com.dokdok.user.entity.User;
 import com.dokdok.user.service.UserValidator;
@@ -47,6 +48,7 @@ public class MeetingService {
     private final MeetingRepository meetingRepository;
     private final MeetingMemberRepository meetingMemberRepository;
     private final TopicRepository topicRepository;
+    private final TopicAnswerRepository topicAnswerRepository;
     private final GatheringRepository gatheringRepository;
     private final GatheringMemberRepository gatheringMemberRepository;
     private final GatheringValidator gatheringValidator;
@@ -275,6 +277,45 @@ public class MeetingService {
         topicRepository.softDeleteByMeetingIdAndProposedById(meetingId, userId);
 
         return meetingId;
+    }
+
+    /**
+     * 약속을 삭제한다. 모임장만 삭제 가능
+     * 진행 전 상태의 약속만 삭제 가능
+     * 약속 시작 24시간 이내 삭제 불가
+     * @param meetingId 약속 식별자
+     */
+    @Transactional
+    public void deleteMeeting(Long meetingId) {
+        Long userId = SecurityUtil.getCurrentUserId();
+        Meeting meeting = meetingValidator.findMeetingOrThrow(meetingId);
+
+        // 모임장만 약속 삭제 가능
+        gatheringValidator.validateLeader(meeting.getGathering().getId(), userId);
+
+        validateDeletableStatus(meeting);
+        validateDeletableMeetingStartDate(meeting);
+
+        topicAnswerRepository.softDeleteByMeetingId(meetingId);
+        topicRepository.softDeleteByMeetingId(meetingId);
+        meetingRepository.delete(meeting);
+    }
+
+    private void validateDeletableStatus(Meeting meeting) {
+        if (meeting.getMeetingStatus() == MeetingStatus.DONE) {
+            throw new MeetingException(
+                    MeetingErrorCode.INVALID_MEETING_STATUS_CHANGE,
+                    "종료된 약속은 삭제할 수 없습니다."
+            );
+        }
+    }
+
+    private void validateDeletableMeetingStartDate(Meeting meeting) {
+        LocalDateTime meetingStartDate = meeting.getMeetingStartDate();
+        if (meetingStartDate != null
+                && meetingStartDate.isBefore(LocalDateTime.now().plusHours(24))) {
+            throw new MeetingException(MeetingErrorCode.MEETING_DELETE_NOT_ALLOWED);
+        }
     }
 
     /**

--- a/src/main/java/com/dokdok/topic/repository/TopicAnswerRepository.java
+++ b/src/main/java/com/dokdok/topic/repository/TopicAnswerRepository.java
@@ -2,7 +2,9 @@ package com.dokdok.topic.repository;
 
 import com.dokdok.topic.entity.TopicAnswer;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import javax.swing.*;
 import java.util.List;
@@ -29,4 +31,17 @@ public interface TopicAnswerRepository extends JpaRepository<TopicAnswer, Long> 
                     AND ta.user.id = :userId
             """)
     List<TopicAnswer> findByMeetingIdUserId(Long meetingId, Long userId);
+
+    @Modifying
+    @Query("""
+            UPDATE TopicAnswer ta
+            SET ta.deletedAt = CURRENT_TIMESTAMP
+            WHERE ta.topic.id IN (
+                SELECT t.id
+                FROM Topic t
+                WHERE t.meeting.id = :meetingId
+            )
+            AND ta.deletedAt IS NULL
+            """)
+    void softDeleteByMeetingId(@Param("meetingId") Long meetingId);
 }

--- a/src/main/java/com/dokdok/topic/repository/TopicRepository.java
+++ b/src/main/java/com/dokdok/topic/repository/TopicRepository.java
@@ -46,6 +46,15 @@ public interface TopicRepository extends JpaRepository<Topic, Long> {
             @Param("userId") Long userId
     );
 
+    @Modifying
+    @Query("""
+            UPDATE Topic t
+            SET t.deletedAt = CURRENT_TIMESTAMP
+            WHERE t.meeting.id = :meetingId
+            AND t.deletedAt IS NULL
+            """)
+    void softDeleteByMeetingId(@Param("meetingId") Long meetingId);
+
     @Query("SELECT t " +
             "FROM Topic t " +
             "JOIN FETCH t.proposedBy p " +

--- a/src/test/java/com/dokdok/meeting/service/MeetingServiceTest.java
+++ b/src/test/java/com/dokdok/meeting/service/MeetingServiceTest.java
@@ -21,6 +21,7 @@ import com.dokdok.meeting.exception.MeetingException;
 import com.dokdok.meeting.repository.MeetingMemberRepository;
 import com.dokdok.meeting.repository.MeetingRepository;
 import com.dokdok.topic.entity.TopicType;
+import com.dokdok.topic.repository.TopicAnswerRepository;
 import com.dokdok.topic.repository.TopicRepository;
 import com.dokdok.user.entity.User;
 import com.dokdok.user.service.UserValidator;
@@ -61,6 +62,9 @@ class MeetingServiceTest {
 
     @Mock
     private TopicRepository topicRepository;
+
+    @Mock
+    private TopicAnswerRepository topicAnswerRepository;
 
     @Mock
     private GatheringRepository gatheringRepository;
@@ -149,6 +153,89 @@ class MeetingServiceTest {
                     .isInstanceOf(MeetingException.class)
                     .extracting("errorCode")
                     .isEqualTo(MeetingErrorCode.MEETING_NOT_FOUND);
+        }
+    }
+
+    @DisplayName("모임장이 약속을 삭제하면 연관 데이터가 soft delete 되고 약속이 삭제된다.")
+    @Test
+    void givenLeaderAndDeletableMeeting_whenDeleteMeeting_thenSoftDeleteAndRemove() {
+        // given
+        Long userId = leader.getId();
+        meeting = Meeting.builder()
+                .id(meetingId)
+                .meetingStatus(MeetingStatus.CONFIRMED)
+                .meetingStartDate(LocalDateTime.now().plusDays(2))
+                .meetingLeader(leader)
+                .gathering(gathering)
+                .build();
+
+        given(meetingValidator.findMeetingOrThrow(meetingId))
+                .willReturn(meeting);
+
+        try (MockedStatic<SecurityUtil> securityUtilMock = mockStatic(SecurityUtil.class)) {
+            securityUtilMock.when(SecurityUtil::getCurrentUserId).thenReturn(userId);
+
+            // when
+            meetingService.deleteMeeting(meetingId);
+
+            // then
+            verify(gatheringValidator).validateLeader(gathering.getId(), userId);
+            verify(topicAnswerRepository).softDeleteByMeetingId(meetingId);
+            verify(topicRepository).softDeleteByMeetingId(meetingId);
+            verify(meetingRepository).delete(meeting);
+        }
+    }
+
+    @DisplayName("약속 시작 24시간 이내면 약속 삭제가 불가하다.")
+    @Test
+    void givenMeetingWithin24Hours_whenDeleteMeeting_thenThrowException() {
+        // given
+        Long userId = leader.getId();
+        meeting = Meeting.builder()
+                .id(meetingId)
+                .meetingStatus(MeetingStatus.CONFIRMED)
+                .meetingStartDate(LocalDateTime.now().plusHours(23))
+                .meetingLeader(leader)
+                .gathering(gathering)
+                .build();
+
+        given(meetingValidator.findMeetingOrThrow(meetingId))
+                .willReturn(meeting);
+
+        try (MockedStatic<SecurityUtil> securityUtilMock = mockStatic(SecurityUtil.class)) {
+            securityUtilMock.when(SecurityUtil::getCurrentUserId).thenReturn(userId);
+
+            // when + then
+            assertThatThrownBy(() -> meetingService.deleteMeeting(meetingId))
+                    .isInstanceOf(MeetingException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(MeetingErrorCode.MEETING_DELETE_NOT_ALLOWED);
+        }
+    }
+
+    @DisplayName("완료된 약속은 삭제할 수 없다.")
+    @Test
+    void givenDoneMeeting_whenDeleteMeeting_thenThrowException() {
+        // given
+        Long userId = leader.getId();
+        meeting = Meeting.builder()
+                .id(meetingId)
+                .meetingStatus(MeetingStatus.DONE)
+                .meetingLeader(leader)
+                .gathering(gathering)
+                .build();
+
+        given(meetingValidator.findMeetingOrThrow(meetingId))
+                .willReturn(meeting);
+
+        try (MockedStatic<SecurityUtil> securityUtilMock = mockStatic(SecurityUtil.class)) {
+            securityUtilMock.when(SecurityUtil::getCurrentUserId).thenReturn(userId);
+
+            // when + then
+            assertThatThrownBy(() -> meetingService.deleteMeeting(meetingId))
+                    .isInstanceOf(MeetingException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(MeetingErrorCode.INVALID_MEETING_STATUS_CHANGE);
         }
     }
 


### PR DESCRIPTION
## PR 요약
> 이 PR이 어떤 변경을 하는지 간단히 설명하고, 체크 표시는 괄호 사이에 소문자 'x'를 삽입하세요.

- [x] 기능 추가
- [ ] 버그 수정
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 기타 (설명)

---

## 이슈 번호
- #24

---

## 주요 변경 사항
> 주요 파일, 로직, 컴포넌트 등을 구체적으로 적어주세요.

권한: 모임장
제약: 종료된 약속은 삭제 불가
제약: 약속 시작 24시간 이내 삭제 불가
약속 삭제 시 연관된 데이터도 삭제 처리

- `src/main/java/com/dokdok/meeting`: +77/-0 (4 files) — 요구사항 반영
- `src/main/java/com/dokdok/topic`: +24/-0 (2 files) — 요구사항 반영
- `src/test/java/com/dokdok/meeting`: +87/-0 (1 files) — 요구사항 반영

---

## 참고 사항
> 리뷰어가 알아야 할 추가 정보, 테스트 방법 등을 작성해주세요.

예:
- 테스트 계정 정보
- 관련 API 엔드포인트
- 로컬 테스트 방법

---
