### PR TITLE
[#164] 주제 사전답변 ai 요약 테스트 api

### DIFF
--- a/src/main/java/com/dokdok/ai/client/AiSummaryClient.java
+++ b/src/main/java/com/dokdok/ai/client/AiSummaryClient.java
@@ -1,0 +1,26 @@
+package com.dokdok.ai.client;
+
+import com.dokdok.ai.dto.TopicSummaryRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Component
+@RequiredArgsConstructor
+public class AiSummaryClient {
+
+    private final WebClient aiWebClient;
+
+    @Value("${ai.api.summary-path}")
+    private String summaryPath;
+
+    public String requestTopicSummary(TopicSummaryRequest request) {
+        return aiWebClient.post()
+                .uri(summaryPath)
+                .bodyValue(request)
+                .retrieve()
+                .bodyToMono(String.class)
+                .block();
+    }
+}

--- a/src/main/java/com/dokdok/ai/dto/TopicSummaryRequest.java
+++ b/src/main/java/com/dokdok/ai/dto/TopicSummaryRequest.java
@@ -1,0 +1,15 @@
+package com.dokdok.ai.dto;
+
+import java.util.List;
+
+public record TopicSummaryRequest(
+        Long topicId,
+        String topicTitle,
+        List<Answer> answers
+) {
+    public record Answer(
+            Long userId,
+            String content
+    ) {
+    }
+}

--- a/src/main/java/com/dokdok/global/config/AiWebClientConfig.java
+++ b/src/main/java/com/dokdok/global/config/AiWebClientConfig.java
@@ -1,0 +1,20 @@
+package com.dokdok.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Configuration
+public class AiWebClientConfig {
+
+    @Value("${ai.api.base-url}")
+    private String baseUrl;
+
+    @Bean
+    public WebClient aiWebClient() {
+        return WebClient.builder()
+                .baseUrl(baseUrl)
+                .build();
+    }
+}

--- a/src/main/java/com/dokdok/topic/api/TopicSummaryApi.java
+++ b/src/main/java/com/dokdok/topic/api/TopicSummaryApi.java
@@ -1,0 +1,48 @@
+package com.dokdok.topic.api;
+
+import com.dokdok.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Tag(name = "토픽 요약", description = "토픽 요약 관련 API")
+@RequestMapping("/api/gatherings/{gathering_id}/meetings/{meeting_id}/topics/{topic_id}/summaries")
+public interface TopicSummaryApi {
+
+    @Operation(
+            summary = "토픽 요약 요청 (AI 테스트)",
+            description = "AI 서버로 토픽 답변 요약 요청을 전달합니다.",
+            parameters = {
+                    @Parameter(name = "gathering_id", description = "모임 식별자", in = ParameterIn.PATH, required = true),
+                    @Parameter(name = "meeting_id", description = "약속 식별자", in = ParameterIn.PATH, required = true),
+                    @Parameter(name = "topic_id", description = "토픽 식별자", in = ParameterIn.PATH, required = true)
+            }
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "토픽 요약 요청 성공",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = Object.class))
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "모임 또는 약속의 멤버가 아님"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "모임, 약속 또는 토픽을 찾을 수 없음"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 오류")
+    })
+    @PostMapping(value = "/ai-test", produces = MediaType.APPLICATION_JSON_VALUE)
+    ResponseEntity<ApiResponse<String>> requestTopicSummary(
+            @PathVariable("gathering_id") Long gatheringId,
+            @PathVariable("meeting_id") Long meetingId,
+            @PathVariable("topic_id") Long topicId
+    );
+}

--- a/src/main/java/com/dokdok/topic/controller/TopicSummaryController.java
+++ b/src/main/java/com/dokdok/topic/controller/TopicSummaryController.java
@@ -1,0 +1,26 @@
+package com.dokdok.topic.controller;
+
+import com.dokdok.global.response.ApiResponse;
+import com.dokdok.topic.api.TopicSummaryApi;
+import com.dokdok.topic.service.TopicSummaryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class TopicSummaryController implements TopicSummaryApi {
+
+    private final TopicSummaryService topicSummaryService;
+
+    @Override
+    public ResponseEntity<ApiResponse<String>> requestTopicSummary(
+            Long gatheringId,
+            Long meetingId,
+            Long topicId
+    ) {
+        String response = topicSummaryService.requestTopicSummary(gatheringId, meetingId, topicId);
+
+        return ApiResponse.success(response, "AI 요약 요청이 전달되었습니다.");
+    }
+}

--- a/src/main/java/com/dokdok/topic/repository/TopicAnswerRepository.java
+++ b/src/main/java/com/dokdok/topic/repository/TopicAnswerRepository.java
@@ -6,7 +6,6 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-import javax.swing.*;
 import java.util.List;
 import java.util.Optional;
 
@@ -31,6 +30,15 @@ public interface TopicAnswerRepository extends JpaRepository<TopicAnswer, Long> 
                     AND ta.user.id = :userId
             """)
     List<TopicAnswer> findByMeetingIdUserId(Long meetingId, Long userId);
+
+    @Query("""
+            SELECT ta
+            FROM TopicAnswer ta
+            JOIN FETCH ta.user u
+            WHERE ta.topic.id = :topicId
+            AND ta.isSubmitted = true
+            """)
+    List<TopicAnswer> findSubmittedByTopicId(@Param("topicId") Long topicId);
 
     @Modifying
     @Query("""

--- a/src/main/java/com/dokdok/topic/service/TopicSummaryService.java
+++ b/src/main/java/com/dokdok/topic/service/TopicSummaryService.java
@@ -1,0 +1,53 @@
+package com.dokdok.topic.service;
+
+import com.dokdok.ai.client.AiSummaryClient;
+import com.dokdok.ai.dto.TopicSummaryRequest;
+import com.dokdok.gathering.service.GatheringValidator;
+import com.dokdok.global.util.SecurityUtil;
+import com.dokdok.meeting.service.MeetingValidator;
+import com.dokdok.topic.entity.Topic;
+import com.dokdok.topic.entity.TopicAnswer;
+import com.dokdok.topic.repository.TopicAnswerRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class TopicSummaryService {
+
+    private final GatheringValidator gatheringValidator;
+    private final MeetingValidator meetingValidator;
+    private final TopicValidator topicValidator;
+    private final TopicAnswerRepository topicAnswerRepository;
+    private final AiSummaryClient aiSummaryClient;
+
+    public String requestTopicSummary(Long gatheringId, Long meetingId, Long topicId) {
+        Long userId = SecurityUtil.getCurrentUserId();
+        gatheringValidator.validateGathering(gatheringId);
+        meetingValidator.validateMeetingInGathering(meetingId, gatheringId);
+        meetingValidator.validateMeetingMember(meetingId, userId);
+
+        Topic topic = topicValidator.getTopicInMeeting(topicId, meetingId);
+        List<TopicAnswer> answers = topicAnswerRepository.findSubmittedByTopicId(topicId);
+
+        List<TopicSummaryRequest.Answer> answerDtos = answers.stream()
+                .map(answer -> new TopicSummaryRequest.Answer(
+                        answer.getUser().getId(),
+                        answer.getContent()
+                ))
+                .filter(answer -> answer.content() != null && !answer.content().isBlank())
+                .toList();
+
+        TopicSummaryRequest request = new TopicSummaryRequest(
+                topic.getId(),
+                topic.getTitle(),
+                answerDtos
+        );
+
+        return aiSummaryClient.requestTopicSummary(request);
+    }
+}

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -93,3 +93,8 @@ minio:
   access-key: ${MINIO_ACCESS_KEY}
   secret-key: ${MINIO_SECRET_KEY}
   bucket: ${MINIO_BUCKET:dokdok-storage}
+
+ai:
+  api:
+    base-url: http://localhost:8000
+    summary-path: /summaries/topics

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -18,3 +18,8 @@ app:
       - http://localhost:5173
       - https://yourdomain.com
       - https://dev.yourdomain.com
+
+ai:
+  api:
+    base-url: ${AI_API_BASE_URL:http://localhost:8000}
+    summary-path: ${AI_API_SUMMARY_PATH:/summaries/topics}

--- a/src/test/java/com/dokdok/topic/service/TopicSummaryServiceTest.java
+++ b/src/test/java/com/dokdok/topic/service/TopicSummaryServiceTest.java
@@ -1,0 +1,217 @@
+package com.dokdok.topic.service;
+
+import com.dokdok.ai.client.AiSummaryClient;
+import com.dokdok.ai.dto.TopicSummaryRequest;
+import com.dokdok.gathering.service.GatheringValidator;
+import com.dokdok.global.exception.GlobalException;
+import com.dokdok.meeting.service.MeetingValidator;
+import com.dokdok.topic.entity.Topic;
+import com.dokdok.topic.entity.TopicAnswer;
+import com.dokdok.topic.repository.TopicAnswerRepository;
+import com.dokdok.user.entity.User;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class TopicSummaryServiceTest {
+
+    @Mock
+    private GatheringValidator gatheringValidator;
+
+    @Mock
+    private MeetingValidator meetingValidator;
+
+    @Mock
+    private TopicValidator topicValidator;
+
+    @Mock
+    private TopicAnswerRepository topicAnswerRepository;
+
+    @Mock
+    private AiSummaryClient aiSummaryClient;
+
+    @InjectMocks
+    private TopicSummaryService topicSummaryService;
+
+    @BeforeEach
+    void setUpSecurityContext() {
+        User user = User.builder()
+                .id(1L)
+                .nickname("tester")
+                .kakaoId(1L)
+                .build();
+        com.dokdok.oauth2.CustomOAuth2User principal = com.dokdok.oauth2.CustomOAuth2User.builder()
+                .user(user)
+                .attributes(java.util.Collections.emptyMap())
+                .build();
+        UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
+                principal,
+                null,
+                principal.getAuthorities()
+        );
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+    }
+
+    @AfterEach
+    void clearSecurityContext() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    @DisplayName("토픽 요약 요청 시 제출된 답변만 모아 AI에 전달한다")
+    void requestTopicSummary_buildsPayloadAndDelegatesToClient() {
+        Long gatheringId = 1L;
+        Long meetingId = 2L;
+        Long topicId = 5L;
+        Topic topic = Topic.builder().id(topicId).title("데미안 토론").build();
+
+        User user3 = User.builder().id(3L).kakaoId(3L).build();
+        User user4 = User.builder().id(4L).kakaoId(4L).build();
+        User user5 = User.builder().id(5L).kakaoId(5L).build();
+
+        TopicAnswer answer1 = TopicAnswer.builder()
+                .topic(topic)
+                .user(user3)
+                .content("답변 1")
+                .isSubmitted(true)
+                .build();
+        TopicAnswer answer2 = TopicAnswer.builder()
+                .topic(topic)
+                .user(user4)
+                .content("  ")
+                .isSubmitted(true)
+                .build();
+        TopicAnswer answer3 = TopicAnswer.builder()
+                .topic(topic)
+                .user(user5)
+                .content("답변 3")
+                .isSubmitted(true)
+                .build();
+
+        doNothing().when(gatheringValidator).validateGathering(gatheringId);
+        doNothing().when(meetingValidator).validateMeetingInGathering(meetingId, gatheringId);
+        doNothing().when(meetingValidator).validateMeetingMember(meetingId, 1L);
+        when(topicValidator.getTopicInMeeting(topicId, meetingId)).thenReturn(topic);
+        when(topicAnswerRepository.findSubmittedByTopicId(topicId))
+                .thenReturn(List.of(answer1, answer2, answer3));
+        when(aiSummaryClient.requestTopicSummary(org.mockito.ArgumentMatchers.any()))
+                .thenReturn("ok");
+
+        String result = topicSummaryService.requestTopicSummary(gatheringId, meetingId, topicId);
+
+        ArgumentCaptor<TopicSummaryRequest> captor = ArgumentCaptor.forClass(TopicSummaryRequest.class);
+        verify(aiSummaryClient).requestTopicSummary(captor.capture());
+
+        TopicSummaryRequest request = captor.getValue();
+        assertThat(request.topicId()).isEqualTo(topicId);
+        assertThat(request.topicTitle()).isEqualTo("데미안 토론");
+        assertThat(request.answers()).containsExactly(
+                new TopicSummaryRequest.Answer(3L, "답변 1"),
+                new TopicSummaryRequest.Answer(5L, "답변 3")
+        );
+        assertThat(result).isEqualTo("ok");
+    }
+
+    @Test
+    @DisplayName("제출된 답변이 비어있으면 빈 answers로 AI 요청한다")
+    void requestTopicSummary_sendsEmptyAnswersWhenNoContent() {
+        Long gatheringId = 1L;
+        Long meetingId = 2L;
+        Long topicId = 5L;
+        Topic topic = Topic.builder().id(topicId).title("빈 답변 토픽").build();
+
+        User user3 = User.builder().id(3L).kakaoId(3L).build();
+        TopicAnswer answer1 = TopicAnswer.builder()
+                .topic(topic)
+                .user(user3)
+                .content("   ")
+                .isSubmitted(true)
+                .build();
+
+        doNothing().when(gatheringValidator).validateGathering(gatheringId);
+        doNothing().when(meetingValidator).validateMeetingInGathering(meetingId, gatheringId);
+        doNothing().when(meetingValidator).validateMeetingMember(meetingId, 1L);
+        when(topicValidator.getTopicInMeeting(topicId, meetingId)).thenReturn(topic);
+        when(topicAnswerRepository.findSubmittedByTopicId(topicId))
+                .thenReturn(List.of(answer1));
+        when(aiSummaryClient.requestTopicSummary(org.mockito.ArgumentMatchers.any()))
+                .thenReturn("ok");
+
+        topicSummaryService.requestTopicSummary(gatheringId, meetingId, topicId);
+
+        ArgumentCaptor<TopicSummaryRequest> captor = ArgumentCaptor.forClass(TopicSummaryRequest.class);
+        verify(aiSummaryClient).requestTopicSummary(captor.capture());
+        assertThat(captor.getValue().answers()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("제출된 답변이 없으면 빈 answers로 AI 요청한다")
+    void requestTopicSummary_sendsEmptyAnswersWhenNoSubmittedAnswer() {
+        Long gatheringId = 1L;
+        Long meetingId = 2L;
+        Long topicId = 5L;
+        Topic topic = Topic.builder().id(topicId).title("빈 답변 토픽").build();
+
+        doNothing().when(gatheringValidator).validateGathering(gatheringId);
+        doNothing().when(meetingValidator).validateMeetingInGathering(meetingId, gatheringId);
+        doNothing().when(meetingValidator).validateMeetingMember(meetingId, 1L);
+        when(topicValidator.getTopicInMeeting(topicId, meetingId)).thenReturn(topic);
+        when(topicAnswerRepository.findSubmittedByTopicId(topicId))
+                .thenReturn(List.of());
+        when(aiSummaryClient.requestTopicSummary(org.mockito.ArgumentMatchers.any()))
+                .thenReturn("ok");
+
+        topicSummaryService.requestTopicSummary(gatheringId, meetingId, topicId);
+
+        ArgumentCaptor<TopicSummaryRequest> captor = ArgumentCaptor.forClass(TopicSummaryRequest.class);
+        verify(aiSummaryClient).requestTopicSummary(captor.capture());
+        assertThat(captor.getValue().answers()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("인증 정보가 없으면 예외가 발생한다")
+    void requestTopicSummary_throwsWhenUnauthenticated() {
+        SecurityContextHolder.clearContext();
+
+        assertThatThrownBy(() -> topicSummaryService.requestTopicSummary(1L, 2L, 3L))
+                .isInstanceOf(GlobalException.class);
+    }
+
+    @Test
+    @DisplayName("AI 호출 실패 시 예외가 그대로 전파된다")
+    void requestTopicSummary_throwsWhenAiClientFails() {
+        Long gatheringId = 1L;
+        Long meetingId = 2L;
+        Long topicId = 5L;
+        Topic topic = Topic.builder().id(topicId).title("데미안 토론").build();
+
+        doNothing().when(gatheringValidator).validateGathering(gatheringId);
+        doNothing().when(meetingValidator).validateMeetingInGathering(meetingId, gatheringId);
+        doNothing().when(meetingValidator).validateMeetingMember(meetingId, 1L);
+        when(topicValidator.getTopicInMeeting(topicId, meetingId)).thenReturn(topic);
+        when(topicAnswerRepository.findSubmittedByTopicId(topicId))
+                .thenReturn(List.of());
+        when(aiSummaryClient.requestTopicSummary(org.mockito.ArgumentMatchers.any()))
+                .thenThrow(new IllegalStateException("ai fail"));
+
+        assertThatThrownBy(() -> topicSummaryService.requestTopicSummary(gatheringId, meetingId, topicId))
+                .isInstanceOf(IllegalStateException.class);
+    }
+}


### PR DESCRIPTION
## PR 요약

  - [x] 기능 추가
  - [ ] 버그 수정
  - [ ] 코드 리팩토링
  - [ ] 문서 수정
  - [ ] 기타 (AI 요약 테스트 API 추가)

  ———

  ## 이슈 번호

  - #164 

  ———

  ## 주요 변경 사항

  - src/main/java/com/dokdok/global/config/AiWebClientConfig.java: AI 서버 호출용 WebClient 설정 추가
  - src/main/java/com/dokdok/ai/client/AiSummaryClient.java: AI 요약 요청 클라이언트 구현
  - src/main/java/com/dokdok/ai/dto/TopicSummaryRequest.java: AI 요청 payload DTO 추가
  - src/main/java/com/dokdok/topic/service/TopicSummaryService.java: 제출된 답변 수집 후 AI 요청 전달
  - src/main/java/com/dokdok/topic/api/TopicSummaryApi.java: 테스트용 API 인터페이스 추가
  - src/main/java/com/dokdok/topic/controller/TopicSummaryController.java: 테스트용 엔드포인트 구현
  - src/main/java/com/dokdok/topic/repository/TopicAnswerRepository.java: 제출된 답변 조회 메서드 추가
  - src/main/resources/application.yaml: AI 서버 기본 설정 추가
  - src/main/resources/application-local.yaml: 로컬 AI 설정 추가
  - src/main/resources/application-dev.yaml: dev AI 설정 추가
  - src/test/java/com/dokdok/topic/service/TopicSummaryServiceTest.java: 요약 요청 서비스 테스트 추가

  ———

  ## 참고 사항

  - 테스트 API: POST /api/gatherings/{gathering_id}/meetings/{meeting_id}/topics/{topic_id}/summaries/ai-test
  - AI API: POST /summaries/topics
  - 로컬 설정: ai.api.base-url, ai.api.summary-path