### PR TITLE
[#161][FIX] 프로필 이미지 null일 때, 미니오 스토로지를 조회하지 않도록 수정

### DIFF
--- a/src/main/java/com/dokdok/storage/service/StorageService.java
+++ b/src/main/java/com/dokdok/storage/service/StorageService.java
@@ -64,6 +64,10 @@ public class StorageService {
 
     public String getPresignedProfileImage(String profileImageUrl) {
 
+        if (profileImageUrl == null || profileImageUrl.isBlank()) {
+            return null;
+        }
+
         try {
             return externalMinioClient.getPresignedObjectUrl(
                     GetPresignedObjectUrlArgs.builder()


### PR DESCRIPTION
## PR 요약
> 이 PR이 어떤 변경을 하는지 간단히 설명하고, 체크 표시는 괄호 사이에 소문자 'x'를 삽입하세요.

- [ ] 기능 추가
- [x] 버그 수정
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 기타 (설명)

---

## 이슈 번호
- #161

---

## 주요 변경 사항
> 주요 파일, 로직, 컴포넌트 등을 구체적으로 적어주세요.

- `src/main/java/com/dokdok/storage/service/StorageService.java`: 프로필 이미지가 null일 경우

---