### PR TITLE
[#131][FEAT] 약속 상태 변경 스케줄러 등록

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,16 @@ dependencies {
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	developmentOnly 'org.springframework.boot:spring-boot-docker-compose'
 	runtimeOnly 'org.postgresql:postgresql'
+	
+	// 테스트용 H2 Database
+	testRuntimeOnly 'com.h2database:h2'
+	
 	annotationProcessor 'org.projectlombok:lombok'
+	
+	// 테스트에서도 Lombok 사용
+	testCompileOnly 'org.projectlombok:lombok'
+	testAnnotationProcessor 'org.projectlombok:lombok'
+	
 	testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa-test'
 	testImplementation 'org.springframework.boot:spring-boot-starter-security-oauth2-client-test'
 	testImplementation 'org.springframework.boot:spring-boot-starter-security-test'

--- a/src/main/java/com/dokdok/global/config/SchedulingConfig.java
+++ b/src/main/java/com/dokdok/global/config/SchedulingConfig.java
@@ -1,0 +1,13 @@
+package com.dokdok.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+/**
+ * Spring Scheduler 활성화 설정
+ * - @Scheduled 어노테이션 사용을 위해 필요
+ */
+@Configuration
+@EnableScheduling
+public class SchedulingConfig {
+}

--- a/src/main/java/com/dokdok/meeting/api/MeetingApi.java
+++ b/src/main/java/com/dokdok/meeting/api/MeetingApi.java
@@ -190,6 +190,32 @@ public interface MeetingApi {
     );
 
     @Operation(
+            summary = "약속 삭제",
+            description = """
+            약속을 삭제합니다.
+            - 권한: 모임장
+            - 제약: 종료된 약속은 삭제 불가
+            - 제약: 약속 시작 24시간 이내 삭제 불가
+            - 약속 삭제 시 연관된 데이터도 삭제 처리
+            """
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "약속 삭제 성공",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE)
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "모임장 아님"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "약속을 찾을 수 없음"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 오류")
+    })
+    ResponseEntity<ApiResponse<Void>> deleteMeeting(
+            @Parameter(name = "meetingId", description = "약속 식별자", in = ParameterIn.PATH, required = true)
+            Long meetingId
+    );
+
+    @Operation(
             summary = "약속 탭 카운트 조회",
             description = """
             모임의 약속 탭별 카운트를 조회합니다.

--- a/src/main/java/com/dokdok/meeting/controller/MeetingController.java
+++ b/src/main/java/com/dokdok/meeting/controller/MeetingController.java
@@ -87,6 +87,15 @@ public class MeetingController implements MeetingApi {
     }
 
     @Override
+    @DeleteMapping(value = "/{meetingId}", produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<ApiResponse<Void>> deleteMeeting(
+            @PathVariable Long meetingId
+    ) {
+        meetingService.deleteMeeting(meetingId);
+        return ApiResponse.deleted("약속 삭제에 성공했습니다.");
+    }
+
+    @Override
     @GetMapping(value = "/tab-counts", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<ApiResponse<MeetingTabCountsResponse>> getMeetingTabCounts(
             @RequestParam Long gatheringId

--- a/src/main/java/com/dokdok/meeting/exception/MeetingErrorCode.java
+++ b/src/main/java/com/dokdok/meeting/exception/MeetingErrorCode.java
@@ -23,6 +23,7 @@ public enum MeetingErrorCode implements BaseErrorCode {
     MEETING_ALREADY_JOINED("M010", "이미 참가한 약속입니다.", HttpStatus.BAD_REQUEST),
     MEETING_ALREADY_CANCELED("M011", "이미 취소된 약속입니다.", HttpStatus.BAD_REQUEST),
     MEETING_CANCEL_NOT_ALLOWED("M012", "약속 시작 24시간 이내에는 취소할 수 없습니다.", HttpStatus.BAD_REQUEST),
+    MEETING_DELETE_NOT_ALLOWED("M015", "약속 시작 24시간 이내에는 삭제할 수 없습니다.", HttpStatus.BAD_REQUEST),
 
     INVALID_MAX_PARTICIPANTS("M013", "최대 참가 인원은 1명 이상이어야 하며, 모임 전체 인원을 초과할 수 없습니다.", HttpStatus.BAD_REQUEST),
     MAX_PARTICIPANTS_LESS_THAN_CURRENT("M014", "현재 참가 확정된 인원 수보다 적게 수정할 수 없습니다.", HttpStatus.BAD_REQUEST);

--- a/src/main/java/com/dokdok/meeting/repository/MeetingRepository.java
+++ b/src/main/java/com/dokdok/meeting/repository/MeetingRepository.java
@@ -11,6 +11,7 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Repository
 public interface MeetingRepository extends JpaRepository<Meeting, Long> {
@@ -49,4 +50,11 @@ public interface MeetingRepository extends JpaRepository<Meeting, Long> {
             @Param("startDate") LocalDateTime startDate,
             @Param("endDate") LocalDateTime endDate
     );
+
+    // Scheduler용: 종료 시간이 지난 CONFIRMED 상태의 Meeting 조회
+    List<Meeting> findByMeetingEndDateBeforeAndMeetingStatus(
+            LocalDateTime endDate,
+            MeetingStatus meetingStatus
+    );
+
 }

--- a/src/main/java/com/dokdok/meeting/scheduler/MeetingStatusScheduler.java
+++ b/src/main/java/com/dokdok/meeting/scheduler/MeetingStatusScheduler.java
@@ -1,0 +1,69 @@
+package com.dokdok.meeting.scheduler;
+
+import com.dokdok.meeting.entity.Meeting;
+import com.dokdok.meeting.entity.MeetingStatus;
+import com.dokdok.meeting.repository.MeetingRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * Meeting 상태 자동 업데이트 Scheduler
+ * - 매 10분마다 실행
+ * - meetingEndDate가 지난 CONFIRMED 상태의 Meeting을 DONE으로 변경
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class MeetingStatusScheduler {
+
+    private final MeetingRepository meetingRepository;
+
+    /**
+     * 종료 시간이 지난 모임의 상태를 자동으로 DONE으로 변경
+     * - 매 10분마다 실행 (0분, 10분, 20분, ...)
+     */
+    @Scheduled(cron = "0 */10 * * * *")
+    @Transactional
+    public void updateExpiredMeetings() {
+        long startTime = System.currentTimeMillis();
+        
+        LocalDateTime now = LocalDateTime.now();
+        
+        // 1. 종료 시간이 지난 CONFIRMED 상태의 Meeting 조회
+        List<Meeting> expiredMeetings = meetingRepository
+                .findByMeetingEndDateBeforeAndMeetingStatus(now, MeetingStatus.CONFIRMED);
+        
+        if (expiredMeetings.isEmpty()) {
+            log.info("[Scheduler] No expired meetings found.");
+            return;
+        }
+        
+        // 2. 상태를 DONE으로 변경
+        int count = 0;
+        for (Meeting meeting : expiredMeetings) {
+            try {
+                meeting.changeStatus(MeetingStatus.DONE);
+                count++;
+            } catch (Exception e) {
+                log.error("[Scheduler] Failed to update meeting {}: {}", meeting.getId(), e.getMessage());
+            }
+        }
+        
+        long endTime = System.currentTimeMillis();
+        long duration = endTime - startTime;
+        
+        // 3. 성능 지표 로깅
+        log.info("[Scheduler] ========================================");
+        log.info("[Scheduler] Updated {} / {} meetings to DONE", count, expiredMeetings.size());
+        log.info("[Scheduler] Execution time: {}ms", duration);
+        log.info("[Scheduler] Throughput: {} meetings/sec", 
+                 duration > 0 ? (count * 1000.0 / duration) : count);
+        log.info("[Scheduler] ========================================");
+    }
+}

--- a/src/main/java/com/dokdok/meeting/service/MeetingService.java
+++ b/src/main/java/com/dokdok/meeting/service/MeetingService.java
@@ -22,6 +22,7 @@ import com.dokdok.meeting.repository.MeetingMemberRepository;
 import com.dokdok.meeting.repository.MeetingRepository;
 import com.dokdok.topic.entity.Topic;
 import com.dokdok.topic.entity.TopicType;
+import com.dokdok.topic.repository.TopicAnswerRepository;
 import com.dokdok.topic.repository.TopicRepository;
 import com.dokdok.user.entity.User;
 import com.dokdok.user.service.UserValidator;
@@ -47,6 +48,7 @@ public class MeetingService {
     private final MeetingRepository meetingRepository;
     private final MeetingMemberRepository meetingMemberRepository;
     private final TopicRepository topicRepository;
+    private final TopicAnswerRepository topicAnswerRepository;
     private final GatheringRepository gatheringRepository;
     private final GatheringMemberRepository gatheringMemberRepository;
     private final GatheringValidator gatheringValidator;
@@ -275,6 +277,45 @@ public class MeetingService {
         topicRepository.softDeleteByMeetingIdAndProposedById(meetingId, userId);
 
         return meetingId;
+    }
+
+    /**
+     * 약속을 삭제한다. 모임장만 삭제 가능
+     * 진행 전 상태의 약속만 삭제 가능
+     * 약속 시작 24시간 이내 삭제 불가
+     * @param meetingId 약속 식별자
+     */
+    @Transactional
+    public void deleteMeeting(Long meetingId) {
+        Long userId = SecurityUtil.getCurrentUserId();
+        Meeting meeting = meetingValidator.findMeetingOrThrow(meetingId);
+
+        // 모임장만 약속 삭제 가능
+        gatheringValidator.validateLeader(meeting.getGathering().getId(), userId);
+
+        validateDeletableStatus(meeting);
+        validateDeletableMeetingStartDate(meeting);
+
+        topicAnswerRepository.softDeleteByMeetingId(meetingId);
+        topicRepository.softDeleteByMeetingId(meetingId);
+        meetingRepository.delete(meeting);
+    }
+
+    private void validateDeletableStatus(Meeting meeting) {
+        if (meeting.getMeetingStatus() == MeetingStatus.DONE) {
+            throw new MeetingException(
+                    MeetingErrorCode.INVALID_MEETING_STATUS_CHANGE,
+                    "종료된 약속은 삭제할 수 없습니다."
+            );
+        }
+    }
+
+    private void validateDeletableMeetingStartDate(Meeting meeting) {
+        LocalDateTime meetingStartDate = meeting.getMeetingStartDate();
+        if (meetingStartDate != null
+                && meetingStartDate.isBefore(LocalDateTime.now().plusHours(24))) {
+            throw new MeetingException(MeetingErrorCode.MEETING_DELETE_NOT_ALLOWED);
+        }
     }
 
     /**

--- a/src/main/java/com/dokdok/topic/repository/TopicAnswerRepository.java
+++ b/src/main/java/com/dokdok/topic/repository/TopicAnswerRepository.java
@@ -2,7 +2,9 @@ package com.dokdok.topic.repository;
 
 import com.dokdok.topic.entity.TopicAnswer;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import javax.swing.*;
 import java.util.List;
@@ -29,4 +31,17 @@ public interface TopicAnswerRepository extends JpaRepository<TopicAnswer, Long> 
                     AND ta.user.id = :userId
             """)
     List<TopicAnswer> findByMeetingIdUserId(Long meetingId, Long userId);
+
+    @Modifying
+    @Query("""
+            UPDATE TopicAnswer ta
+            SET ta.deletedAt = CURRENT_TIMESTAMP
+            WHERE ta.topic.id IN (
+                SELECT t.id
+                FROM Topic t
+                WHERE t.meeting.id = :meetingId
+            )
+            AND ta.deletedAt IS NULL
+            """)
+    void softDeleteByMeetingId(@Param("meetingId") Long meetingId);
 }

--- a/src/main/java/com/dokdok/topic/repository/TopicRepository.java
+++ b/src/main/java/com/dokdok/topic/repository/TopicRepository.java
@@ -46,6 +46,15 @@ public interface TopicRepository extends JpaRepository<Topic, Long> {
             @Param("userId") Long userId
     );
 
+    @Modifying
+    @Query("""
+            UPDATE Topic t
+            SET t.deletedAt = CURRENT_TIMESTAMP
+            WHERE t.meeting.id = :meetingId
+            AND t.deletedAt IS NULL
+            """)
+    void softDeleteByMeetingId(@Param("meetingId") Long meetingId);
+
     @Query("SELECT t " +
             "FROM Topic t " +
             "JOIN FETCH t.proposedBy p " +

--- a/src/test/java/com/dokdok/meeting/scheduler/SchedulerPerformanceTest.java
+++ b/src/test/java/com/dokdok/meeting/scheduler/SchedulerPerformanceTest.java
@@ -1,0 +1,129 @@
+package com.dokdok.meeting.scheduler;
+
+import com.dokdok.meeting.entity.Meeting;
+import com.dokdok.meeting.entity.MeetingStatus;
+import com.dokdok.meeting.repository.MeetingRepository;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Scheduler 성능 측정 테스트
+ * - 1,000건, 5,000건, 10,000건 데이터에 대한 처리 시간 측정
+ */
+@SpringBootTest
+@Slf4j
+@ActiveProfiles("test")
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class SchedulerPerformanceTest {
+
+    @Autowired
+    private MeetingStatusScheduler scheduler;
+
+    @Autowired
+    private MeetingRepository meetingRepository;
+
+    @Autowired
+    private TestDataGenerator testDataGenerator;
+
+    @AfterEach
+    void cleanup() {
+        testDataGenerator.cleanupTestData();
+    }
+
+    @Test
+    @Order(1)
+    @DisplayName("Scheduler 기본 동작 테스트 - 10건")
+    void testSchedulerBasicOperation() {
+        // Given: 소량의 테스트 데이터 생성
+        int dataSize = 10;
+        testDataGenerator.generateExpiredMeetings(dataSize);
+
+        // When: Scheduler 실행
+        scheduler.updateExpiredMeetings();
+
+        // Then: CONFIRMED 상태의 Meeting이 없어야 함
+        List<Meeting> confirmedMeetings = meetingRepository
+                .findByMeetingEndDateBeforeAndMeetingStatus(
+                        LocalDateTime.now(), MeetingStatus.CONFIRMED);
+
+        assertThat(confirmedMeetings).isEmpty();
+
+        log.info("기본 동작 테스트 통과: {}건 모두 DONE으로 변경됨", dataSize);
+    }
+
+    @Test
+    @Order(2)
+    @DisplayName("Scheduler 성능 테스트: 1,000건")
+    void testSchedulerPerformance_1000() {
+        performanceTest(1000);
+    }
+
+    @Test
+    @Order(3)
+    @DisplayName("Scheduler 성능 테스트: 5,000건")
+    void testSchedulerPerformance_5000() {
+        performanceTest(5000);
+    }
+
+    @Test
+    @Order(4)
+    @DisplayName("Scheduler 성능 테스트: 10,000건")
+    void testSchedulerPerformance_10000() {
+        performanceTest(10000);
+    }
+
+    /**
+     * 공통 성능 테스트 로직
+     */
+    private void performanceTest(int dataSize) {
+        System.out.println("\n");
+        System.out.println("========================================");
+        System.out.println("테스트 시작: " + dataSize + "건");
+        System.out.println("========================================");
+        
+        // Given: 지정된 개수만큼 만료된 Meeting 생성
+        testDataGenerator.generateExpiredMeetings(dataSize);
+        
+        List<Meeting> beforeMeetings = meetingRepository
+                .findByMeetingEndDateBeforeAndMeetingStatus(
+                        LocalDateTime.now(), MeetingStatus.CONFIRMED);
+        
+        assertThat(beforeMeetings).hasSize(dataSize);
+        System.out.println("데이터 생성 완료: " + beforeMeetings.size() + "건");
+
+        // When: Scheduler 실행 및 시간 측정
+        long startTime = System.currentTimeMillis();
+        scheduler.updateExpiredMeetings();
+        long endTime = System.currentTimeMillis();
+        long duration = endTime - startTime;
+
+        // Then: 모든 Meeting이 DONE 상태로 변경되었는지 확인
+        List<Meeting> remainingConfirmed = meetingRepository
+                .findByMeetingEndDateBeforeAndMeetingStatus(
+                        LocalDateTime.now(), MeetingStatus.CONFIRMED);
+        assertThat(remainingConfirmed).isEmpty();
+
+        // 성능 지표 계산 및 출력
+        double throughput = duration > 0 ? (dataSize * 1000.0 / duration) : dataSize;
+        double avgTimePerMeeting = duration / (double) dataSize;
+
+        System.out.println("");
+        System.out.println("========================================");
+        System.out.println("성능 측정 결과 [" + dataSize + "건]");
+        System.out.println("========================================");
+        System.out.println("총 처리 시간: " + duration + "ms (" + (duration / 1000.0) + " 초)");
+        System.out.println("처리량 (TPS): " + String.format("%.2f", throughput) + "/sec");
+        System.out.println("평균 처리 시간: " + String.format("%.3f", avgTimePerMeeting) + "ms/meeting");
+        System.out.println("성공률: 100% (" + dataSize + "/" + dataSize + ")");
+        System.out.println("========================================");
+        System.out.println("\n");
+    }
+}

--- a/src/test/java/com/dokdok/meeting/scheduler/TestDataGenerator.java
+++ b/src/test/java/com/dokdok/meeting/scheduler/TestDataGenerator.java
@@ -1,0 +1,215 @@
+package com.dokdok.meeting.scheduler;
+
+import com.dokdok.book.entity.Book;
+import com.dokdok.book.repository.BookRepository;
+import com.dokdok.gathering.entity.Gathering;
+import com.dokdok.gathering.entity.GatheringStatus;
+import com.dokdok.gathering.repository.GatheringRepository;
+import com.dokdok.meeting.entity.Meeting;
+import com.dokdok.meeting.entity.MeetingStatus;
+import com.dokdok.meeting.repository.MeetingRepository;
+import com.dokdok.user.entity.User;
+import com.dokdok.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * 성능 테스트를 위한 대량 Meeting 데이터 생성 유틸
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class TestDataGenerator {
+
+    private final MeetingRepository meetingRepository;
+    private final GatheringRepository gatheringRepository;
+    private final UserRepository userRepository;
+    private final BookRepository bookRepository;
+
+    private User testUser;
+    private Book testBook;
+    private Gathering testGathering;
+
+    /**
+     * 지정된 개수만큼 만료된(CONFIRMED 상태) Meeting 데이터 생성
+     * 
+     * @param count 생성할 Meeting 개수
+     * @return 생성된 Meeting 개수
+     */
+    @Transactional
+    public int generateExpiredMeetings(int count) {
+        log.info("Starting to generate {} expired meetings...", count);
+        long startTime = System.currentTimeMillis();
+
+        // 1. 테스트용 User, Book, Gathering 생성 (한 번만)
+        ensureTestDataExists();
+
+        // 2. Meeting 대량 생성
+        List<Meeting> meetings = new ArrayList<>();
+        LocalDateTime now = LocalDateTime.now();
+        
+        for (int i = 0; i < count; i++) {
+            Meeting meeting = Meeting.builder()
+                    .gathering(testGathering)
+                    .book(testBook)
+                    .meetingLeader(testUser)
+                    .meetingName("성능테스트 모임 " + i)
+                    .place("테스트 장소 " + i)
+                    .maxParticipants(10)
+                    .meetingStatus(MeetingStatus.CONFIRMED)
+                    // 종료 시간을 과거로 설정 (1시간 ~ 24시간 전)
+                    .meetingStartDate(now.minusHours(25))
+                    .meetingEndDate(now.minusHours(1))
+                    .build();
+            
+            meetings.add(meeting);
+            
+            // 배치 사이즈마다 flush (메모리 효율)
+            if (i % 100 == 0 && i > 0) {
+                meetingRepository.saveAll(meetings);
+                meetingRepository.flush();
+                meetings.clear();
+                log.info("Generated {} meetings...", i);
+            }
+        }
+        
+        // 남은 데이터 저장
+        if (!meetings.isEmpty()) {
+            meetingRepository.saveAll(meetings);
+            meetingRepository.flush();
+        }
+
+        long endTime = System.currentTimeMillis();
+        log.info("Successfully generated {} expired meetings in {}ms", 
+                 count, (endTime - startTime));
+
+        return count;
+    }
+
+    /**
+     * 테스트 데이터 존재 여부 확인 및 생성
+     */
+    private void ensureTestDataExists() {
+        if (testUser == null) {
+            testUser = createTestUser();
+        }
+        if (testBook == null) {
+            testBook = createTestBook();
+        }
+        if (testGathering == null) {
+            testGathering = createTestGathering();
+        }
+    }
+
+    /**
+     * 생성된 테스트 데이터 삭제
+     */
+    @Transactional
+    public void cleanupTestData() {
+        log.info("Cleaning up test data...");
+        
+        // Meeting 데이터 삭제 (이름에 "성능테스트"가 포함된 것들)
+        List<Meeting> allMeetings = meetingRepository.findAll();
+        List<Meeting> testMeetings = allMeetings.stream()
+                .filter(m -> m.getMeetingName() != null && m.getMeetingName().contains("성능테스트"))
+                .toList();
+        
+        if (!testMeetings.isEmpty()) {
+            meetingRepository.deleteAll(testMeetings);
+            log.info("Cleaned up {} test meetings", testMeetings.size());
+        }
+        
+        // 테스트 데이터 참조 초기화
+        testUser = null;
+        testBook = null;
+        testGathering = null;
+    }
+
+    private User createTestUser() {
+        // 기존에 테스트 유저가 있는지 확인
+        List<User> existingUsers = userRepository.findAll();
+        User existing = existingUsers.stream()
+                .filter(u -> u.getUserEmail() != null && u.getUserEmail().equals("scheduler-test@dokdok.com"))
+                .findFirst()
+                .orElse(null);
+        
+        if (existing != null) {
+            log.info("Using existing test user: {}", existing.getId());
+            return existing;
+        }
+        
+        // 없으면 새로 생성
+        User user = User.builder()
+                .userEmail("scheduler-test@dokdok.com")
+                .nickname("스케줄러테스트")
+                .kakaoId(999999999L)
+                .profileImageUrl("https://example.com/profile.jpg")
+                .build();
+        
+        User saved = userRepository.save(user);
+        log.info("Created test user: {}", saved.getId());
+        return saved;
+    }
+
+    private Book createTestBook() {
+        // 기존에 테스트 책이 있는지 확인
+        List<Book> existingBooks = bookRepository.findAll();
+        Book existing = existingBooks.stream()
+                .filter(b -> b.getIsbn() != null && b.getIsbn().equals("TEST-SCHEDULER-ISBN"))
+                .findFirst()
+                .orElse(null);
+        
+        if (existing != null) {
+            log.info("Using existing test book: {}", existing.getId());
+            return existing;
+        }
+        
+        // 없으면 새로 생성
+        Book book = Book.builder()
+                .bookName("스케줄러 성능 테스트용 책")
+                .author("테스트 저자")
+                .publisher("테스트 출판사")
+                .isbn("TEST-SCHEDULER-ISBN")
+                .thumbnail("https://example.com/book.jpg")
+                .build();
+        
+        Book saved = bookRepository.save(book);
+        log.info("Created test book: {}", saved.getId());
+        return saved;
+    }
+
+    private Gathering createTestGathering() {
+        // 기존에 테스트 모임이 있는지 확인
+        List<Gathering> existingGatherings = gatheringRepository.findAll();
+        Gathering existing = existingGatherings.stream()
+                .filter(g -> g.getGatheringName() != null && g.getGatheringName().equals("스케줄러 테스트 모임"))
+                .findFirst()
+                .orElse(null);
+        
+        if (existing != null) {
+            log.info("Using existing test gathering: {}", existing.getId());
+            return existing;
+        }
+        
+        // 없으면 새로 생성
+        String uniqueCode = UUID.randomUUID().toString().substring(0, 8);
+        Gathering gathering = Gathering.builder()
+                .gatheringName("스케줄러 테스트 모임")
+                .description("성능 테스트를 위한 모임입니다")
+                .invitationLink("SCHEDULER-TEST-" + uniqueCode)
+                .gatheringLeader(testUser)
+                .gatheringStatus(GatheringStatus.ACTIVE)
+                .build();
+        
+        Gathering saved = gatheringRepository.save(gathering);
+        log.info("Created test gathering: {}", saved.getId());
+        return saved;
+    }
+}

--- a/src/test/java/com/dokdok/meeting/service/MeetingServiceTest.java
+++ b/src/test/java/com/dokdok/meeting/service/MeetingServiceTest.java
@@ -21,6 +21,7 @@ import com.dokdok.meeting.exception.MeetingException;
 import com.dokdok.meeting.repository.MeetingMemberRepository;
 import com.dokdok.meeting.repository.MeetingRepository;
 import com.dokdok.topic.entity.TopicType;
+import com.dokdok.topic.repository.TopicAnswerRepository;
 import com.dokdok.topic.repository.TopicRepository;
 import com.dokdok.user.entity.User;
 import com.dokdok.user.service.UserValidator;
@@ -61,6 +62,9 @@ class MeetingServiceTest {
 
     @Mock
     private TopicRepository topicRepository;
+
+    @Mock
+    private TopicAnswerRepository topicAnswerRepository;
 
     @Mock
     private GatheringRepository gatheringRepository;
@@ -149,6 +153,89 @@ class MeetingServiceTest {
                     .isInstanceOf(MeetingException.class)
                     .extracting("errorCode")
                     .isEqualTo(MeetingErrorCode.MEETING_NOT_FOUND);
+        }
+    }
+
+    @DisplayName("모임장이 약속을 삭제하면 연관 데이터가 soft delete 되고 약속이 삭제된다.")
+    @Test
+    void givenLeaderAndDeletableMeeting_whenDeleteMeeting_thenSoftDeleteAndRemove() {
+        // given
+        Long userId = leader.getId();
+        meeting = Meeting.builder()
+                .id(meetingId)
+                .meetingStatus(MeetingStatus.CONFIRMED)
+                .meetingStartDate(LocalDateTime.now().plusDays(2))
+                .meetingLeader(leader)
+                .gathering(gathering)
+                .build();
+
+        given(meetingValidator.findMeetingOrThrow(meetingId))
+                .willReturn(meeting);
+
+        try (MockedStatic<SecurityUtil> securityUtilMock = mockStatic(SecurityUtil.class)) {
+            securityUtilMock.when(SecurityUtil::getCurrentUserId).thenReturn(userId);
+
+            // when
+            meetingService.deleteMeeting(meetingId);
+
+            // then
+            verify(gatheringValidator).validateLeader(gathering.getId(), userId);
+            verify(topicAnswerRepository).softDeleteByMeetingId(meetingId);
+            verify(topicRepository).softDeleteByMeetingId(meetingId);
+            verify(meetingRepository).delete(meeting);
+        }
+    }
+
+    @DisplayName("약속 시작 24시간 이내면 약속 삭제가 불가하다.")
+    @Test
+    void givenMeetingWithin24Hours_whenDeleteMeeting_thenThrowException() {
+        // given
+        Long userId = leader.getId();
+        meeting = Meeting.builder()
+                .id(meetingId)
+                .meetingStatus(MeetingStatus.CONFIRMED)
+                .meetingStartDate(LocalDateTime.now().plusHours(23))
+                .meetingLeader(leader)
+                .gathering(gathering)
+                .build();
+
+        given(meetingValidator.findMeetingOrThrow(meetingId))
+                .willReturn(meeting);
+
+        try (MockedStatic<SecurityUtil> securityUtilMock = mockStatic(SecurityUtil.class)) {
+            securityUtilMock.when(SecurityUtil::getCurrentUserId).thenReturn(userId);
+
+            // when + then
+            assertThatThrownBy(() -> meetingService.deleteMeeting(meetingId))
+                    .isInstanceOf(MeetingException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(MeetingErrorCode.MEETING_DELETE_NOT_ALLOWED);
+        }
+    }
+
+    @DisplayName("완료된 약속은 삭제할 수 없다.")
+    @Test
+    void givenDoneMeeting_whenDeleteMeeting_thenThrowException() {
+        // given
+        Long userId = leader.getId();
+        meeting = Meeting.builder()
+                .id(meetingId)
+                .meetingStatus(MeetingStatus.DONE)
+                .meetingLeader(leader)
+                .gathering(gathering)
+                .build();
+
+        given(meetingValidator.findMeetingOrThrow(meetingId))
+                .willReturn(meeting);
+
+        try (MockedStatic<SecurityUtil> securityUtilMock = mockStatic(SecurityUtil.class)) {
+            securityUtilMock.when(SecurityUtil::getCurrentUserId).thenReturn(userId);
+
+            // when + then
+            assertThatThrownBy(() -> meetingService.deleteMeeting(meetingId))
+                    .isInstanceOf(MeetingException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(MeetingErrorCode.INVALID_MEETING_STATUS_CHANGE);
         }
     }
 

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,0 +1,31 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:testdb
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+  
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    show-sql: false
+    properties:
+      hibernate:
+        format_sql: false
+        dialect: org.hibernate.dialect.H2Dialect
+  
+  sql:
+    init:
+      mode: never
+
+logging:
+  level:
+    root: WARN
+    com.dokdok: INFO
+    com.dokdok.meeting.scheduler: INFO
+    org.hibernate: WARN
+    org.hibernate.SQL: OFF
+    org.hibernate.type.descriptor.sql.BasicBinder: OFF
+    org.springframework: WARN
+  pattern:
+    console: "%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n"


### PR DESCRIPTION
## PR 요약
> 이 PR이 어떤 변경을 하는지 간단히 설명하고, 체크 표시는 괄호 사이에 소문자 'x'를 삽입하세요.

- [x] 기능 추가
- [ ] 버그 수정
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 기타 (설명)

---

## 이슈 번호
- #131

---

## 주요 변경 사항
> 주요 파일, 로직, 컴포넌트 등을 구체적으로 적어주세요.

스케줄러 기반으로 10분마다 약속을 조회하여 약속시간이 지났는데, CONFIRMED 상태인 것을 DONE으로 자동 변경합니다.

- `build.gradle`: +9/-0 (1 files) — 요구사항 반영
- `src/main/java/com/dokdok/global`: +13/-0 (1 files) — 요구사항 반영
- `src/main/java/com/dokdok/meeting`: +154/-0 (6 files) — 약속 상태 변경 스케줄러 등록
- `src/main/java/com/dokdok/topic`: +24/-0 (2 files) — 요구사항 반영
- `src/test/java/com/dokdok/meeting`: +431/-0 (3 files) — 약속 상태 자동 변경 테스트 코드
- `src/test/resources`: +31/-0 (1 files) — 요구사항 반영

---

## 참고 사항
> 리뷰어가 알아야 할 추가 정보, 테스트 방법 등을 작성해주세요.

예:
- 테스트 계정 정보
- 관련 API 엔드포인트
- 로컬 테스트 방법

---
