### PR TITLE
[#123][FEAT] 독서 기록 삭제 API

### DIFF
--- a/src/main/java/com/dokdok/book/api/BookApi.java
+++ b/src/main/java/com/dokdok/book/api/BookApi.java
@@ -392,4 +392,40 @@ public interface BookApi {
             )
             @RequestBody PersonalReadingRecordUpdateRequest request
     );
+
+    @Operation(
+            summary = "독서 기록 삭제",
+            description = """
+                    내 책장에 있는 책의 독서 기록을 삭제합니다.
+                    - 경로의 personalBookId와 recordId로 대상을 지정합니다.
+                    - Soft Delete로 처리되어 이후 조회에서 노출되지 않습니다.
+                    - 로그인한 사용자 기준으로 본인 기록만 삭제할 수 있습니다.
+                    """
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "독서 기록 삭제 성공",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = ApiResponse.class),
+                            examples = @io.swagger.v3.oas.annotations.media.ExampleObject(
+                                    value = """
+                                            {
+                                              "code": "DELETED",
+                                              "message": "기록 삭제 성공"
+                                            }
+                                            """
+                            ))
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 실패 - 로그인이 필요합니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "책 또는 기록을 찾을 수 없음"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 오류")
+    })
+    @DeleteMapping("/{personalBookId}/records/{recordId}")
+    ResponseEntity<ApiResponse<Void>> deleteMyReadingRecord(
+            @Parameter(description = "삭제할 개인 책 ID", required = true, example = "10")
+            @PathVariable Long personalBookId,
+            @Parameter(description = "삭제할 기록 ID", required = true, example = "5")
+            @PathVariable Long recordId
+    );
 }

--- a/src/main/java/com/dokdok/book/controller/BookController.java
+++ b/src/main/java/com/dokdok/book/controller/BookController.java
@@ -13,8 +13,6 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
-import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 

--- a/src/main/java/com/dokdok/book/controller/BookController.java
+++ b/src/main/java/com/dokdok/book/controller/BookController.java
@@ -13,6 +13,8 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -71,5 +73,12 @@ public class BookController implements BookApi {
     public ResponseEntity<ApiResponse<PersonalReadingRecordCreateResponse>> updateMyReadingRecord(@PathVariable Long personalBookId, @PathVariable Long recordId, @RequestBody PersonalReadingRecordUpdateRequest request) {
         PersonalReadingRecordCreateResponse response = personalReadingRecordService.update(personalBookId, recordId, request);
         return ApiResponse.success(response, "기록 수정 성공");
+    }
+
+    @Override
+    @DeleteMapping("/{personalBookId}/records/{recordId}")
+    public ResponseEntity<ApiResponse<Void>> deleteMyReadingRecord(@PathVariable Long personalBookId, @PathVariable Long recordId) {
+        personalReadingRecordService.delete(personalBookId, recordId);
+        return ApiResponse.deleted("기록 삭제 성공");
     }
 }

--- a/src/main/java/com/dokdok/book/entity/PersonalReadingRecord.java
+++ b/src/main/java/com/dokdok/book/entity/PersonalReadingRecord.java
@@ -1,5 +1,7 @@
 package com.dokdok.book.entity;
 
+import com.dokdok.book.exception.RecordErrorCode;
+import com.dokdok.book.exception.RecordException;
 import com.dokdok.global.BaseTimeEntity;
 import com.dokdok.user.entity.User;
 import jakarta.persistence.*;
@@ -66,5 +68,13 @@ public class PersonalReadingRecord extends BaseTimeEntity {
         this.recordType = recordType;
         this.recordContent = recordContent;
         this.meta = meta;
+    }
+
+    public void delete() {
+        if (isDeleted()) {
+            throw new RecordException(RecordErrorCode.RECORD_ALREADY_DELETED);
+        }
+
+        markDeletedNow();
     }
 }

--- a/src/main/java/com/dokdok/book/exception/RecordErrorCode.java
+++ b/src/main/java/com/dokdok/book/exception/RecordErrorCode.java
@@ -10,7 +10,8 @@ import org.springframework.http.HttpStatus;
 public enum RecordErrorCode implements BaseErrorCode {
     INVALID_RECORD_REQUEST("R001", "기록 타입에 필요한 입력값이 누락되었습니다.", HttpStatus.BAD_REQUEST),
     INVALID_RECORD_TYPE("R002", "존재하지 않는 타입입니다.", HttpStatus.BAD_REQUEST),
-    RECORD_NOT_FOUND("R003", "기록을 찾을 수 없습니다.", HttpStatus.NOT_FOUND);
+    RECORD_NOT_FOUND("R003", "기록을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    RECORD_ALREADY_DELETED("R004", "이미 삭제된 기록입니다.", HttpStatus.CONFLICT);
 
     private final String code;
     private final String message;

--- a/src/main/java/com/dokdok/book/service/PersonalReadingRecordService.java
+++ b/src/main/java/com/dokdok/book/service/PersonalReadingRecordService.java
@@ -1,21 +1,18 @@
 package com.dokdok.book.service;
 
 import com.dokdok.book.dto.request.PersonalReadingRecordCreateRequest;
+import com.dokdok.book.dto.request.PersonalReadingRecordUpdateRequest;
 import com.dokdok.book.dto.response.PersonalReadingRecordCreateResponse;
-import com.dokdok.book.dto.response.PersonalReadingRecordListResponse;
 import com.dokdok.book.entity.PersonalBook;
 import com.dokdok.book.entity.PersonalReadingRecord;
 import com.dokdok.book.entity.RecordType;
 import com.dokdok.book.exception.RecordErrorCode;
 import com.dokdok.book.exception.RecordException;
-import com.dokdok.book.dto.request.PersonalReadingRecordUpdateRequest;
 import com.dokdok.book.repository.PersonalReadingRecordRepository;
 import com.dokdok.global.util.SecurityUtil;
 import com.dokdok.user.entity.User;
 import com.dokdok.user.service.UserValidator;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 

--- a/src/main/java/com/dokdok/book/service/PersonalReadingRecordService.java
+++ b/src/main/java/com/dokdok/book/service/PersonalReadingRecordService.java
@@ -2,6 +2,7 @@ package com.dokdok.book.service;
 
 import com.dokdok.book.dto.request.PersonalReadingRecordCreateRequest;
 import com.dokdok.book.dto.response.PersonalReadingRecordCreateResponse;
+import com.dokdok.book.dto.response.PersonalReadingRecordListResponse;
 import com.dokdok.book.entity.PersonalBook;
 import com.dokdok.book.entity.PersonalReadingRecord;
 import com.dokdok.book.entity.RecordType;
@@ -13,6 +14,8 @@ import com.dokdok.global.util.SecurityUtil;
 import com.dokdok.user.entity.User;
 import com.dokdok.user.service.UserValidator;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -65,6 +68,22 @@ public class PersonalReadingRecordService {
         );
 
         return PersonalReadingRecordCreateResponse.from(personalReadingRecord);
+    }
+
+    @Transactional
+    public void delete(Long personalBookId, Long recordId) {
+        User userEntity = userValidator.findUserOrThrow(SecurityUtil.getCurrentUserId());
+        PersonalBook personalBookEntity = bookValidator.validateInBookShelf(userEntity.getId(), personalBookId);
+
+        PersonalReadingRecord personalReadingRecord = personalReadingRecordRepository
+                .findByIdAndPersonalBookIdAndUserId(recordId, personalBookEntity.getId(), userEntity.getId())
+                .orElseThrow(() -> new RecordException(RecordErrorCode.RECORD_NOT_FOUND));
+
+        if (personalReadingRecord.isDeleted()) {
+            throw new RecordException(RecordErrorCode.RECORD_ALREADY_DELETED);
+        }
+
+        personalReadingRecord.delete();
     }
 
     private Map<String, Object> normalizeMeta(RecordType recordType, Map<String, Object> meta) {

--- a/src/test/java/com/dokdok/book/service/PersonalReadingRecordServiceTest.java
+++ b/src/test/java/com/dokdok/book/service/PersonalReadingRecordServiceTest.java
@@ -395,4 +395,142 @@ class PersonalReadingRecordServiceTest {
         verify(bookValidator, times(1)).validateInBookShelf(userId, personalBookId);
     }
 
+    @Test
+    @DisplayName("독서 기록을 삭제하면 deletedAt이 설정된다")
+    void deleteRecord_Success() {
+        // given
+        Long userId = 1L;
+        Long personalBookId = 70L;
+        Long recordId = 8L;
+
+        User user = User.builder()
+                .id(userId)
+                .kakaoId(555L)
+                .nickname("deleter")
+                .build();
+
+        PersonalBook personalBook = PersonalBook.builder()
+                .id(personalBookId)
+                .user(user)
+                .book(Book.builder().id(700L).isbn("9784444444444").bookName("책").author("저자").publisher("출판").build())
+                .readingStatus(BookReadingStatus.READING)
+                .build();
+
+        PersonalReadingRecord record = PersonalReadingRecord.builder()
+                .id(recordId)
+                .personalBook(personalBook)
+                .user(user)
+                .recordType(RecordType.MEMO)
+                .recordContent("삭제할 기록")
+                .build();
+
+        securityUtilMock.when(SecurityUtil::getCurrentUserId).thenReturn(userId);
+        when(userValidator.findUserOrThrow(userId)).thenReturn(user);
+        when(bookValidator.validateInBookShelf(userId, personalBookId)).thenReturn(personalBook);
+        when(personalReadingRecordRepository.findByIdAndPersonalBookIdAndUserId(recordId, personalBookId, userId))
+                .thenReturn(Optional.of(record));
+
+        // when
+        personalReadingRecordService.delete(personalBookId, recordId);
+
+        // then
+        assertThat(record.isDeleted()).isTrue();
+        assertThat(record.getDeletedAt()).isNotNull();
+
+        verify(personalReadingRecordRepository, times(1))
+                .findByIdAndPersonalBookIdAndUserId(recordId, personalBookId, userId);
+        verify(personalReadingRecordRepository, never()).save(any());
+        securityUtilMock.verify(SecurityUtil::getCurrentUserId, times(1));
+        verify(userValidator, times(1)).findUserOrThrow(userId);
+        verify(bookValidator, times(1)).validateInBookShelf(userId, personalBookId);
+    }
+
+    @Test
+    @DisplayName("삭제할 기록을 찾지 못하면 RecordException이 발생한다")
+    void deleteRecord_NotFound() {
+        // given
+        Long userId = 1L;
+        Long personalBookId = 80L;
+        Long recordId = 99L;
+
+        User user = User.builder()
+                .id(userId)
+                .kakaoId(666L)
+                .nickname("deleter")
+                .build();
+
+        PersonalBook personalBook = PersonalBook.builder()
+                .id(personalBookId)
+                .user(user)
+                .book(Book.builder().id(800L).isbn("9785555555555").bookName("책").author("저자").publisher("출판").build())
+                .readingStatus(BookReadingStatus.READING)
+                .build();
+
+        securityUtilMock.when(SecurityUtil::getCurrentUserId).thenReturn(userId);
+        when(userValidator.findUserOrThrow(userId)).thenReturn(user);
+        when(bookValidator.validateInBookShelf(userId, personalBookId)).thenReturn(personalBook);
+        when(personalReadingRecordRepository.findByIdAndPersonalBookIdAndUserId(recordId, personalBookId, userId))
+                .thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> personalReadingRecordService.delete(personalBookId, recordId))
+                .isInstanceOf(RecordException.class)
+                .hasFieldOrPropertyWithValue("errorCode", RecordErrorCode.RECORD_NOT_FOUND);
+
+        verify(personalReadingRecordRepository, times(1))
+                .findByIdAndPersonalBookIdAndUserId(recordId, personalBookId, userId);
+        securityUtilMock.verify(SecurityUtil::getCurrentUserId, times(1));
+        verify(userValidator, times(1)).findUserOrThrow(userId);
+        verify(bookValidator, times(1)).validateInBookShelf(userId, personalBookId);
+    }
+
+    @Test
+    @DisplayName("이미 삭제된 기록 삭제 시 RecordException이 발생한다")
+    void deleteRecord_AlreadyDeleted() {
+        // given
+        Long userId = 1L;
+        Long personalBookId = 90L;
+        Long recordId = 77L;
+
+        User user = User.builder()
+                .id(userId)
+                .kakaoId(777L)
+                .nickname("deleter")
+                .build();
+
+        PersonalBook personalBook = PersonalBook.builder()
+                .id(personalBookId)
+                .user(user)
+                .book(Book.builder().id(900L).isbn("9786666666666").bookName("책").author("저자").publisher("출판").build())
+                .readingStatus(BookReadingStatus.READING)
+                .build();
+
+        PersonalReadingRecord record = PersonalReadingRecord.builder()
+                .id(recordId)
+                .personalBook(personalBook)
+                .user(user)
+                .recordType(RecordType.QUOTE)
+                .recordContent("삭제된 기록")
+                .build();
+
+        record.delete();
+
+        securityUtilMock.when(SecurityUtil::getCurrentUserId).thenReturn(userId);
+        when(userValidator.findUserOrThrow(userId)).thenReturn(user);
+        when(bookValidator.validateInBookShelf(userId, personalBookId)).thenReturn(personalBook);
+        when(personalReadingRecordRepository.findByIdAndPersonalBookIdAndUserId(recordId, personalBookId, userId))
+                .thenReturn(Optional.of(record));
+
+        // when & then
+        assertThatThrownBy(() -> personalReadingRecordService.delete(personalBookId, recordId))
+                .isInstanceOf(RecordException.class)
+                .hasFieldOrPropertyWithValue("errorCode", RecordErrorCode.RECORD_ALREADY_DELETED);
+
+        verify(personalReadingRecordRepository, times(1))
+                .findByIdAndPersonalBookIdAndUserId(recordId, personalBookId, userId);
+        securityUtilMock.verify(SecurityUtil::getCurrentUserId, times(1));
+        verify(userValidator, times(1)).findUserOrThrow(userId);
+        verify(bookValidator, times(1)).validateInBookShelf(userId, personalBookId);
+    }
+
 }


### PR DESCRIPTION
## PR 요약

  > 내 책장 독서 기록을 Soft Delete로 삭제하는 API를 추가하고 예외·테스트를 보강했습니다.                                                                                                                                                                                                                                   

  - [x] 기능 추가
  - [ ] 버그 수정
  - [ ] 코드 리팩토링
  - [ ] 문서 수정
  - [ ] 기타 (설명)

  ———

  ## 이슈 번호

  - #123 

  ———

  ## 주요 변경 사항

  > 주요 파일, 로직, 컴포넌트 등을 구체적으로 적어주세요.                                                                                                                                                                                                                                                                   

  - src/main/java/com/dokdok/book/api/BookApi.java: 개인 독서 기록 삭제 엔드포인트 및 Swagger 문서 추가.
  - src/main/java/com/dokdok/book/controller/BookController.java: 삭제 API를 노출하고 성공 시 공통 삭제 응답 반환.
  - src/main/java/com/dokdok/book/entity/PersonalReadingRecord.java: Soft Delete 처리 메서드 추가 및 중복 삭제 방지.
  - src/main/java/com/dokdok/book/exception/RecordErrorCode.java: 이미 삭제된 기록 예외 코드 추가.
  - src/main/java/com/dokdok/book/service/PersonalReadingRecordService.java: 사용자·책 소유 검증 후 삭제 처리, 삭제/미존재 시 예외 처리.
  - src/test/java/com/dokdok/book/service/PersonalReadingRecordServiceTest.java: 삭제 성공/미존재/이미 삭제 케이스 단위 테스트 추가.

  ———

  ## 참고 사항

  > 리뷰어가 알아야 할 추가 정보, 테스트 방법 등을 작성해주세요.                                                                                                                                                                                                                                                            

  - 삭제는 Soft Delete(deletedAt 설정)로 동작하며, 이미 삭제된 기록 요청 시 RECORD_ALREADY_DELETED 예외를 반환합니다.