### PR TITLE
[#88][REFACTOR] 키워드 리스트화, 다대다 엔티티 추가

### DIFF
--- a/src/main/java/com/dokdok/book/dto/request/BookReviewRequest.java
+++ b/src/main/java/com/dokdok/book/dto/request/BookReviewRequest.java
@@ -1,13 +1,14 @@
 package com.dokdok.book.dto.request;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotEmpty;
 
 import java.math.BigDecimal;
+import java.util.List;
 
 public record BookReviewRequest(
         BigDecimal rating,
 
-        @NotNull(message = "keywordId는 필수입니다")
-        Long keywordId
+        @NotEmpty(message = "keywordIds는 필수입니다")
+        List<Long> keywordIds
 ) {
 }

--- a/src/main/java/com/dokdok/book/dto/response/BookReviewResponse.java
+++ b/src/main/java/com/dokdok/book/dto/response/BookReviewResponse.java
@@ -4,13 +4,15 @@ import com.dokdok.book.entity.BookReview;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
 
 public record BookReviewResponse(
         Long reviewId,
         Long bookId,
         Long userId,
         BigDecimal rating,
-        Long keywordId,
+        List<Long> keywordIds,
         LocalDateTime createdAt,
         LocalDateTime updatedAt
 ) {
@@ -20,7 +22,9 @@ public record BookReviewResponse(
                 review.getBook().getId(),
                 review.getUser().getId(),
                 review.getRating(),
-                review.getKeyword().getId(),
+                review.getKeywords().stream()
+                        .map(reviewKeyword -> reviewKeyword.getKeyword().getId())
+                        .collect(Collectors.toList()),
                 review.getCreatedAt(),
                 review.getUpdatedAt()
         );

--- a/src/main/java/com/dokdok/book/entity/BookReview.java
+++ b/src/main/java/com/dokdok/book/entity/BookReview.java
@@ -8,6 +8,8 @@ import lombok.*;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.SQLRestriction;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.math.BigDecimal;
 
 @Entity
@@ -36,25 +38,33 @@ public class BookReview extends BaseTimeEntity {
     @Column(name = "rating", precision = 2, scale = 1)
     private BigDecimal rating;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "keyword_id", nullable = false)
-    private Keyword keyword;
+    @OneToMany(mappedBy = "bookReview", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Builder.Default
+    private List<BookReviewKeyword> keywords = new ArrayList<>();
 
-    public static BookReview create(Book book, User user, BigDecimal rating, Keyword keyword) {
-        return BookReview.builder()
+    public static BookReview create(Book book, User user, BigDecimal rating, List<Keyword> keywords) {
+        BookReview review = BookReview.builder()
                 .book(book)
                 .user(user)
                 .rating(rating)
-                .keyword(keyword)
                 .build();
+        review.replaceKeywords(keywords);
+        return review;
     }
 
-    public void updateReview(BigDecimal rating, Keyword keyword) {
+    public void updateReview(BigDecimal rating, List<Keyword> keywords) {
         this.rating = rating;
-        this.keyword = keyword;
+        replaceKeywords(keywords);
     }
 
     public void deleteReview() {
         this.markDeletedNow();
+    }
+
+    private void replaceKeywords(List<Keyword> keywords) {
+        this.keywords = new ArrayList<>();
+        for (Keyword keyword : keywords) {
+            this.keywords.add(BookReviewKeyword.create(this, keyword));
+        }
     }
 }

--- a/src/main/java/com/dokdok/book/entity/BookReviewKeyword.java
+++ b/src/main/java/com/dokdok/book/entity/BookReviewKeyword.java
@@ -1,0 +1,44 @@
+package com.dokdok.book.entity;
+
+import com.dokdok.keyword.entity.Keyword;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "book_review_keyword")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class BookReviewKeyword {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "book_review_keyword_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "book_review_id", nullable = false)
+    private BookReview bookReview;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "keyword_id", nullable = false)
+    private Keyword keyword;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    public static BookReviewKeyword create(BookReview bookReview, Keyword keyword) {
+        return BookReviewKeyword.builder()
+                .bookReview(bookReview)
+                .keyword(keyword)
+                .build();
+    }
+
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/dokdok/book/service/BookReviewService.java
+++ b/src/main/java/com/dokdok/book/service/BookReviewService.java
@@ -13,6 +13,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 @Service
 @RequiredArgsConstructor
 public class BookReviewService {
@@ -28,15 +31,15 @@ public class BookReviewService {
 
         Book book = bookValidator.validateAndGetBook(bookId);
 
-        Keyword keyword = keywordValidator.validateAndGetSelectableKeyword(
-                request.keywordId()
-        );
+        List<Keyword> keywords = request.keywordIds().stream()
+                .map(keywordValidator::validateAndGetSelectableKeyword)
+                .collect(Collectors.toList());
 
         bookValidator.validateReviewNotExists(bookId, userId);
 
         User user = SecurityUtil.getCurrentUserEntity();
 
-        BookReview review = BookReview.create(book, user, request.rating(), keyword);
+        BookReview review = BookReview.create(book, user, request.rating(), keywords);
 
         return BookReviewResponse.from(bookReviewRepository.save(review));
     }
@@ -57,11 +60,11 @@ public class BookReviewService {
 
         BookReview review = bookValidator.validateAndGetReviewForUpdate(bookId, userId);
 
-        Keyword keyword = keywordValidator.validateAndGetSelectableKeyword(
-                request.keywordId()
-        );
+        List<Keyword> keywords = request.keywordIds().stream()
+                .map(keywordValidator::validateAndGetSelectableKeyword)
+                .collect(Collectors.toList());
 
-        review.updateReview(request.rating(), keyword);
+        review.updateReview(request.rating(), keywords);
 
         return BookReviewResponse.from(review);
     }

--- a/src/main/resources/data/book_review_keyword_migration.sql
+++ b/src/main/resources/data/book_review_keyword_migration.sql
@@ -1,0 +1,22 @@
+-- Migrate book_review.keyword_id to book_review_keyword join table.
+CREATE TABLE IF NOT EXISTS book_review_keyword (
+    book_review_keyword_id BIGSERIAL PRIMARY KEY,
+    book_review_id BIGINT NOT NULL,
+    keyword_id BIGINT NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT fk_book_review_keyword_review
+        FOREIGN KEY (book_review_id) REFERENCES book_review (book_review_id),
+    CONSTRAINT fk_book_review_keyword_keyword
+        FOREIGN KEY (keyword_id) REFERENCES keyword (keyword_id)
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_book_review_keyword
+    ON book_review_keyword (book_review_id, keyword_id);
+
+INSERT INTO book_review_keyword (book_review_id, keyword_id, created_at)
+SELECT book_review_id, keyword_id, created_at
+FROM book_review
+WHERE keyword_id IS NOT NULL
+ON CONFLICT DO NOTHING;
+
+ALTER TABLE book_review DROP COLUMN IF EXISTS keyword_id;

--- a/src/test/java/com/dokdok/book/service/BookReviewServiceTest.java
+++ b/src/test/java/com/dokdok/book/service/BookReviewServiceTest.java
@@ -4,6 +4,7 @@ import com.dokdok.book.dto.request.BookReviewRequest;
 import com.dokdok.book.dto.response.BookReviewResponse;
 import com.dokdok.book.entity.Book;
 import com.dokdok.book.entity.BookReview;
+import com.dokdok.book.entity.BookReviewKeyword;
 import com.dokdok.book.exception.BookErrorCode;
 import com.dokdok.book.exception.BookException;
 import com.dokdok.book.repository.BookReviewRepository;
@@ -22,6 +23,7 @@ import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.math.BigDecimal;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -52,15 +54,19 @@ class BookReviewServiceTest {
     void createReview_success() {
         Book book = Book.builder().id(1L).build();
         Keyword keyword = Keyword.builder().id(2L).build();
+        Keyword keywordSecond = Keyword.builder().id(4L).build();
         User user = User.builder().id(3L).build();
-        BookReviewRequest request = new BookReviewRequest(new BigDecimal("4.5"), 2L);
+        BookReviewRequest request = new BookReviewRequest(new BigDecimal("4.5"), List.of(2L, 4L));
 
         BookReview saved = BookReview.builder()
                 .id(10L)
                 .book(book)
                 .user(user)
                 .rating(new BigDecimal("4.5"))
-                .keyword(keyword)
+                .keywords(List.of(
+                        BookReviewKeyword.builder().keyword(keyword).build(),
+                        BookReviewKeyword.builder().keyword(keywordSecond).build()
+                ))
                 .build();
 
         try (MockedStatic<SecurityUtil> securityUtilMock = org.mockito.Mockito.mockStatic(SecurityUtil.class)) {
@@ -70,6 +76,7 @@ class BookReviewServiceTest {
             doNothing().when(bookValidator).validateReviewNotExists(1L, 3L);
             when(bookValidator.validateAndGetBook(1L)).thenReturn(book);
             when(keywordValidator.validateAndGetSelectableKeyword(2L)).thenReturn(keyword);
+            when(keywordValidator.validateAndGetSelectableKeyword(4L)).thenReturn(keywordSecond);
             when(bookReviewRepository.save(any(BookReview.class))).thenReturn(saved);
 
             BookReviewResponse response = bookReviewService.createReview(1L, request);
@@ -78,11 +85,12 @@ class BookReviewServiceTest {
             assertThat(response.bookId()).isEqualTo(1L);
             assertThat(response.userId()).isEqualTo(3L);
             assertThat(response.rating()).isEqualTo(new BigDecimal("4.5"));
-            assertThat(response.keywordId()).isEqualTo(2L);
+            assertThat(response.keywordIds()).containsExactly(2L, 4L);
 
             verify(bookValidator).validateReviewNotExists(1L, 3L);
             verify(bookValidator).validateAndGetBook(1L);
             verify(keywordValidator).validateAndGetSelectableKeyword(2L);
+            verify(keywordValidator).validateAndGetSelectableKeyword(4L);
             verify(bookReviewRepository).save(any(BookReview.class));
         }
     }
@@ -90,7 +98,7 @@ class BookReviewServiceTest {
     @Test
     @DisplayName("책이 없으면 예외가 발생한다")
     void createReview_throwsWhenBookMissing() {
-        BookReviewRequest request = new BookReviewRequest(new BigDecimal("4.5"), 2L);
+        BookReviewRequest request = new BookReviewRequest(new BigDecimal("4.5"), List.of(2L));
 
         try (MockedStatic<SecurityUtil> securityUtilMock = org.mockito.Mockito.mockStatic(SecurityUtil.class)) {
             securityUtilMock.when(SecurityUtil::getCurrentUserId).thenReturn(3L);
@@ -110,7 +118,7 @@ class BookReviewServiceTest {
     @Test
     @DisplayName("선택 불가 키워드를 요청하면 예외가 발생한다")
     void createReview_throwsWhenKeywordNotSelectable() {
-        BookReviewRequest request = new BookReviewRequest(new BigDecimal("4.5"), 2L);
+        BookReviewRequest request = new BookReviewRequest(new BigDecimal("4.5"), List.of(2L));
         Book book = Book.builder().id(1L).build();
 
         try (MockedStatic<SecurityUtil> securityUtilMock = org.mockito.Mockito.mockStatic(SecurityUtil.class)) {
@@ -131,7 +139,7 @@ class BookReviewServiceTest {
     @Test
     @DisplayName("인증 정보가 없으면 예외가 발생한다")
     void createReview_throwsWhenUnauthenticated() {
-        BookReviewRequest request = new BookReviewRequest(new BigDecimal("4.5"), 2L);
+        BookReviewRequest request = new BookReviewRequest(new BigDecimal("4.5"), List.of(2L));
 
         try (MockedStatic<SecurityUtil> securityUtilMock = org.mockito.Mockito.mockStatic(SecurityUtil.class)) {
             securityUtilMock.when(SecurityUtil::getCurrentUserId)
@@ -148,7 +156,7 @@ class BookReviewServiceTest {
     @Test
     @DisplayName("별점이 유효하지 않으면 생성 시 예외가 발생한다")
     void createReview_throwsWhenInvalidRating() {
-        BookReviewRequest request = new BookReviewRequest(new BigDecimal("4.7"), 2L);
+        BookReviewRequest request = new BookReviewRequest(new BigDecimal("4.7"), List.of(2L));
 
         try (MockedStatic<SecurityUtil> securityUtilMock = org.mockito.Mockito.mockStatic(SecurityUtil.class)) {
             securityUtilMock.when(SecurityUtil::getCurrentUserId).thenReturn(3L);
@@ -172,7 +180,7 @@ class BookReviewServiceTest {
         Book book = Book.builder().id(1L).build();
         Keyword keyword = Keyword.builder().id(2L).build();
         User user = User.builder().id(3L).build();
-        BookReviewRequest request = new BookReviewRequest(new BigDecimal("4.5"), 2L);
+        BookReviewRequest request = new BookReviewRequest(new BigDecimal("4.5"), List.of(2L));
 
         try (MockedStatic<SecurityUtil> securityUtilMock = org.mockito.Mockito.mockStatic(SecurityUtil.class)) {
             securityUtilMock.when(SecurityUtil::getCurrentUserId).thenReturn(3L);
@@ -196,13 +204,17 @@ class BookReviewServiceTest {
     void getMyReview_success() {
         Book book = Book.builder().id(1L).build();
         Keyword keyword = Keyword.builder().id(2L).build();
+        Keyword keywordSecond = Keyword.builder().id(4L).build();
         User user = User.builder().id(3L).build();
         BookReview review = BookReview.builder()
                 .id(10L)
                 .book(book)
                 .user(user)
                 .rating(new BigDecimal("4.5"))
-                .keyword(keyword)
+                .keywords(List.of(
+                        BookReviewKeyword.builder().keyword(keyword).build(),
+                        BookReviewKeyword.builder().keyword(keywordSecond).build()
+                ))
                 .build();
 
         try (MockedStatic<SecurityUtil> securityUtilMock = org.mockito.Mockito.mockStatic(SecurityUtil.class)) {
@@ -217,7 +229,7 @@ class BookReviewServiceTest {
             assertThat(response.bookId()).isEqualTo(1L);
             assertThat(response.userId()).isEqualTo(3L);
             assertThat(response.rating()).isEqualTo(new BigDecimal("4.5"));
-            assertThat(response.keywordId()).isEqualTo(2L);
+            assertThat(response.keywordIds()).containsExactly(2L, 4L);
         }
     }
 
@@ -242,26 +254,31 @@ class BookReviewServiceTest {
         Book book = Book.builder().id(1L).build();
         Keyword keyword = Keyword.builder().id(2L).build();
         Keyword newKeyword = Keyword.builder().id(5L).build();
+        Keyword newKeywordSecond = Keyword.builder().id(8L).build();
         User user = User.builder().id(3L).build();
         BookReview review = BookReview.builder()
                 .id(10L)
                 .book(book)
                 .user(user)
                 .rating(new BigDecimal("4.5"))
-                .keyword(keyword)
+                .keywords(List.of(
+                        BookReviewKeyword.builder().keyword(keyword).build()
+                ))
                 .build();
-        BookReviewRequest request = new BookReviewRequest(new BigDecimal("3.5"), 5L);
+        BookReviewRequest request = new BookReviewRequest(new BigDecimal("3.5"), List.of(5L, 8L));
 
         try (MockedStatic<SecurityUtil> securityUtilMock = org.mockito.Mockito.mockStatic(SecurityUtil.class)) {
             securityUtilMock.when(SecurityUtil::getCurrentUserId).thenReturn(3L);
 
             when(bookValidator.validateAndGetReviewForUpdate(1L, 3L)).thenReturn(review);
             when(keywordValidator.validateAndGetSelectableKeyword(5L)).thenReturn(newKeyword);
+            when(keywordValidator.validateAndGetSelectableKeyword(8L)).thenReturn(newKeywordSecond);
 
             BookReviewResponse response = bookReviewService.updateMyReview(1L, request);
 
             assertThat(review.getRating()).isEqualTo(new BigDecimal("3.5"));
-            assertThat(review.getKeyword().getId()).isEqualTo(5L);
+            assertThat(review.getKeywords()).hasSize(2);
+            assertThat(response.keywordIds()).containsExactly(5L, 8L);
             assertThat(response.reviewId()).isEqualTo(10L);
         }
     }
@@ -269,7 +286,7 @@ class BookReviewServiceTest {
     @Test
     @DisplayName("내 책 리뷰가 없으면 수정 시 예외가 발생한다")
     void updateMyReview_throwsWhenReviewMissing() {
-        BookReviewRequest request = new BookReviewRequest(new BigDecimal("3.5"), 5L);
+        BookReviewRequest request = new BookReviewRequest(new BigDecimal("3.5"), List.of(5L));
 
         try (MockedStatic<SecurityUtil> securityUtilMock = org.mockito.Mockito.mockStatic(SecurityUtil.class)) {
             securityUtilMock.when(SecurityUtil::getCurrentUserId).thenReturn(3L);
@@ -294,9 +311,11 @@ class BookReviewServiceTest {
                 .book(book)
                 .user(user)
                 .rating(new BigDecimal("4.5"))
-                .keyword(keyword)
+                .keywords(List.of(
+                        BookReviewKeyword.builder().keyword(keyword).build()
+                ))
                 .build();
-        BookReviewRequest request = new BookReviewRequest(new BigDecimal("3.5"), 5L);
+        BookReviewRequest request = new BookReviewRequest(new BigDecimal("3.5"), List.of(5L));
 
         try (MockedStatic<SecurityUtil> securityUtilMock = org.mockito.Mockito.mockStatic(SecurityUtil.class)) {
             securityUtilMock.when(SecurityUtil::getCurrentUserId).thenReturn(3L);
@@ -314,7 +333,7 @@ class BookReviewServiceTest {
     @Test
     @DisplayName("삭제된 리뷰면 수정 시 예외가 발생한다")
     void updateMyReview_throwsWhenReviewDeleted() {
-        BookReviewRequest request = new BookReviewRequest(new BigDecimal("3.5"), 5L);
+        BookReviewRequest request = new BookReviewRequest(new BigDecimal("3.5"), List.of(5L));
 
         try (MockedStatic<SecurityUtil> securityUtilMock = org.mockito.Mockito.mockStatic(SecurityUtil.class)) {
             securityUtilMock.when(SecurityUtil::getCurrentUserId).thenReturn(3L);
@@ -331,7 +350,7 @@ class BookReviewServiceTest {
     @Test
     @DisplayName("별점이 유효하지 않으면 수정 시 예외가 발생한다")
     void updateMyReview_throwsWhenInvalidRating() {
-        BookReviewRequest request = new BookReviewRequest(new BigDecimal("0.3"), 2L);
+        BookReviewRequest request = new BookReviewRequest(new BigDecimal("0.3"), List.of(2L));
 
         try (MockedStatic<SecurityUtil> securityUtilMock = org.mockito.Mockito.mockStatic(SecurityUtil.class)) {
             securityUtilMock.when(SecurityUtil::getCurrentUserId).thenReturn(3L);
@@ -359,7 +378,9 @@ class BookReviewServiceTest {
                 .book(book)
                 .user(user)
                 .rating(new BigDecimal("4.5"))
-                .keyword(keyword)
+                .keywords(List.of(
+                        BookReviewKeyword.builder().keyword(keyword).build()
+                ))
                 .build();
 
         try (MockedStatic<SecurityUtil> securityUtilMock = org.mockito.Mockito.mockStatic(SecurityUtil.class)) {


### PR DESCRIPTION
 ## PR 요약

  - [x] 기능 추가
  - [ ] 버그 수정
  - [x] 코드 리팩토링
  - [ ] 문서 수정
  - [ ] 기타 (설명)

  ———

  ## 이슈 번호

  - #88 #91 #92 #95 

  ———

  ## 주요 변경 사항

  - src/main/java/com/dokdok/book/dto/request/BookReviewRequest.java: 키워드 단일 ID에서 다중 ID 리스트로 변경
  - src/main/java/com/dokdok/book/dto/response/BookReviewResponse.java: 키워드 리스트 반환으로 응답 형식 확장
  - src/main/java/com/dokdok/book/entity/BookReview.java: 키워드 연결을 조인 엔티티 기반으로 교체
  - src/main/java/com/dokdok/book/entity/BookReviewKeyword.java: 리뷰-키워드 연결 엔티티 추가
  - src/main/java/com/dokdok/book/service/BookReviewService.java: 요청 키워드 리스트 검증/저장 로직 반영
  - src/main/resources/data/book_review_keyword_migration.sql: 기존 keyword_id 컬럼 데이터를 조인 테이블로 마이그레이션

  ———

  ## 참고 사항

  - 테스트: book_review_keyword_migration.sql 실행하셔야 db 연관관계가 바뀝니다.