### PR TITLE
[#169][FEAT] 프로필 이미지 변경/삭제 API 추가

### DIFF
--- a/src/main/java/com/dokdok/gathering/dto/request/GatheringCreateRequest.java
+++ b/src/main/java/com/dokdok/gathering/dto/request/GatheringCreateRequest.java
@@ -1,10 +1,15 @@
 package com.dokdok.gathering.dto.request;
 
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 
 public record GatheringCreateRequest(
         @NotBlank(message = "모임의 이름은 필수입력입니다.")
+        @Size(max = 12, message = "모임 이름은 12자 이내로 입력해주세요.")
         String gatheringName,
+
+        @Size(max = 150, message = "모임 설명은 150자 이내로 입력해주세요.")
         String gatheringDescription
 ) {
 }

--- a/src/main/java/com/dokdok/storage/service/StorageService.java
+++ b/src/main/java/com/dokdok/storage/service/StorageService.java
@@ -83,6 +83,24 @@ public class StorageService {
         }
     }
 
+    public void deleteProfileImage(String objectPath) {
+        if (objectPath == null || objectPath.isBlank()) {
+            return;
+        }
+
+        try {
+            internalMinioClient.removeObject(
+                    RemoveObjectArgs.builder()
+                            .bucket(bucket)
+                            .object(objectPath)
+                            .build()
+            );
+        } catch (Exception e) {
+            log.error("파일 삭제 실패: {}", e.getMessage(), e);
+            throw new StorageException(StorageErrorCode.FILE_DELETE_FAILED, e);
+        }
+    }
+
 	private void validateImageFile(MultipartFile file) {
 		if (file.isEmpty()) {
 			throw new StorageException(StorageErrorCode.INVALID_FILE_TYPE);

--- a/src/main/java/com/dokdok/user/api/UserApi.java
+++ b/src/main/java/com/dokdok/user/api/UserApi.java
@@ -385,4 +385,143 @@ public interface UserApi {
     ResponseEntity<ApiResponse<Void>> deleteCurrentUser(
             @Parameter(hidden = true) HttpServletRequest request
     );
+
+    @Operation(
+            summary = "프로필 이미지 변경",
+            description = """
+                    현재 사용자의 프로필 이미지를 변경합니다.
+                    - 기존 이미지가 있으면 삭제 후 새 이미지로 교체
+                    - jpg, jpeg, png 형식만 허용
+                    - 최대 5MB
+                    """
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "프로필 이미지 변경 성공",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = UserDetailResponse.class),
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                              "code": "SUCCESS",
+                                              "message": "프로필 이미지가 변경되었습니다.",
+                                              "data": {
+                                                "userId": 1,
+                                                "nickname": "테스트닉네임",
+                                                "email": "test@example.com",
+                                                "profileImageUrl": "https://example.com/new-profile.jpg",
+                                                "createdAt": "2024-01-13T10:30:00"
+                                              }
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "400",
+                    description = "잘못된 요청",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            examples = {
+                                    @ExampleObject(
+                                            name = "파일 형식 오류",
+                                            description = "지원하지 않는 이미지 형식인 경우",
+                                            value = "{\"code\":\"S003\",\"message\":\"지원하지 않는 파일 형식입니다.\"}"
+                                    ),
+                                    @ExampleObject(
+                                            name = "파일 크기 초과",
+                                            description = "파일 크기가 5MB를 초과한 경우",
+                                            value = "{\"code\":\"S004\",\"message\":\"파일 크기가 제한을 초과했습니다.\"}"
+                                    )
+                            }
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "401",
+                    description = "인증되지 않은 사용자",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(
+                                    value = "{\"code\":\"G001\",\"message\":\"인증되지 않은 사용자입니다.\"}"
+                            )
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "사용자를 찾을 수 없음",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(
+                                    value = "{\"code\":\"U001\",\"message\":\"존재하지 않는 사용자입니디.\"}"
+                            )
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "500",
+                    description = "서버 오류",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(
+                                    value = "{\"code\":\"S001\",\"message\":\"파일 업로드에 실패했습니다.\"}"
+                            )
+                    )
+            )
+    })
+    @PatchMapping(value = "/me/profile-image", consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
+    ResponseEntity<ApiResponse<UserDetailResponse>> updateProfileImage(
+            @Parameter(description = "프로필 이미지 (jpg, jpeg, png / 최대 5MB)", required = true, schema = @Schema(type = "string", format = "binary"))
+            @RequestPart("profileImage") MultipartFile profileImage
+    );
+
+    @Operation(
+            summary = "프로필 이미지 삭제",
+            description = "현재 사용자의 프로필 이미지를 삭제합니다. 삭제 후 기본 이미지(null)로 설정됩니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "프로필 이미지 삭제 성공",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = ApiResponse.class),
+                            examples = @ExampleObject(
+                                    value = "{\"code\":\"SUCCESS\",\"message\":\"프로필 이미지가 삭제되었습니다.\"}"
+                            )
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "401",
+                    description = "인증되지 않은 사용자",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(
+                                    value = "{\"code\":\"G001\",\"message\":\"인증되지 않은 사용자입니다.\"}"
+                            )
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "사용자를 찾을 수 없음",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(
+                                    value = "{\"code\":\"U001\",\"message\":\"존재하지 않는 사용자입니디.\"}"
+                            )
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "500",
+                    description = "서버 오류",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(
+                                    value = "{\"code\":\"S002\",\"message\":\"파일 삭제에 실패했습니다.\"}"
+                            )
+                    )
+            )
+    })
+    @DeleteMapping(value = "/me/profile-image", produces = MediaType.APPLICATION_JSON_VALUE)
+    ResponseEntity<ApiResponse<Void>> deleteProfileImage();
 }

--- a/src/main/java/com/dokdok/user/controller/UserController.java
+++ b/src/main/java/com/dokdok/user/controller/UserController.java
@@ -76,4 +76,18 @@ public class UserController implements UserApi {
             session.invalidate();
         }
     }
+
+    @Override
+    @PatchMapping("/me/profile-image")
+    public ResponseEntity<ApiResponse<UserDetailResponse>> updateProfileImage(MultipartFile profileImage) {
+        UserDetailResponse response = userService.updateProfileImage(profileImage);
+        return ApiResponse.success(response, "프로필 이미지가 변경되었습니다.");
+    }
+
+    @Override
+    @DeleteMapping("/me/profile-image")
+    public ResponseEntity<ApiResponse<Void>> deleteProfileImage() {
+        userService.deleteProfileImage();
+        return ApiResponse.success("프로필 이미지가 삭제되었습니다.");
+    }
 }

--- a/src/main/java/com/dokdok/user/service/UserService.java
+++ b/src/main/java/com/dokdok/user/service/UserService.java
@@ -93,6 +93,38 @@ public class UserService {
         user.delete();
     }
 
+    @Transactional
+    public UserDetailResponse updateProfileImage(MultipartFile file) {
+        Long currentUserId = SecurityUtil.getCurrentUserId();
+        User user = getUserById(currentUserId);
+
+        String oldImageUrl = user.getProfileImageUrl();
+        if (oldImageUrl != null && !oldImageUrl.isBlank()) {
+            storageService.deleteProfileImage(oldImageUrl);
+        }
+
+        String newImageUrl = storageService.uploadProfileImage(file);
+        user.updateProfileImage(newImageUrl);
+
+        SecurityUtil.updateCurrentUserInContext(user);
+
+        String presignedUrl = storageService.getPresignedProfileImage(newImageUrl);
+        return UserDetailResponse.from(user, presignedUrl);
+    }
+
+    @Transactional
+    public void deleteProfileImage() {
+        Long currentUserId = SecurityUtil.getCurrentUserId();
+        User user = getUserById(currentUserId);
+
+        String imageUrl = user.getProfileImageUrl();
+        if (imageUrl != null && !imageUrl.isBlank()) {
+            storageService.deleteProfileImage(imageUrl);
+            user.updateProfileImage(null);
+            SecurityUtil.updateCurrentUserInContext(user);
+        }
+    }
+
     /**
      * 닉네임 유효성을 검사합니다.
      * @param nickname trim된 닉네임

--- a/src/test/java/com/dokdok/user/service/UserServiceTest.java
+++ b/src/test/java/com/dokdok/user/service/UserServiceTest.java
@@ -877,4 +877,202 @@ class UserServiceTest {
             securityUtilMock.verify(() -> SecurityUtil.updateCurrentUserInContext(user), times(1));
         }
     }
+
+    @Test
+    @DisplayName("프로필 이미지 변경 - 기존 이미지 없이 새 이미지 업로드 성공")
+    void updateProfileImage_WithoutExistingImage_Success() {
+        // given
+        Long userId = 1L;
+        String newImageUrl = "profiles/1/new-uuid.jpg";
+        String presignedUrl = "https://minio.example.com/presigned/new-uuid.jpg";
+
+        User user = User.builder()
+                .id(userId)
+                .nickname("테스트닉네임")
+                .profileImageUrl(null)
+                .build();
+
+        MultipartFile mockFile = mock(MultipartFile.class);
+
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        when(storageService.uploadProfileImage(mockFile)).thenReturn(newImageUrl);
+        when(storageService.getPresignedProfileImage(newImageUrl)).thenReturn(presignedUrl);
+
+        try (MockedStatic<SecurityUtil> securityUtilMock = mockStatic(SecurityUtil.class)) {
+            securityUtilMock.when(SecurityUtil::getCurrentUserId).thenReturn(userId);
+
+            // when
+            var response = userService.updateProfileImage(mockFile);
+
+            // then
+            assertThat(response).isNotNull();
+            assertThat(response.profileImageUrl()).isEqualTo(presignedUrl);
+            assertThat(user.getProfileImageUrl()).isEqualTo(newImageUrl);
+
+            verify(storageService, never()).deleteProfileImage(anyString());
+            verify(storageService, times(1)).uploadProfileImage(mockFile);
+            verify(storageService, times(1)).getPresignedProfileImage(newImageUrl);
+            securityUtilMock.verify(() -> SecurityUtil.updateCurrentUserInContext(user), times(1));
+        }
+    }
+
+    @Test
+    @DisplayName("프로필 이미지 변경 - 기존 이미지 삭제 후 새 이미지 업로드 성공")
+    void updateProfileImage_WithExistingImage_DeletesOldAndUploadsNew() {
+        // given
+        Long userId = 1L;
+        String oldImageUrl = "profiles/1/old-uuid.jpg";
+        String newImageUrl = "profiles/1/new-uuid.jpg";
+        String presignedUrl = "https://minio.example.com/presigned/new-uuid.jpg";
+
+        User user = User.builder()
+                .id(userId)
+                .nickname("테스트닉네임")
+                .profileImageUrl(oldImageUrl)
+                .build();
+
+        MultipartFile mockFile = mock(MultipartFile.class);
+
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        when(storageService.uploadProfileImage(mockFile)).thenReturn(newImageUrl);
+        when(storageService.getPresignedProfileImage(newImageUrl)).thenReturn(presignedUrl);
+
+        try (MockedStatic<SecurityUtil> securityUtilMock = mockStatic(SecurityUtil.class)) {
+            securityUtilMock.when(SecurityUtil::getCurrentUserId).thenReturn(userId);
+
+            // when
+            var response = userService.updateProfileImage(mockFile);
+
+            // then
+            assertThat(response).isNotNull();
+            assertThat(response.profileImageUrl()).isEqualTo(presignedUrl);
+            assertThat(user.getProfileImageUrl()).isEqualTo(newImageUrl);
+
+            verify(storageService, times(1)).deleteProfileImage(oldImageUrl);
+            verify(storageService, times(1)).uploadProfileImage(mockFile);
+            verify(storageService, times(1)).getPresignedProfileImage(newImageUrl);
+            securityUtilMock.verify(() -> SecurityUtil.updateCurrentUserInContext(user), times(1));
+        }
+    }
+
+    @Test
+    @DisplayName("프로필 이미지 변경 - 존재하지 않는 사용자 예외")
+    void updateProfileImage_UserNotFound_ThrowsException() {
+        // given
+        Long userId = 1L;
+        MultipartFile mockFile = mock(MultipartFile.class);
+
+        when(userRepository.findById(userId)).thenReturn(Optional.empty());
+
+        try (MockedStatic<SecurityUtil> securityUtilMock = mockStatic(SecurityUtil.class)) {
+            securityUtilMock.when(SecurityUtil::getCurrentUserId).thenReturn(userId);
+
+            // when & then
+            assertThatThrownBy(() -> userService.updateProfileImage(mockFile))
+                    .isInstanceOf(UserException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", UserErrorCode.USER_NOT_FOUND);
+
+            verify(storageService, never()).deleteProfileImage(anyString());
+            verify(storageService, never()).uploadProfileImage(any());
+        }
+    }
+
+    @Test
+    @DisplayName("프로필 이미지 삭제 - 기존 이미지 삭제 성공")
+    void deleteProfileImage_WithExistingImage_Success() {
+        // given
+        Long userId = 1L;
+        String existingImageUrl = "profiles/1/uuid.jpg";
+
+        User user = User.builder()
+                .id(userId)
+                .nickname("테스트닉네임")
+                .profileImageUrl(existingImageUrl)
+                .build();
+
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+
+        try (MockedStatic<SecurityUtil> securityUtilMock = mockStatic(SecurityUtil.class)) {
+            securityUtilMock.when(SecurityUtil::getCurrentUserId).thenReturn(userId);
+
+            // when
+            userService.deleteProfileImage();
+
+            // then
+            assertThat(user.getProfileImageUrl()).isNull();
+            verify(storageService, times(1)).deleteProfileImage(existingImageUrl);
+            securityUtilMock.verify(() -> SecurityUtil.updateCurrentUserInContext(user), times(1));
+        }
+    }
+
+    @Test
+    @DisplayName("프로필 이미지 삭제 - 기존 이미지 없으면 삭제 스킵")
+    void deleteProfileImage_WithoutExistingImage_SkipsDelete() {
+        // given
+        Long userId = 1L;
+
+        User user = User.builder()
+                .id(userId)
+                .nickname("테스트닉네임")
+                .profileImageUrl(null)
+                .build();
+
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+
+        try (MockedStatic<SecurityUtil> securityUtilMock = mockStatic(SecurityUtil.class)) {
+            securityUtilMock.when(SecurityUtil::getCurrentUserId).thenReturn(userId);
+
+            // when
+            userService.deleteProfileImage();
+
+            // then
+            assertThat(user.getProfileImageUrl()).isNull();
+            verify(storageService, never()).deleteProfileImage(anyString());
+        }
+    }
+
+    @Test
+    @DisplayName("프로필 이미지 삭제 - 빈 문자열 이미지 URL이면 삭제 스킵")
+    void deleteProfileImage_WithBlankImageUrl_SkipsDelete() {
+        // given
+        Long userId = 1L;
+
+        User user = User.builder()
+                .id(userId)
+                .nickname("테스트닉네임")
+                .profileImageUrl("   ")
+                .build();
+
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+
+        try (MockedStatic<SecurityUtil> securityUtilMock = mockStatic(SecurityUtil.class)) {
+            securityUtilMock.when(SecurityUtil::getCurrentUserId).thenReturn(userId);
+
+            // when
+            userService.deleteProfileImage();
+
+            // then
+            verify(storageService, never()).deleteProfileImage(anyString());
+        }
+    }
+
+    @Test
+    @DisplayName("프로필 이미지 삭제 - 존재하지 않는 사용자 예외")
+    void deleteProfileImage_UserNotFound_ThrowsException() {
+        // given
+        Long userId = 1L;
+
+        when(userRepository.findById(userId)).thenReturn(Optional.empty());
+
+        try (MockedStatic<SecurityUtil> securityUtilMock = mockStatic(SecurityUtil.class)) {
+            securityUtilMock.when(SecurityUtil::getCurrentUserId).thenReturn(userId);
+
+            // when & then
+            assertThatThrownBy(() -> userService.deleteProfileImage())
+                    .isInstanceOf(UserException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", UserErrorCode.USER_NOT_FOUND);
+
+            verify(storageService, never()).deleteProfileImage(anyString());
+        }
+    }
 }


### PR DESCRIPTION
## PR 요약
> 사용자 프로필 이미지를 별도로 변경하거나 삭제할 수 있는 REST API를 추가합니다.

- [x] 기능 추가
- [ ] 버그 수정
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 기타 (설명)

---

## 이슈 번호
- #169

---

## 주요 변경 사항
> 주요 파일, 로직, 컴포넌트 등을 구체적으로 적어주세요.

- `StorageService.java`: MinIO에서 프로필 이미지를 삭제하는 deleteProfileImage 메서드 추가
- `UserApi.java`: PATCH/DELETE /api/users/me/profile-image 엔드포인트 Swagger 명세 추가
- `UserController.java`: 프로필 이미지 변경/삭제 엔드포인트 구현
- `UserService.java`: updateProfileImage, deleteProfileImage 메서드 추가 및 SecurityContext 동기화 처리
- `UserServiceTest.java`: 프로필 이미지 변경/삭제 관련 테스트 케이스 7개 추가

---

## 참고 사항
> 리뷰어가 알아야 할 추가 정보, 테스트 방법 등을 작성해주세요.

### API 엔드포인트
- `PATCH /api/users/me/profile-image`: 프로필 이미지 변경 (multipart/form-data)
- `DELETE /api/users/me/profile-image`: 프로필 이미지 삭제

### 주요 구현 내용
1. 기존 이미지가 있는 경우 MinIO에서 삭제 후 새 이미지 업로드
2. 프로필 변경 후 SecurityContext 업데이트하여 이후 조회 시 최신 데이터 반영
3. presigned URL로 이미지 접근 가능

### 테스트 방법
```bash
# 프로필 이미지 변경
curl -X PATCH /api/users/me/profile-image \
  -H "Content-Type: multipart/form-data" \
  -F "file=@profile.jpg"

# 프로필 이미지 삭제
curl -X DELETE /api/users/me/profile-image
```

---