### PR TITLE
[#167][REFACTOR] 모임 생성 시 텍스트 길이 제한 설정.

### DIFF
--- a/src/main/java/com/dokdok/gathering/dto/request/GatheringCreateRequest.java
+++ b/src/main/java/com/dokdok/gathering/dto/request/GatheringCreateRequest.java
@@ -1,10 +1,15 @@
 package com.dokdok.gathering.dto.request;
 
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 
 public record GatheringCreateRequest(
         @NotBlank(message = "모임의 이름은 필수입력입니다.")
+        @Size(max = 12, message = "모임 이름은 12자 이내로 입력해주세요.")
         String gatheringName,
+
+        @Size(max = 150, message = "모임 설명은 150자 이내로 입력해주세요.")
         String gatheringDescription
 ) {
 }


### PR DESCRIPTION
## PR 요약
> 이 PR이 어떤 변경을 하는지 간단히 설명하고, 체크 표시는 괄호 사이에 소문자 'x'를 삽입하세요.

- [ ] 기능 추가
- [ ] 버그 수정
- [x] 코드 리팩토링
- [ ] 문서 수정
- [ ] 기타 (설명)

---

## 이슈 번호
- #167 

---

## 주요 변경 사항
> 주요 파일, 로직, 컴포넌트 등을 구체적으로 적어주세요.

- `src/main/java/com/dokdok/gathering/dto/request/GatheringCreateRequest.java`: 모임 생성 시 입력 받는 모임명, 모임 설명에 텍스트 길이 제한을 설정하였습니다.

---