### PR TITLE
[#128][FEAT] 공동 회고 작성 구현

### DIFF
--- a/src/main/java/com/dokdok/retrospective/api/MeetingRetrospectiveApi.java
+++ b/src/main/java/com/dokdok/retrospective/api/MeetingRetrospectiveApi.java
@@ -1,6 +1,7 @@
 package com.dokdok.retrospective.api;
 
 import com.dokdok.global.response.ApiResponse;
+import com.dokdok.retrospective.dto.request.MeetingRetrospectiveRequest;
 import com.dokdok.retrospective.dto.response.MeetingRetrospectiveResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -9,10 +10,13 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 
 @Tag(name = "공동 회고", description = "공동 회고 관련 API")
 public interface MeetingRetrospectiveApi {
@@ -38,5 +42,30 @@ public interface MeetingRetrospectiveApi {
     @GetMapping(produces = MediaType.APPLICATION_JSON_VALUE)
     ResponseEntity<ApiResponse<MeetingRetrospectiveResponse>> getMeetingRetrospective(
             @PathVariable Long meetingId
+    );
+
+    @Operation(
+            summary = "공동 회고 작성",
+            description = "약속에 대한 공동 회고를 작성합니다.",
+            parameters = {
+                    @Parameter(name = "meetingId", description = "약속 식별자", in = ParameterIn.PATH, required = true)
+            }
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "201",
+                    description = "공동 회고 작성 완료",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = MeetingRetrospectiveResponse.CommentResponse.class))
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "접근 권한 없음"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "약속 또는 토픽을 찾을 수 없음"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 오류")
+    })
+    @PostMapping(consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
+    ResponseEntity<ApiResponse<MeetingRetrospectiveResponse.CommentResponse>> createMeetingRetrospective(
+            @PathVariable Long meetingId,
+            @Valid @RequestBody MeetingRetrospectiveRequest request
     );
 }

--- a/src/main/java/com/dokdok/retrospective/controller/MeetingRetrospectiveController.java
+++ b/src/main/java/com/dokdok/retrospective/controller/MeetingRetrospectiveController.java
@@ -2,14 +2,14 @@ package com.dokdok.retrospective.controller;
 
 import com.dokdok.global.response.ApiResponse;
 import com.dokdok.retrospective.api.MeetingRetrospectiveApi;
+import com.dokdok.retrospective.dto.request.MeetingRetrospectiveRequest;
 import com.dokdok.retrospective.dto.response.MeetingRetrospectiveResponse;
+import com.dokdok.retrospective.entity.MeetingRetrospective;
 import com.dokdok.retrospective.service.MeetingRetrospectiveService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -24,5 +24,15 @@ public class MeetingRetrospectiveController implements MeetingRetrospectiveApi {
         MeetingRetrospectiveResponse response = meetingRetrospectiveService.getMeetingRetrospective(meetingId);
 
         return ApiResponse.success(response,"공동 회고 조회 성공");
+    }
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<MeetingRetrospectiveResponse.CommentResponse>> createMeetingRetrospective(
+            @PathVariable Long meetingId,
+            @Valid @RequestBody MeetingRetrospectiveRequest request
+            ) {
+        MeetingRetrospectiveResponse.CommentResponse response = meetingRetrospectiveService.createMeetingRetrospective(meetingId, request);
+
+        return ApiResponse.created(response, "공동 회고 작성 완료");
     }
 }

--- a/src/main/java/com/dokdok/retrospective/dto/request/MeetingRetrospectiveRequest.java
+++ b/src/main/java/com/dokdok/retrospective/dto/request/MeetingRetrospectiveRequest.java
@@ -1,0 +1,15 @@
+package com.dokdok.retrospective.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+
+@Builder
+public record MeetingRetrospectiveRequest(
+
+        @NotNull
+        Long topicId,
+
+        @NotBlank
+        String comment
+) { }

--- a/src/main/java/com/dokdok/retrospective/entity/MeetingRetrospective.java
+++ b/src/main/java/com/dokdok/retrospective/entity/MeetingRetrospective.java
@@ -41,4 +41,13 @@ public class MeetingRetrospective extends BaseTimeEntity {
 
     @Column(name = "comment", columnDefinition = "TEXT")
     private String comment;
+
+    public static MeetingRetrospective of(Meeting meeting, User user, Topic topic, String comment){
+        return MeetingRetrospective.builder()
+                .meeting(meeting)
+                .createdBy(user)
+                .topic(topic)
+                .comment(comment).
+                build();
+    }
 }

--- a/src/main/java/com/dokdok/retrospective/repository/RetrospectiveRepository.java
+++ b/src/main/java/com/dokdok/retrospective/repository/RetrospectiveRepository.java
@@ -11,5 +11,4 @@ public interface RetrospectiveRepository extends JpaRepository<MeetingRetrospect
 
     List<MeetingRetrospective> findAllByMeetingId(Long meetingId);
 
-    List<MeetingRetrospective> findAllByTopicId(Long topicId);
 }

--- a/src/main/java/com/dokdok/retrospective/repository/TopicRetrospectiveSummaryRepository.java
+++ b/src/main/java/com/dokdok/retrospective/repository/TopicRetrospectiveSummaryRepository.java
@@ -11,7 +11,6 @@ import java.util.Optional;
 @Repository
 public interface TopicRetrospectiveSummaryRepository extends JpaRepository<TopicRetrospectiveSummary, Long> {
 
-    Optional<TopicRetrospectiveSummary> findByTopicId(Long topicId);
-
     List<TopicRetrospectiveSummary> findAllByTopicIdIn(Collection<Long> topicIds);
+
 }

--- a/src/main/java/com/dokdok/retrospective/service/MeetingRetrospectiveService.java
+++ b/src/main/java/com/dokdok/retrospective/service/MeetingRetrospectiveService.java
@@ -5,6 +5,8 @@ import com.dokdok.meeting.entity.Meeting;
 import com.dokdok.meeting.exception.MeetingErrorCode;
 import com.dokdok.meeting.exception.MeetingException;
 import com.dokdok.meeting.repository.MeetingRepository;
+import com.dokdok.meeting.service.MeetingValidator;
+import com.dokdok.retrospective.dto.request.MeetingRetrospectiveRequest;
 import com.dokdok.retrospective.dto.response.MeetingRetrospectiveResponse;
 import com.dokdok.retrospective.entity.MeetingRetrospective;
 import com.dokdok.retrospective.entity.TopicRetrospectiveSummary;
@@ -13,6 +15,9 @@ import com.dokdok.retrospective.repository.TopicRetrospectiveSummaryRepository;
 import com.dokdok.topic.entity.Topic;
 import com.dokdok.topic.entity.TopicStatus;
 import com.dokdok.topic.repository.TopicRepository;
+import com.dokdok.topic.service.TopicValidator;
+import com.dokdok.user.entity.User;
+import com.dokdok.user.service.UserValidator;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -26,18 +31,17 @@ import java.util.stream.Collectors;
 @Transactional(readOnly = true)
 public class MeetingRetrospectiveService {
 
-    private final MeetingRepository meetingRepository;
     private final TopicRepository topicRepository;
     private final RetrospectiveValidator retrospectiveValidator;
     private final TopicRetrospectiveSummaryRepository topicRetrospectiveSummaryRepository;
     private final RetrospectiveRepository retrospectiveRepository;
+    private final MeetingValidator meetingValidator;
+    private final TopicValidator topicValidator;
 
     public MeetingRetrospectiveResponse getMeetingRetrospective(Long meetingId){
         Long userId = SecurityUtil.getCurrentUserId();
 
-        // Meeting 조회
-        Meeting meeting = meetingRepository.findById(meetingId)
-                .orElseThrow(() -> new MeetingException(MeetingErrorCode.MEETING_NOT_FOUND));
+        Meeting meeting = meetingValidator.findMeetingOrThrow(meetingId);
 
         // 권한 검증
         retrospectiveValidator.validateMeetingRetrospectiveAccess(
@@ -84,5 +88,30 @@ public class MeetingRetrospectiveService {
         return comments.stream()
                 .map(MeetingRetrospectiveResponse.CommentResponse::from)
                 .toList();
+    }
+
+    @Transactional
+    public MeetingRetrospectiveResponse.CommentResponse createMeetingRetrospective(
+            Long meetingId,
+            MeetingRetrospectiveRequest request
+    ){
+        // user 조회
+        User user = SecurityUtil.getCurrentUser().getUser();
+        Long userId = SecurityUtil.getCurrentUserId();
+
+        // Meeting 조회
+        Meeting meeting = meetingValidator.findMeetingOrThrow(meetingId);
+
+        // 권한 검증
+        retrospectiveValidator.validateMeetingRetrospectiveAccess(meeting.getGathering().getId(),meetingId,userId);
+
+        // Topic 조회
+        Topic topic = topicValidator.getTopicInMeeting(request.topicId(), meetingId);
+
+        // save
+        MeetingRetrospective retrospective = MeetingRetrospective.of(meeting, user, topic, request.comment());
+        MeetingRetrospective saved = retrospectiveRepository.save(retrospective);
+
+        return MeetingRetrospectiveResponse.CommentResponse.from(saved);
     }
 }

--- a/src/main/java/com/dokdok/retrospective/service/RetrospectiveValidator.java
+++ b/src/main/java/com/dokdok/retrospective/service/RetrospectiveValidator.java
@@ -1,13 +1,6 @@
 package com.dokdok.retrospective.service;
 
-import com.dokdok.gathering.exception.GatheringErrorCode;
-import com.dokdok.gathering.exception.GatheringException;
-import com.dokdok.gathering.repository.GatheringMemberRepository;
 import com.dokdok.gathering.service.GatheringValidator;
-import com.dokdok.meeting.exception.MeetingErrorCode;
-import com.dokdok.meeting.exception.MeetingException;
-import com.dokdok.meeting.repository.MeetingMemberRepository;
-import com.dokdok.meeting.repository.MeetingRepository;
 import com.dokdok.meeting.service.MeetingValidator;
 import com.dokdok.retrospective.exception.RetrospectiveErrorCode;
 import com.dokdok.retrospective.exception.RetrospectiveException;

--- a/src/test/java/com/dokdok/retrospective/service/MeetingRetrospectiveServiceTest.java
+++ b/src/test/java/com/dokdok/retrospective/service/MeetingRetrospectiveServiceTest.java
@@ -8,13 +8,19 @@ import com.dokdok.meeting.entity.Meeting;
 import com.dokdok.meeting.exception.MeetingErrorCode;
 import com.dokdok.meeting.exception.MeetingException;
 import com.dokdok.meeting.repository.MeetingRepository;
+import com.dokdok.meeting.service.MeetingValidator;
+import com.dokdok.oauth2.CustomOAuth2User;
+import com.dokdok.retrospective.dto.request.MeetingRetrospectiveRequest;
 import com.dokdok.retrospective.dto.response.MeetingRetrospectiveResponse;
+import com.dokdok.retrospective.entity.MeetingRetrospective;
 import com.dokdok.retrospective.entity.TopicRetrospectiveSummary;
 import com.dokdok.retrospective.repository.RetrospectiveRepository;
 import com.dokdok.retrospective.repository.TopicRetrospectiveSummaryRepository;
 import com.dokdok.topic.entity.Topic;
 import com.dokdok.topic.entity.TopicStatus;
 import com.dokdok.topic.repository.TopicRepository;
+import com.dokdok.topic.service.TopicValidator;
+import com.dokdok.user.entity.User;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -25,7 +31,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -52,31 +57,33 @@ class MeetingRetrospectiveServiceTest {
 	@InjectMocks
 	private MeetingRetrospectiveService meetingRetrospectiveService;
 
+	@Mock
+	private MeetingValidator meetingValidator;
+
+	@Mock
+	private TopicValidator topicValidator;
+
 	@Test
 	@DisplayName("약속이 없으면 예외가 발생한다")
 	void getMeetingRetrospective_throwsWhenMeetingNotFound() {
-		// given
 		Long meetingId = 999L;
 		Long userId = 1L;
 
 		try (MockedStatic<SecurityUtil> securityUtilMock = mockStatic(SecurityUtil.class)) {
 			securityUtilMock.when(SecurityUtil::getCurrentUserId).thenReturn(userId);
 
-			when(meetingRepository.findById(meetingId)).thenReturn(Optional.empty());
+			when(meetingValidator.findMeetingOrThrow(meetingId))
+					.thenThrow(new MeetingException(MeetingErrorCode.MEETING_NOT_FOUND));
 
-			// when & then
 			assertThatThrownBy(() -> meetingRetrospectiveService.getMeetingRetrospective(meetingId))
 					.isInstanceOf(MeetingException.class)
 					.hasFieldOrPropertyWithValue("errorCode", MeetingErrorCode.MEETING_NOT_FOUND);
-
-			verify(retrospectiveValidator, never()).validateMeetingRetrospectiveAccess(any(), any(), any());
 		}
 	}
 
 	@Test
 	@DisplayName("모임 멤버가 아니면 예외가 발생한다")
 	void getMeetingRetrospective_throwsWhenNotGatheringMember() {
-		// given
 		Long meetingId = 1L;
 		Long userId = 999L;
 		Long gatheringId = 1L;
@@ -87,23 +94,19 @@ class MeetingRetrospectiveServiceTest {
 		try (MockedStatic<SecurityUtil> securityUtilMock = mockStatic(SecurityUtil.class)) {
 			securityUtilMock.when(SecurityUtil::getCurrentUserId).thenReturn(userId);
 
-			when(meetingRepository.findById(meetingId)).thenReturn(Optional.of(meeting));
+			when(meetingValidator.findMeetingOrThrow(meetingId)).thenReturn(meeting);
 			doThrow(new GatheringException(GatheringErrorCode.NOT_GATHERING_MEMBER))
 					.when(retrospectiveValidator).validateMeetingRetrospectiveAccess(gatheringId, meetingId, userId);
 
-			// when & then
 			assertThatThrownBy(() -> meetingRetrospectiveService.getMeetingRetrospective(meetingId))
 					.isInstanceOf(GatheringException.class)
 					.hasFieldOrPropertyWithValue("errorCode", GatheringErrorCode.NOT_GATHERING_MEMBER);
-
-			verify(topicRepository, never()).findByMeetingIdAndTopicStatusOrderByConfirmOrderAsc(any(), any());
 		}
 	}
 
 	@Test
 	@DisplayName("약속 멤버가 아니면 예외가 발생한다")
 	void getMeetingRetrospective_throwsWhenNotMeetingMember() {
-		// given
 		Long meetingId = 1L;
 		Long userId = 999L;
 		Long gatheringId = 1L;
@@ -114,23 +117,19 @@ class MeetingRetrospectiveServiceTest {
 		try (MockedStatic<SecurityUtil> securityUtilMock = mockStatic(SecurityUtil.class)) {
 			securityUtilMock.when(SecurityUtil::getCurrentUserId).thenReturn(userId);
 
-			when(meetingRepository.findById(meetingId)).thenReturn(Optional.of(meeting));
+			when(meetingValidator.findMeetingOrThrow(meetingId)).thenReturn(meeting);
 			doThrow(new MeetingException(MeetingErrorCode.NOT_GATHERING_MEETING))
 					.when(retrospectiveValidator).validateMeetingRetrospectiveAccess(gatheringId, meetingId, userId);
 
-			// when & then
 			assertThatThrownBy(() -> meetingRetrospectiveService.getMeetingRetrospective(meetingId))
 					.isInstanceOf(MeetingException.class)
 					.hasFieldOrPropertyWithValue("errorCode", MeetingErrorCode.NOT_GATHERING_MEETING);
-
-			verify(topicRepository, never()).findByMeetingIdAndTopicStatusOrderByConfirmOrderAsc(any(), any());
 		}
 	}
 
 	@Test
 	@DisplayName("확정된 토픽이 없으면 빈 목록을 반환한다")
 	void getMeetingRetrospective_withNoTopics_returnsEmptyList() {
-		// given
 		Long meetingId = 1L;
 		Long userId = 1L;
 		Long gatheringId = 1L;
@@ -147,17 +146,15 @@ class MeetingRetrospectiveServiceTest {
 		try (MockedStatic<SecurityUtil> securityUtilMock = mockStatic(SecurityUtil.class)) {
 			securityUtilMock.when(SecurityUtil::getCurrentUserId).thenReturn(userId);
 
-			when(meetingRepository.findById(meetingId)).thenReturn(Optional.of(meeting));
+			when(meetingValidator.findMeetingOrThrow(meetingId)).thenReturn(meeting);
 			doNothing().when(retrospectiveValidator).validateMeetingRetrospectiveAccess(gatheringId, meetingId, userId);
 			when(topicRepository.findByMeetingIdAndTopicStatusOrderByConfirmOrderAsc(meetingId, TopicStatus.CONFIRMED))
 					.thenReturn(List.of());
 			when(topicRetrospectiveSummaryRepository.findAllByTopicIdIn(List.of())).thenReturn(List.of());
 			when(retrospectiveRepository.findAllByMeetingId(meetingId)).thenReturn(List.of());
 
-			// when
 			MeetingRetrospectiveResponse response = meetingRetrospectiveService.getMeetingRetrospective(meetingId);
 
-			// then
 			assertThat(response.meetingId()).isEqualTo(meetingId);
 			assertThat(response.topics()).isEmpty();
 		}
@@ -166,7 +163,6 @@ class MeetingRetrospectiveServiceTest {
 	@Test
 	@DisplayName("코멘트가 없어도 정상적으로 조회한다")
 	void getMeetingRetrospective_withNoComments_success() {
-		// given
 		Long meetingId = 1L;
 		Long userId = 1L;
 		Long gatheringId = 1L;
@@ -190,20 +186,127 @@ class MeetingRetrospectiveServiceTest {
 		try (MockedStatic<SecurityUtil> securityUtilMock = mockStatic(SecurityUtil.class)) {
 			securityUtilMock.when(SecurityUtil::getCurrentUserId).thenReturn(userId);
 
-			when(meetingRepository.findById(meetingId)).thenReturn(Optional.of(meeting));
+			when(meetingValidator.findMeetingOrThrow(meetingId)).thenReturn(meeting);
 			doNothing().when(retrospectiveValidator).validateMeetingRetrospectiveAccess(gatheringId, meetingId, userId);
 			when(topicRepository.findByMeetingIdAndTopicStatusOrderByConfirmOrderAsc(meetingId, TopicStatus.CONFIRMED))
 					.thenReturn(List.of(topic));
 			when(topicRetrospectiveSummaryRepository.findAllByTopicIdIn(List.of(1L))).thenReturn(List.of(summary));
 			when(retrospectiveRepository.findAllByMeetingId(meetingId)).thenReturn(List.of());
 
-			// when
 			MeetingRetrospectiveResponse response = meetingRetrospectiveService.getMeetingRetrospective(meetingId);
 
-			// then
 			assertThat(response.topics()).hasSize(1);
 			assertThat(response.topics().get(0).summarizedOpinions()).containsExactly("요약1");
 			assertThat(response.topics().get(0).comments()).isEmpty();
+		}
+	}
+
+	@Test
+	@DisplayName("공동 회고를 정상적으로 작성한다")
+	void createMeetingRetrospective_success() {
+		// given
+		Long meetingId = 1L;
+		Long userId = 1L;
+		Long topicId = 1L;
+		Long gatheringId = 1L;
+
+		Gathering gathering = Gathering.builder().id(gatheringId).build();
+		Meeting meeting = Meeting.builder().id(meetingId).gathering(gathering).build();
+		User user = User.builder().id(userId).nickname("사용자1").profileImageUrl("https://image.jpg").build();
+		Topic topic = Topic.builder().id(topicId).meeting(meeting).title("토픽1").build();
+
+		MeetingRetrospectiveRequest request = new MeetingRetrospectiveRequest(topicId, "회고 코멘트입니다.");
+
+		MeetingRetrospective saved = MeetingRetrospective.builder()
+				.id(1L)
+				.meeting(meeting)
+				.createdBy(user)
+				.topic(topic)
+				.comment("회고 코멘트입니다.")
+				.build();
+
+		CustomOAuth2User customOAuth2User = mock(CustomOAuth2User.class);
+		when(customOAuth2User.getUser()).thenReturn(user);
+
+		try (MockedStatic<SecurityUtil> securityUtilMock = mockStatic(SecurityUtil.class)) {
+			securityUtilMock.when(SecurityUtil::getCurrentUserId).thenReturn(userId);
+			securityUtilMock.when(SecurityUtil::getCurrentUser).thenReturn(customOAuth2User);
+
+			when(meetingValidator.findMeetingOrThrow(meetingId)).thenReturn(meeting);
+			doNothing().when(retrospectiveValidator).validateMeetingRetrospectiveAccess(gatheringId, meetingId, userId);
+			when(topicValidator.getTopicInMeeting(topicId, meetingId)).thenReturn(topic);
+			when(retrospectiveRepository.save(any(MeetingRetrospective.class))).thenReturn(saved);
+
+			// when
+			MeetingRetrospectiveResponse.CommentResponse response =
+					meetingRetrospectiveService.createMeetingRetrospective(meetingId, request);
+
+			// then
+			assertThat(response.meetingRetrospectiveId()).isEqualTo(1L);
+			assertThat(response.userId()).isEqualTo(userId);
+			assertThat(response.comment()).isEqualTo("회고 코멘트입니다.");
+
+			verify(meetingValidator).findMeetingOrThrow(meetingId);
+			verify(retrospectiveValidator).validateMeetingRetrospectiveAccess(gatheringId, meetingId, userId);
+			verify(topicValidator).getTopicInMeeting(topicId, meetingId);
+			verify(retrospectiveRepository).save(any(MeetingRetrospective.class));
+		}
+	}
+
+	@Test
+	@DisplayName("공동 회고 작성 시 약속이 없으면 예외가 발생한다")
+	void createMeetingRetrospective_throwsWhenMeetingNotFound() {
+		Long meetingId = 999L;
+		Long userId = 1L;
+		User user = User.builder().id(userId).build();
+		MeetingRetrospectiveRequest request = new MeetingRetrospectiveRequest(1L, "코멘트");
+
+		CustomOAuth2User customOAuth2User = mock(CustomOAuth2User.class);
+		when(customOAuth2User.getUser()).thenReturn(user);
+
+		try (MockedStatic<SecurityUtil> securityUtilMock = mockStatic(SecurityUtil.class)) {
+			securityUtilMock.when(SecurityUtil::getCurrentUserId).thenReturn(userId);
+			securityUtilMock.when(SecurityUtil::getCurrentUser).thenReturn(customOAuth2User);
+
+			when(meetingValidator.findMeetingOrThrow(meetingId))
+					.thenThrow(new MeetingException(MeetingErrorCode.MEETING_NOT_FOUND));
+
+			assertThatThrownBy(() -> meetingRetrospectiveService.createMeetingRetrospective(meetingId, request))
+					.isInstanceOf(MeetingException.class)
+					.hasFieldOrPropertyWithValue("errorCode", MeetingErrorCode.MEETING_NOT_FOUND);
+
+			verify(retrospectiveRepository, never()).save(any());
+		}
+	}
+
+	@Test
+	@DisplayName("공동 회고 작성 시 권한이 없으면 예외가 발생한다")
+	void createMeetingRetrospective_throwsWhenNoAccess() {
+		Long meetingId = 1L;
+		Long userId = 999L;
+		Long gatheringId = 1L;
+
+		Gathering gathering = Gathering.builder().id(gatheringId).build();
+		Meeting meeting = Meeting.builder().id(meetingId).gathering(gathering).build();
+		User user = User.builder().id(userId).build();
+		MeetingRetrospectiveRequest request = new MeetingRetrospectiveRequest(1L, "코멘트");
+
+		CustomOAuth2User customOAuth2User = mock(CustomOAuth2User.class);
+		when(customOAuth2User.getUser()).thenReturn(user);
+
+		try (MockedStatic<SecurityUtil> securityUtilMock = mockStatic(SecurityUtil.class)) {
+			securityUtilMock.when(SecurityUtil::getCurrentUserId).thenReturn(userId);
+			securityUtilMock.when(SecurityUtil::getCurrentUser).thenReturn(customOAuth2User);
+
+			when(meetingValidator.findMeetingOrThrow(meetingId)).thenReturn(meeting);
+			doThrow(new GatheringException(GatheringErrorCode.NOT_GATHERING_MEMBER))
+					.when(retrospectiveValidator).validateMeetingRetrospectiveAccess(gatheringId, meetingId, userId);
+
+			assertThatThrownBy(() -> meetingRetrospectiveService.createMeetingRetrospective(meetingId, request))
+					.isInstanceOf(GatheringException.class)
+					.hasFieldOrPropertyWithValue("errorCode", GatheringErrorCode.NOT_GATHERING_MEMBER);
+
+			verify(retrospectiveRepository, never()).save(any());
 		}
 	}
 }


### PR DESCRIPTION
## PR 요약
> 이 PR이 어떤 변경을 하는지 간단히 설명하고, 체크 표시는 괄호 사이에 소문자 'x'를 삽입하세요.

- [x] 기능 추가
- [ ] 버그 수정
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 기타 (설명)

---

## 이슈 번호
- #128 

---

## 주요 변경 사항
> 주요 파일, 로직, 컴포넌트 등을 구체적으로 적어주세요.

- src/main/java/com/dokdok/retrospective/controller/MeetingRetrospectiveController.java: 공동 회고 작성 엔드포인트 구현 추가
- src/main/java/com/dokdok/retrospective/dto/request/MeetingRetrospectiveRequest.java: 회고 작성 요청 DTO 신규 추가(topicId, comment)
- src/main/java/com/dokdok/retrospective/entity/MeetingRetrospective.java: 엔티티 생성 편의용 정적 팩토리 메서드 추가
 - src/main/java/com/dokdok/retrospective/repository/RetrospectiveRepository.java: findAllByTopicId 제거
  - src/main/java/com/dokdok/retrospective/repository/RetrospectiveRepository.java: 더 이상 사용되지 않는 쿼리 정리
  - src/main/java/com/dokdok/retrospective/repository/TopicRetrospectiveSummaryRepository.java: findByTopicId 제거, findAllByTopicIdIn만 유지
  - src/main/java/com/dokdok/retrospective/service/MeetingRetrospectiveService.java: 공동 회고 작성 기능 구현과 검증 책임 분리를 위해 수정
  - src/main/java/com/dokdok/retrospective/service/RetrospectiveValidator.java: 불필요한 repository/exception import 정리
  - src/main/java/com/dokdok/retrospective/service/RetrospectiveValidator.java: Validator 역할에 맞게 의존성 축소
  - src/test/java/com/dokdok/retrospective/service/MeetingRetrospectiveServiceTest.java: 회고 작성 성공/예외 케이스 테스트 추가, validator 기반 조회로 테스트 수정


