### PR TITLE
[#140][FEAT] 약속 거절 API 추가, 승인 API 분리

### DIFF
--- a/src/main/java/com/dokdok/meeting/api/MeetingApi.java
+++ b/src/main/java/com/dokdok/meeting/api/MeetingApi.java
@@ -7,7 +7,6 @@ import com.dokdok.meeting.dto.MeetingStatusResponse;
 import com.dokdok.meeting.dto.MeetingTabCountsResponse;
 import com.dokdok.meeting.dto.MeetingUpdateRequest;
 import com.dokdok.meeting.dto.MeetingUpdateResponse;
-import com.dokdok.meeting.entity.MeetingStatus;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
@@ -73,10 +72,10 @@ public interface MeetingApi {
     );
 
     @Operation(
-            summary = "약속 생성 확정",
+            summary = "약속 확정",
             description = """
-            신청된 약속 중 하나를 확정합니다.
-            - 상태: PENDING(신청), CONFIRMED(모임장 확정), DONE(종료)
+            신청된 약속을 확정합니다.
+            - 상태: PENDING(신청), CONFIRMED(모임장 확정), REJECTED(거절), DONE(종료)
             - 확정 시 신청자가 약속장으로 변경된다.
             - 약속장은 자동으로 약속에 포함된다 (MeetingMember).
             - 확정된 약속은 되돌릴 수 없다.
@@ -85,15 +84,13 @@ public interface MeetingApi {
             - 신청된 약속이 없으면 모임장이 약속을 바로 생성/확정 가능
             """,
             parameters = {
-                    @Parameter(name = "meetingId", description = "약속 식별자", in = ParameterIn.PATH, required = true),
-                    @Parameter(name = "meetingStatus", description = "변경할 약속 상태 (PENDING, CONFIRMED, DONE)",
-                            in = ParameterIn.QUERY, required = true)
+                    @Parameter(name = "meetingId", description = "약속 식별자", in = ParameterIn.PATH, required = true)
             }
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(
                     responseCode = "200",
-                    description = "약속 상태 변경 성공",
+                    description = "약속 확정 성공",
                     content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
                             schema = @Schema(implementation = MeetingStatusResponse.class))
             ),
@@ -101,9 +98,34 @@ public interface MeetingApi {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "약속을 찾을 수 없음"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 오류")
     })
-    ResponseEntity<ApiResponse<MeetingStatusResponse>> changeMeetingStatus(
-            Long meetingId,
-            MeetingStatus meetingStatus
+    ResponseEntity<ApiResponse<MeetingStatusResponse>> confirmMeeting(
+            Long meetingId
+    );
+
+    @Operation(
+            summary = "약속 거절",
+            description = """
+            신청된 약속을 거절합니다.
+            - 상태: PENDING(신청), CONFIRMED(모임장 확정), REJECTED(거절), DONE(종료)
+            - 거절된 약속은 되돌릴 수 없다.
+            """,
+            parameters = {
+                    @Parameter(name = "meetingId", description = "약속 식별자", in = ParameterIn.PATH, required = true)
+            }
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "약속 거절 성공",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = MeetingStatusResponse.class))
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "약속을 찾을 수 없음"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 오류")
+    })
+    ResponseEntity<ApiResponse<MeetingStatusResponse>> rejectMeeting(
+            Long meetingId
     );
 
     @Operation(

--- a/src/main/java/com/dokdok/meeting/controller/MeetingController.java
+++ b/src/main/java/com/dokdok/meeting/controller/MeetingController.java
@@ -8,21 +8,12 @@ import com.dokdok.meeting.dto.MeetingStatusResponse;
 import com.dokdok.meeting.dto.MeetingTabCountsResponse;
 import com.dokdok.meeting.dto.MeetingUpdateRequest;
 import com.dokdok.meeting.dto.MeetingUpdateResponse;
-import com.dokdok.meeting.entity.MeetingStatus;
 import com.dokdok.meeting.service.MeetingService;
 import lombok.RequiredArgsConstructor;
 import jakarta.validation.Valid;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -48,13 +39,21 @@ public class MeetingController implements MeetingApi {
     }
 
     @Override
-    @PatchMapping(value = "/{meetingId}/status", produces = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity<ApiResponse<MeetingStatusResponse>> changeMeetingStatus(
-            @PathVariable Long meetingId,
-            @RequestParam MeetingStatus meetingStatus
+    @PostMapping(value = "/{meetingId}/confirm", produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<ApiResponse<MeetingStatusResponse>> confirmMeeting(
+            @PathVariable Long meetingId
     ) {
-        MeetingStatusResponse response = meetingService.changeMeetingStatus(meetingId, meetingStatus);
-        return ApiResponse.updated(response, "약속 상태 변경에 성공했습니다.");
+        MeetingStatusResponse response = meetingService.confirmMeeting(meetingId);
+        return ApiResponse.updated(response, "약속 확정에 성공했습니다.");
+    }
+
+    @Override
+    @PostMapping(value = "/{meetingId}/reject", produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<ApiResponse<MeetingStatusResponse>> rejectMeeting(
+            @PathVariable Long meetingId
+    ) {
+        MeetingStatusResponse response = meetingService.rejectMeeting(meetingId);
+        return ApiResponse.updated(response, "약속 거절에 성공했습니다.");
     }
 
     @Override

--- a/src/main/java/com/dokdok/meeting/entity/Meeting.java
+++ b/src/main/java/com/dokdok/meeting/entity/Meeting.java
@@ -85,15 +85,16 @@ public class Meeting extends BaseTimeEntity {
 
     public void changeStatus(MeetingStatus targetStatus) {
 
-        // DONE 이후는 어떤 변경도 불가
-        if (this.meetingStatus == MeetingStatus.DONE) {
+        // DONE/REJECTED 이후는 어떤 변경도 불가
+        if (this.meetingStatus == MeetingStatus.DONE
+                || this.meetingStatus == MeetingStatus.REJECTED) {
             throw new MeetingException(MeetingErrorCode.INVALID_MEETING_STATUS_CHANGE,
                     "종료된 약속의 상태는 변경할 수 없습니다.");
         }
 
         // CONFIRMED 이후에는 이전 상태로 되돌릴 수 없음
         if (this.meetingStatus == MeetingStatus.CONFIRMED
-                && targetStatus == MeetingStatus.PENDING) {
+                && (targetStatus == MeetingStatus.PENDING || targetStatus == MeetingStatus.REJECTED)) {
             throw new MeetingException(MeetingErrorCode.INVALID_MEETING_STATUS_CHANGE,
                     "확정된 약속은 다시 신청 상태로 되돌릴 수 없습니다.");
         }
@@ -103,6 +104,13 @@ public class Meeting extends BaseTimeEntity {
                 && this.meetingStatus != MeetingStatus.PENDING) {
             throw new MeetingException(MeetingErrorCode.INVALID_MEETING_STATUS_CHANGE,
                     "신청된 약속만 확정할 수 있습니다.");
+        }
+
+        // REJECTED는 PENDING에서만 가능
+        if (targetStatus == MeetingStatus.REJECTED
+                && this.meetingStatus != MeetingStatus.PENDING) {
+            throw new MeetingException(MeetingErrorCode.INVALID_MEETING_STATUS_CHANGE,
+                    "신청된 약속만 거절할 수 있습니다.");
         }
 
         this.meetingStatus = targetStatus;

--- a/src/main/java/com/dokdok/meeting/entity/MeetingStatus.java
+++ b/src/main/java/com/dokdok/meeting/entity/MeetingStatus.java
@@ -1,5 +1,5 @@
 package com.dokdok.meeting.entity;
 
 public enum MeetingStatus {
-    PENDING, CONFIRMED, DONE
+    PENDING, CONFIRMED, REJECTED, DONE
 }

--- a/src/main/java/com/dokdok/meeting/service/MeetingService.java
+++ b/src/main/java/com/dokdok/meeting/service/MeetingService.java
@@ -112,26 +112,42 @@ public class MeetingService {
     }
 
     /**
-     * 약속 상태를 변경한다. 모임장만 상태 변경 가능
+     * 약속을 확정한다. 모임장만 확정 가능
      * @param meetingId 약속 식별자
-     * @param meetingStatus 약속 상태
      * @return 약속 상태 응답 정보
      */
     @Transactional
-    public MeetingStatusResponse changeMeetingStatus(Long meetingId, MeetingStatus meetingStatus) {
+    public MeetingStatusResponse confirmMeeting(Long meetingId) {
 
         Long userId = SecurityUtil.getCurrentUserId();
         Meeting meeting = meetingValidator.findMeetingOrThrow(meetingId);
 
-        // 모임장만 상태 변경 가능
+        // 모임장만 확정 가능
         gatheringValidator.validateLeader(meeting.getGathering().getId(), userId);
 
-        if (meetingStatus == MeetingStatus.CONFIRMED) {
-            validateConfirmable(meeting);
-            ensureLeaderMember(meeting);
-        }
+        validateConfirmable(meeting);
+        ensureLeaderMember(meeting);
 
-        meeting.changeStatus(meetingStatus);
+        meeting.changeStatus(MeetingStatus.CONFIRMED);
+
+        return MeetingStatusResponse.from(meeting);
+    }
+
+    /**
+     * 약속을 거절한다. 모임장만 거절 가능
+     * @param meetingId 약속 식별자
+     * @return 약속 상태 응답 정보
+     */
+    @Transactional
+    public MeetingStatusResponse rejectMeeting(Long meetingId) {
+
+        Long userId = SecurityUtil.getCurrentUserId();
+        Meeting meeting = meetingValidator.findMeetingOrThrow(meetingId);
+
+        // 모임장만 거절 가능
+        gatheringValidator.validateLeader(meeting.getGathering().getId(), userId);
+
+        meeting.changeStatus(MeetingStatus.REJECTED);
 
         return MeetingStatusResponse.from(meeting);
     }

--- a/src/test/java/com/dokdok/meeting/service/MeetingServiceTest.java
+++ b/src/test/java/com/dokdok/meeting/service/MeetingServiceTest.java
@@ -371,11 +371,10 @@ class MeetingServiceTest {
 
     @DisplayName("모임장이 약속을 확정하면 약속장이 멤버로 포함된다.")
     @Test
-    void givenMeetingStatus_whenChangeStatus_thenMeetingStatusChange() {
+    void givenMeetingStatus_whenConfirm_thenMeetingStatusChange() {
         // given
         Long meetingId = 1L;
         Long gatheringLeaderId = 10L;
-        MeetingStatus meetingStatus = MeetingStatus.CONFIRMED;
 
         given(meetingValidator.findMeetingOrThrow(meetingId)).willReturn(meeting);
         given(meetingRepository.existsByGatheringIdAndMeetingStatus(gathering.getId(), MeetingStatus.CONFIRMED))
@@ -387,7 +386,7 @@ class MeetingServiceTest {
             securityUtilMock.when(SecurityUtil::getCurrentUserId).thenReturn(gatheringLeaderId);
 
             // when
-            MeetingStatusResponse response = meetingService.changeMeetingStatus(meetingId, meetingStatus);
+            MeetingStatusResponse response = meetingService.confirmMeeting(meetingId);
 
             // then
             verify(gatheringValidator).validateLeader(gathering.getId(), gatheringLeaderId);
@@ -414,7 +413,7 @@ class MeetingServiceTest {
             securityUtilMock.when(SecurityUtil::getCurrentUserId).thenReturn(gatheringLeaderId);
 
             // when + then
-            assertThatThrownBy(() -> meetingService.changeMeetingStatus(meetingId, MeetingStatus.CONFIRMED))
+            assertThatThrownBy(() -> meetingService.confirmMeeting(meetingId))
                     .isInstanceOf(MeetingException.class)
                     .extracting("errorCode")
                     .isEqualTo(MeetingErrorCode.INVALID_MEETING_STATUS_CHANGE);
@@ -435,7 +434,7 @@ class MeetingServiceTest {
             securityUtilMock.when(SecurityUtil::getCurrentUserId).thenReturn(notLeaderId);
 
             // when + then
-            assertThatThrownBy(() -> meetingService.changeMeetingStatus(meetingId, MeetingStatus.CONFIRMED))
+            assertThatThrownBy(() -> meetingService.confirmMeeting(meetingId))
                     .isInstanceOf(GatheringException.class)
                     .extracting("errorCode")
                     .isEqualTo(GatheringErrorCode.NOT_GATHERING_LEADER);
@@ -462,16 +461,16 @@ class MeetingServiceTest {
             securityUtilMock.when(SecurityUtil::getCurrentUserId).thenReturn(gatheringLeaderId);
 
             // when + then
-            assertThatThrownBy(() -> meetingService.changeMeetingStatus(meetingId, MeetingStatus.CONFIRMED))
+            assertThatThrownBy(() -> meetingService.confirmMeeting(meetingId))
                     .isInstanceOf(MeetingException.class)
                     .extracting("errorCode")
                     .isEqualTo(MeetingErrorCode.INVALID_MEETING_STATUS_CHANGE);
         }
     }
 
-    @DisplayName("확정된 약속은 다시 신청 상태로 되돌릴 수 없다.")
+    @DisplayName("확정된 약속은 거절할 수 없다.")
     @Test
-    void givenConfirmedMeeting_whenRollbackToPending_thenThrowMeetingException() {
+    void givenConfirmedMeeting_whenReject_thenThrowMeetingException() {
         // given
         Long meetingId = 1L;
         Long gatheringLeaderId = 10L;
@@ -488,7 +487,7 @@ class MeetingServiceTest {
             securityUtilMock.when(SecurityUtil::getCurrentUserId).thenReturn(gatheringLeaderId);
 
             // when + then
-            assertThatThrownBy(() -> meetingService.changeMeetingStatus(meetingId, MeetingStatus.PENDING))
+            assertThatThrownBy(() -> meetingService.rejectMeeting(meetingId))
                     .isInstanceOf(MeetingException.class)
                     .extracting("errorCode")
                     .isEqualTo(MeetingErrorCode.INVALID_MEETING_STATUS_CHANGE);


### PR DESCRIPTION
## PR 요약
> 이 PR이 어떤 변경을 하는지 간단히 설명하고, 체크 표시는 괄호 사이에 소문자 'x'를 삽입하세요.

- [x] 기능 추가
- [ ] 버그 수정
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 기타 (설명)

---

## 이슈 번호
- #140

---

## 주요 변경 사항
> 주요 파일, 로직, 컴포넌트 등을 구체적으로 적어주세요.

- 약속 상태 변경을 단일 status 수정 API에서 확정/거절 행위 중심 API로 분리
- 약속 거절(REJECTED) 기능을 추가하고, 상태 전이 규칙 및 DB 제약 조건을 함께 정비
- 확정 시 약속장 변경·자동 참가 등 비즈니스 로직을 서비스 레벨로 명확히 분리
- `src/main/java/com/dokdok/meeting`: +85/-40 (5 files) — 요구사항 반영
- `src/test/java/com/dokdok/meeting`: +8/-9 (1 files) — 요구사항 반영

---

## 참고 사항
> 리뷰어가 알아야 할 추가 정보, 테스트 방법 등을 작성해주세요.

예:
- 테스트 계정 정보
- 관련 API 엔드포인트
- 로컬 테스트 방법

---
