### PR TITLE
[#126][FEAT]개인 기록 조회 API 구현

### DIFF
--- a/src/main/java/com/dokdok/book/api/BookApi.java
+++ b/src/main/java/com/dokdok/book/api/BookApi.java
@@ -428,4 +428,88 @@ public interface BookApi {
             @Parameter(description = "삭제할 기록 ID", required = true, example = "5")
             @PathVariable Long recordId
     );
+
+
+    @Operation(
+            summary = "독서 기록 목록 조회",
+            description = """
+                    내 책장에 있는 책의 독서 기록을 조회합니다.
+                    - 경로의 personalBookId로 책을 지정합니다.
+                    - 로그인한 사용자 기준으로 본인 책의 기록만 조회됩니다.
+                    - page/size/sort 파라미터로 페이징과 정렬을 제어할 수 있습니다. (기본 정렬: createdAt DESC)
+                    """
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "독서 기록 조회 성공",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = ApiResponse.class),
+                            examples = @io.swagger.v3.oas.annotations.media.ExampleObject(
+                                    value = """
+                                            {
+                                              "code": "SUCCESS",
+                                              "message": "기록 조회 성공",
+                                              "data": {
+                                                "content": [
+                                                  {
+                                                    "recordId": 5,
+                                                    "recordType": "QUOTE",
+                                                    "recordContent": "오늘 기억하고 싶은 문장을 기록합니다.",
+                                                    "meta": {
+                                                      "page": 23,
+                                                      "excerpt": "이 문장이 좋았다."
+                                                    },
+                                                    "personalBookId": 10
+                                                  }
+                                                ],
+                                                "pageable": {
+                                                  "pageNumber": 0,
+                                                  "pageSize": 10,
+                                                  "offset": 0,
+                                                  "paged": true,
+                                                  "unpaged": false,
+                                                  "sort": {
+                                                    "empty": false,
+                                                    "sorted": true,
+                                                    "unsorted": false
+                                                  }
+                                                },
+                                                "last": true,
+                                                "totalPages": 1,
+                                                "totalElements": 1,
+                                                "size": 10,
+                                                "number": 0,
+                                                "sort": {
+                                                  "empty": false,
+                                                  "sorted": true,
+                                                  "unsorted": false
+                                                },
+                                                "first": true,
+                                                "numberOfElements": 1,
+                                                "empty": false
+                                              }
+                                            }
+                                            """
+                            ))
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 실패 - 로그인이 필요합니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "책을 찾을 수 없음"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 오류")
+    })
+    @GetMapping("/{personalBookId}/records")
+    ResponseEntity<ApiResponse<Page<PersonalReadingRecordListResponse>>> getMyReadingRecords(
+            @Parameter(description = "책장 ID", required = true, example = "10")
+            @PathVariable Long personalBookId,
+            @ParameterObject
+            @Parameter(
+                    description = "페이징 정보 (page: 페이지 번호, size: 페이지 크기, sort: 정렬 기준)",
+                    example = "page=0&size=10&sort=createdAt,desc"
+            )
+            @PageableDefault(
+                    size = 10,
+                    sort = "createdAt",
+                    direction = Sort.Direction.DESC
+            ) Pageable pageable
+    );
 }

--- a/src/main/java/com/dokdok/book/controller/BookController.java
+++ b/src/main/java/com/dokdok/book/controller/BookController.java
@@ -13,6 +13,8 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -78,5 +80,17 @@ public class BookController implements BookApi {
     public ResponseEntity<ApiResponse<Void>> deleteMyReadingRecord(@PathVariable Long personalBookId, @PathVariable Long recordId) {
         personalReadingRecordService.delete(personalBookId, recordId);
         return ApiResponse.deleted("기록 삭제 성공");
+    }
+
+    @Override
+    @GetMapping("/{personalBookId}/records")
+    public ResponseEntity<ApiResponse<Page<PersonalReadingRecordListResponse>>> getMyReadingRecords(
+            @PathVariable Long personalBookId,
+            @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
+    ) {
+
+        Page<PersonalReadingRecordListResponse> records = personalReadingRecordService.getRecords(personalBookId, pageable);
+        return ApiResponse.success(records, "기록 조회 성공");
+
     }
 }

--- a/src/main/java/com/dokdok/book/dto/response/PersonalReadingRecordListResponse.java
+++ b/src/main/java/com/dokdok/book/dto/response/PersonalReadingRecordListResponse.java
@@ -1,0 +1,26 @@
+package com.dokdok.book.dto.response;
+
+import com.dokdok.book.entity.PersonalReadingRecord;
+import com.dokdok.book.entity.RecordType;
+import lombok.Builder;
+
+import java.util.Map;
+
+@Builder
+public record PersonalReadingRecordListResponse(
+        Long recordId,
+        RecordType recordType,
+        String recordContent,
+        Map<String, Object> meta,
+        Long personalBookId
+) {
+    public static PersonalReadingRecordListResponse from(PersonalReadingRecord record) {
+        return PersonalReadingRecordListResponse.builder()
+                .recordId(record.getId())
+                .recordType(record.getRecordType())
+                .recordContent(record.getRecordContent())
+                .meta(record.getMeta())
+                .personalBookId(record.getPersonalBook().getId())
+                .build();
+    }
+}

--- a/src/main/java/com/dokdok/book/repository/PersonalReadingRecordRepository.java
+++ b/src/main/java/com/dokdok/book/repository/PersonalReadingRecordRepository.java
@@ -1,10 +1,13 @@
 package com.dokdok.book.repository;
 
 import com.dokdok.book.entity.PersonalReadingRecord;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
 public interface PersonalReadingRecordRepository extends JpaRepository<PersonalReadingRecord, Long> {
     Optional<PersonalReadingRecord> findByIdAndPersonalBookIdAndUserId(Long id, Long personalBookId, Long userId);
+    Page<PersonalReadingRecord> findAllByPersonalBookIdAndUserId(Long personalBookId, Long userId, Pageable pageable);
 }

--- a/src/main/java/com/dokdok/book/service/PersonalReadingRecordService.java
+++ b/src/main/java/com/dokdok/book/service/PersonalReadingRecordService.java
@@ -1,18 +1,21 @@
 package com.dokdok.book.service;
 
 import com.dokdok.book.dto.request.PersonalReadingRecordCreateRequest;
-import com.dokdok.book.dto.request.PersonalReadingRecordUpdateRequest;
 import com.dokdok.book.dto.response.PersonalReadingRecordCreateResponse;
+import com.dokdok.book.dto.response.PersonalReadingRecordListResponse;
 import com.dokdok.book.entity.PersonalBook;
 import com.dokdok.book.entity.PersonalReadingRecord;
 import com.dokdok.book.entity.RecordType;
 import com.dokdok.book.exception.RecordErrorCode;
 import com.dokdok.book.exception.RecordException;
+import com.dokdok.book.dto.request.PersonalReadingRecordUpdateRequest;
 import com.dokdok.book.repository.PersonalReadingRecordRepository;
 import com.dokdok.global.util.SecurityUtil;
 import com.dokdok.user.entity.User;
 import com.dokdok.user.service.UserValidator;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -81,6 +84,20 @@ public class PersonalReadingRecordService {
         }
 
         personalReadingRecord.delete();
+    }
+
+    public Page<PersonalReadingRecordListResponse> getRecords(Long personalBookId, Pageable pageable) {
+
+        User userEntity = userValidator.findUserOrThrow(SecurityUtil.getCurrentUserId());
+        PersonalBook personalBookEntity = bookValidator.validateInBookShelf(userEntity.getId(), personalBookId);
+
+        Page<PersonalReadingRecord> entities = personalReadingRecordRepository.findAllByPersonalBookIdAndUserId(
+                personalBookEntity.getId(),
+                userEntity.getId(),
+                pageable
+        );
+
+        return entities.map(PersonalReadingRecordListResponse::from);
     }
 
     private Map<String, Object> normalizeMeta(RecordType recordType, Map<String, Object> meta) {


### PR DESCRIPTION
 ## PR 요약
  > 이 PR이 어떤 변경을 하는지 간단히 설명하고, 체크 표시는 괄호 사이에 소문자 'x'를 삽입하세요.

  - [x] 기능 추가
  - [ ] 버그 수정
  - [ ] 코드 리팩토링
  - [ ] 문서 수정
  - [ ] 기타 (설명)

  ---

  ## 이슈 번호
  - #126 

  ---

  ## 주요 변경 사항
  > 주요 파일, 로직, 컴포넌트 등을 구체적으로 적어주세요.

  - `src/main/java/com/dokdok/book/api/BookApi.java`: 개인 책장 ID 기반 독서 기록 목록 조회 API 명세 및 Swagger 응답 예시 추가 (페이징/정렬 지원, 기본 createdAt DESC)
  - `src/main/java/com/dokdok/book/controller/BookController.java`: GET `/ {personalBookId}/records` 엔드포인트 구현, 서비스 호출로 페이지 응답 반환
  - `src/main/java/com/dokdok/book/service/PersonalReadingRecordService.java`: 사용자/책장 검증 후 기록 페이지 조회 로직 추가
  - `src/main/java/com/dokdok/book/repository/PersonalReadingRecordRepository.java`: personalBookId+userId 조건 페이징 조회 메서드 추가
  - `src/main/java/com/dokdok/book/dto/response/PersonalReadingRecordListResponse.java`: 기록 목록 응답 DTO 신규 정의 및 엔티티 매핑

  ---

  ## 참고 사항
  > 리뷰어가 알아야 할 추가 정보, 테스트 방법 등을 작성해주세요.