### PR TITLE
[#139][REFACTOR] 개인 회고 입력/수정 폼 조회 API 응답 구조 개선 및 프로필 이미지 조회 추가

### DIFF
--- a/src/main/java/com/dokdok/meeting/repository/MeetingMemberRepository.java
+++ b/src/main/java/com/dokdok/meeting/repository/MeetingMemberRepository.java
@@ -112,6 +112,10 @@ public interface MeetingMemberRepository extends JpaRepository<MeetingMember, Lo
                 FROM MeetingMember mm
                 JOIN FETCH mm.user u
                 WHERE mm.meeting.id = :meetingId
+                AND mm.user.id <> :userId
             """)
-    List<MeetingMember> findByMeetingId(Long meetingId);
+    List<MeetingMember> findOtherMembersByMeetingId(
+            @Param("meetingId") Long meetingId,
+            @Param("userId") Long userId
+    );
 }

--- a/src/main/java/com/dokdok/retrospective/api/PersonalRetrospectiveApi.java
+++ b/src/main/java/com/dokdok/retrospective/api/PersonalRetrospectiveApi.java
@@ -74,7 +74,7 @@ public interface PersonalRetrospectiveApi {
     );
 
     @Operation(
-            summary = "개인 회고 조회",
+            summary = "개인 회고 수정 폼 조회",
             description = "기존에 작성한 개인 회고를 수정하기 위한 데이터를 조회합니다.",
             parameters = {
                     @Parameter(name = "meetingId", description = "약속 식별자", in = ParameterIn.PATH, required = true),
@@ -84,7 +84,7 @@ public interface PersonalRetrospectiveApi {
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(
                     responseCode = "200",
-                    description = "개인 회고 조회 성공",
+                    description = "개인 회고 수정 폼 조회 성공",
                     content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
                             schema = @Schema(implementation = PersonalRetrospectiveResponse.class))
             ),

--- a/src/main/java/com/dokdok/retrospective/dto/response/MemberInfo.java
+++ b/src/main/java/com/dokdok/retrospective/dto/response/MemberInfo.java
@@ -1,0 +1,15 @@
+package com.dokdok.retrospective.dto.response;
+
+public record MemberInfo(
+        Long meetingMemberId,
+        String nickname,
+        String profileImageUrl
+) {
+    public static MemberInfo of(Long meetingMemberId, String nickname, String profileImageUrl) {
+        return new MemberInfo(
+                meetingMemberId,
+                nickname,
+                profileImageUrl
+        );
+    }
+}

--- a/src/main/java/com/dokdok/retrospective/dto/response/PersonalRetrospectiveDetailResponse.java
+++ b/src/main/java/com/dokdok/retrospective/dto/response/PersonalRetrospectiveDetailResponse.java
@@ -8,20 +8,28 @@ import java.util.List;
 
 public record PersonalRetrospectiveDetailResponse(
         Long retrospectiveId,
-        List<ChangedThought> changedThoughts,
-        List<OthersPerspective> othersPerspectives,
-        List<FreeText> freeTexts
+        RetrospectiveData retrospective,  // 작성 데이터 묶음
+        List<TopicInfo> topics,
+        List<MemberInfo> meetingMembers
 ) {
+
+    public record RetrospectiveData(
+            List<ChangedThought> changedThoughts,
+            List<OthersPerspective> othersPerspectives,
+            List<FreeText> freeTexts
+    ) {}
+
     public record ChangedThought(
             Long topicId,
             String keyIssue,
+            String preOpinion,
             String postOpinion
     ) {
-
         public static ChangedThought from(RetrospectiveChangedThought changedThought) {
             return new ChangedThought(
                     changedThought.getTopic().getId(),
                     changedThought.getKeyIssue(),
+                    changedThought.getPreOpinion(),
                     changedThought.getPostOpinion()
             );
         }
@@ -59,13 +67,15 @@ public record PersonalRetrospectiveDetailResponse(
             Long retrospectiveId,
             List<ChangedThought> changedThoughts,
             List<OthersPerspective> othersPerspectives,
-            List<FreeText> freeTexts
+            List<FreeText> freeTexts,
+            List<TopicInfo> topics,
+            List<MemberInfo> meetingMembers
     ) {
         return new PersonalRetrospectiveDetailResponse(
                 retrospectiveId,
-                changedThoughts,
-                othersPerspectives,
-                freeTexts
+                new RetrospectiveData(changedThoughts, othersPerspectives, freeTexts), // 묶어서 전달
+                topics,
+                meetingMembers
         );
     }
 }

--- a/src/main/java/com/dokdok/retrospective/dto/response/PersonalRetrospectiveFormResponse.java
+++ b/src/main/java/com/dokdok/retrospective/dto/response/PersonalRetrospectiveFormResponse.java
@@ -8,8 +8,8 @@ import java.util.List;
 public record PersonalRetrospectiveFormResponse(
         Long meetingId,
         List<PreOpinions> preOpinions,
-        List<Topics> topics,
-        List<MeetingMembers> meetingMembers
+        List<TopicInfo> topics,
+        List<MemberInfo> meetingMembers
 ) {
     public record PreOpinions(
         Long topicId,
@@ -26,36 +26,11 @@ public record PersonalRetrospectiveFormResponse(
         }
     }
 
-    public record Topics(
-            Long topicId,
-            String topicName
-    ) {
-        public static Topics from(Topic topic) {
-            return new Topics(
-                    topic.getId(),
-                    topic.getTitle()
-            );
-        }
-    }
-
-    public record MeetingMembers(
-        Long meetingMemberId,
-        String nickName
-    ) {
-        public static MeetingMembers of(Long meetingMemberId, String nickName) {
-            return new MeetingMembers(
-                    meetingMemberId,
-                    nickName
-            );
-        }
-
-    }
-
     public static PersonalRetrospectiveFormResponse of(
             Long meetingId,
             List<PreOpinions> preOpinions,
-            List<Topics> topics,
-            List<MeetingMembers> meetingMembers
+            List<TopicInfo> topics,
+            List<MemberInfo> meetingMembers
     ) {
         return new PersonalRetrospectiveFormResponse(
                 meetingId,

--- a/src/main/java/com/dokdok/retrospective/dto/response/TopicInfo.java
+++ b/src/main/java/com/dokdok/retrospective/dto/response/TopicInfo.java
@@ -1,0 +1,15 @@
+package com.dokdok.retrospective.dto.response;
+
+import com.dokdok.topic.entity.Topic;
+
+public record TopicInfo(
+        Long topicId,
+        String topicName
+) {
+    public static TopicInfo from(Topic topic) {
+        return new TopicInfo(
+                topic.getId(),
+                topic.getTitle()
+        );
+    }
+}

--- a/src/main/java/com/dokdok/retrospective/service/PersonalRetrospectiveAssembler.java
+++ b/src/main/java/com/dokdok/retrospective/service/PersonalRetrospectiveAssembler.java
@@ -1,13 +1,17 @@
 package com.dokdok.retrospective.service;
 
 import com.dokdok.meeting.entity.MeetingMember;
+import com.dokdok.retrospective.dto.response.MemberInfo;
 import com.dokdok.retrospective.dto.response.PersonalRetrospectiveDetailResponse;
 import com.dokdok.retrospective.dto.response.PersonalRetrospectiveFormResponse;
+import com.dokdok.retrospective.dto.response.TopicInfo;
 import com.dokdok.retrospective.entity.RetrospectiveChangedThought;
 import com.dokdok.retrospective.entity.RetrospectiveFreeText;
 import com.dokdok.retrospective.entity.RetrospectiveOthersPerspective;
+import com.dokdok.storage.service.StorageService;
 import com.dokdok.topic.entity.Topic;
 import com.dokdok.topic.entity.TopicAnswer;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
@@ -16,7 +20,10 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 @Component
+@RequiredArgsConstructor
 public class PersonalRetrospectiveAssembler {
+
+    private final StorageService storageService;
 
     public PersonalRetrospectiveFormResponse assembleCreate(
             Long meetingId,
@@ -25,16 +32,13 @@ public class PersonalRetrospectiveAssembler {
             List<MeetingMember> meetingMembers
     ) {
 
-        List<PersonalRetrospectiveFormResponse.Topics> topicDtos =
-                topics.stream()
-                        .map(PersonalRetrospectiveFormResponse.Topics::from)
-                        .toList();
+        List<TopicInfo> topicDtos = toTopicDtos(topics);
 
         Map<Long, TopicAnswer> topicAnswerMap =
                 topicAnswers.stream()
                         .collect(Collectors.toMap(
-                                ta -> ta.getTopic().getId(), // Key: 주제 ID (1L, 2L)
-                                Function.identity() // TopicAnswer
+                                ta -> ta.getTopic().getId(),
+                                Function.identity()
                         ));
 
         List<PersonalRetrospectiveFormResponse.PreOpinions> preOpinions =
@@ -48,15 +52,7 @@ public class PersonalRetrospectiveAssembler {
                         )
                         .toList();
 
-        List<PersonalRetrospectiveFormResponse.MeetingMembers> memberDtos =
-                meetingMembers.stream()
-                        .map(member ->
-                                PersonalRetrospectiveFormResponse.MeetingMembers.of(
-                                        member.getId(),
-                                        member.getUser().getNickname()
-                                )
-                        )
-                        .toList();
+        List<MemberInfo> memberDtos = toMemberDtos(meetingMembers);
 
         return PersonalRetrospectiveFormResponse.of(
                 meetingId,
@@ -70,7 +66,9 @@ public class PersonalRetrospectiveAssembler {
             Long retrospectiveId,
             List<RetrospectiveChangedThought> changedThoughts,
             List<RetrospectiveOthersPerspective> othersPerspectives,
-            List<RetrospectiveFreeText> freeTexts
+            List<RetrospectiveFreeText> freeTexts,
+            List<Topic> topics,
+            List<MeetingMember> meetingMembers
     ) {
         List<PersonalRetrospectiveDetailResponse.ChangedThought> changedThoughtList =
                 changedThoughts.stream()
@@ -87,11 +85,40 @@ public class PersonalRetrospectiveAssembler {
                         .map(PersonalRetrospectiveDetailResponse.FreeText::from)
                         .toList();
 
+        List<TopicInfo> topicDtos = toTopicDtos(topics);
+        List<MemberInfo> memberDtos = toMemberDtos(meetingMembers);
+
         return PersonalRetrospectiveDetailResponse.from(
                 retrospectiveId,
                 changedThoughtList,
                 othersPerspectiveList,
-                freeTextList
+                freeTextList,
+                topicDtos,
+                memberDtos
         );
     }
+
+    private List<TopicInfo> toTopicDtos(List<Topic> topics) {
+        return topics.stream()
+                .map(TopicInfo::from)
+                .toList();
+    }
+
+    private List<MemberInfo> toMemberDtos(List<MeetingMember> meetingMembers){
+        return meetingMembers.stream()
+                .map(member -> {
+                    String presignedUrl =
+                            storageService.getPresignedProfileImage(
+                                    member.getUser().getProfileImageUrl()
+                            );
+
+                    return MemberInfo.of(
+                            member.getId(),
+                            member.getUser().getNickname(),
+                            presignedUrl
+                    );
+                })
+                .toList();
+    }
+
 }

--- a/src/main/java/com/dokdok/retrospective/service/PersonalRetrospectiveService.java
+++ b/src/main/java/com/dokdok/retrospective/service/PersonalRetrospectiveService.java
@@ -82,8 +82,9 @@ public class PersonalRetrospectiveService {
         retrospectiveValidator.validateRetrospective(meetingId, userId);
 
         List<Topic> topics = topicValidator.getConfirmedTopics(meetingId);
-        List<TopicAnswer> topicAnswers =  topicAnswerRepository.findByMeetingIdUserId(meetingId, userId);
-        List<MeetingMember> meetingMembers = meetingMemberRepository.findByMeetingId(meetingId);
+        List<TopicAnswer> topicAnswers = topicAnswerRepository.findByMeetingIdUserId(meetingId, userId);
+        List<MeetingMember> meetingMembers
+                = meetingMemberRepository.findOtherMembersByMeetingId(meetingId, userId);
 
         return assembler.assembleCreate(
                 meetingId,
@@ -114,11 +115,18 @@ public class PersonalRetrospectiveService {
         List<RetrospectiveFreeText> freeTexts =
                 freeTextRepository.findByPersonalMeetingRetrospective_Id(retrospectiveId);
 
+        List<Topic> topics = topicValidator.getConfirmedTopics(meetingId);
+
+        List<MeetingMember> meetingMembers
+                = meetingMemberRepository.findOtherMembersByMeetingId(meetingId, userId);
+
         return assembler.assembleDetail(
                 retrospectiveId,
                 changedThoughts,
                 othersPerspectives,
-                freeTexts
+                freeTexts,
+                topics,
+                meetingMembers
         );
     }
 

--- a/src/test/java/com/dokdok/retrospective/service/PersonalRetrospectiveServiceTest.java
+++ b/src/test/java/com/dokdok/retrospective/service/PersonalRetrospectiveServiceTest.java
@@ -10,9 +10,7 @@ import com.dokdok.meeting.exception.MeetingErrorCode;
 import com.dokdok.meeting.exception.MeetingException;
 import com.dokdok.meeting.repository.MeetingMemberRepository;
 import com.dokdok.retrospective.dto.request.PersonalRetrospectiveRequest;
-import com.dokdok.retrospective.dto.response.PersonalRetrospectiveDetailResponse;
-import com.dokdok.retrospective.dto.response.PersonalRetrospectiveFormResponse;
-import com.dokdok.retrospective.dto.response.PersonalRetrospectiveResponse;
+import com.dokdok.retrospective.dto.response.*;
 import com.dokdok.retrospective.entity.RetrospectiveChangedThought;
 import com.dokdok.retrospective.entity.RetrospectiveFreeText;
 import com.dokdok.retrospective.entity.RetrospectiveOthersPerspective;
@@ -494,12 +492,12 @@ class PersonalRetrospectiveServiceTest {
                 meetingId,
                 List.of(new PersonalRetrospectiveFormResponse.PreOpinions(10L, "주제1", "사전 의견1")),
                 List.of(
-                        new PersonalRetrospectiveFormResponse.Topics(10L, "주제1"),
-                        new PersonalRetrospectiveFormResponse.Topics(20L, "주제2")
+                        new TopicInfo(10L, "주제1"),
+                        new TopicInfo(20L, "주제2")
                 ),
                 List.of(
-                        new PersonalRetrospectiveFormResponse.MeetingMembers(1L, "사용자1"),
-                        new PersonalRetrospectiveFormResponse.MeetingMembers(2L, "사용자2")
+                        new MemberInfo(1L, "사용자1", "url"),
+                        new MemberInfo(2L, "사용자2","url")
                 )
         );
 
@@ -511,7 +509,7 @@ class PersonalRetrospectiveServiceTest {
             doNothing().when(retrospectiveValidator).validateRetrospective(meetingId, userId);
             when(topicValidator.getConfirmedTopics(meetingId)).thenReturn(topics);
             when(topicAnswerRepository.findByMeetingIdUserId(meetingId, userId)).thenReturn(topicAnswers);
-            when(meetingMemberRepository.findByMeetingId(meetingId)).thenReturn(meetingMembers);
+            when(meetingMemberRepository.findOtherMembersByMeetingId(meetingId, userId)).thenReturn(meetingMembers);
             when(assembler.assembleCreate(meetingId, topics, topicAnswers, meetingMembers))
                     .thenReturn(expectedResponse);
 
@@ -529,7 +527,7 @@ class PersonalRetrospectiveServiceTest {
             verify(retrospectiveValidator).validateRetrospective(meetingId, userId);
             verify(topicValidator).getConfirmedTopics(meetingId);
             verify(topicAnswerRepository).findByMeetingIdUserId(meetingId, userId);
-            verify(meetingMemberRepository).findByMeetingId(meetingId);
+            verify(meetingMemberRepository).findOtherMembersByMeetingId(meetingId, userId);
             verify(assembler).assembleCreate(meetingId, topics, topicAnswers, meetingMembers);
         }
     }
@@ -552,8 +550,8 @@ class PersonalRetrospectiveServiceTest {
         PersonalRetrospectiveFormResponse expectedResponse = PersonalRetrospectiveFormResponse.of(
                 meetingId,
                 List.of(), // 빈 사전 의견
-                List.of(new PersonalRetrospectiveFormResponse.Topics(10L, "주제1")),
-                List.of(new PersonalRetrospectiveFormResponse.MeetingMembers(1L, "사용자1"))
+                List.of(new TopicInfo(10L, "주제1")),
+                List.of(new MemberInfo(1L, "사용자1", "url"))
         );
 
         try (MockedStatic<SecurityUtil> securityUtilMock = mockStatic(SecurityUtil.class)) {
@@ -564,7 +562,7 @@ class PersonalRetrospectiveServiceTest {
             doNothing().when(retrospectiveValidator).validateRetrospective(meetingId, userId);
             when(topicValidator.getConfirmedTopics(meetingId)).thenReturn(topics);
             when(topicAnswerRepository.findByMeetingIdUserId(meetingId, userId)).thenReturn(topicAnswers);
-            when(meetingMemberRepository.findByMeetingId(meetingId)).thenReturn(meetingMembers);
+            when(meetingMemberRepository.findOtherMembersByMeetingId(meetingId, userId)).thenReturn(meetingMembers);
             when(assembler.assembleCreate(meetingId, topics, topicAnswers, meetingMembers))
                     .thenReturn(expectedResponse);
 
@@ -706,9 +704,11 @@ class PersonalRetrospectiveServiceTest {
 
         PersonalRetrospectiveDetailResponse expectedResponse = PersonalRetrospectiveDetailResponse.from(
                 retrospectiveId,
-                List.of(new PersonalRetrospectiveDetailResponse.ChangedThought(10L, "핵심 쟁점", "사후 의견")),
+                List.of(new PersonalRetrospectiveDetailResponse.ChangedThought(10L, "핵심 쟁점", "사전의견","사후 의견")),
                 List.of(new PersonalRetrospectiveDetailResponse.OthersPerspective(10L, 5L, "타인 의견", "인상 깊었던 이유")),
-                List.of(new PersonalRetrospectiveDetailResponse.FreeText("자유 서술 제목", "자유 서술 내용"))
+                List.of(new PersonalRetrospectiveDetailResponse.FreeText("자유 서술 제목", "자유 서술 내용")),
+                List.of(),
+                List.of()
         );
 
         try (MockedStatic<SecurityUtil> securityUtilMock = mockStatic(SecurityUtil.class)) {
@@ -723,7 +723,11 @@ class PersonalRetrospectiveServiceTest {
                     .thenReturn(othersPerspectives);
             when(freeTextRepository.findByPersonalMeetingRetrospective_Id(retrospectiveId))
                     .thenReturn(freeTexts);
-            when(assembler.assembleDetail(retrospectiveId, changedThoughts, othersPerspectives, freeTexts))
+            List<Topic> topics = List.of();
+            List<MeetingMember> meetingMembers = List.of();
+            when(topicValidator.getConfirmedTopics(meetingId)).thenReturn(topics);
+            when(meetingMemberRepository.findOtherMembersByMeetingId(meetingId, userId)).thenReturn(meetingMembers);
+            when(assembler.assembleDetail(retrospectiveId, changedThoughts, othersPerspectives, freeTexts, topics, meetingMembers))
                     .thenReturn(expectedResponse);
 
             // when
@@ -732,9 +736,9 @@ class PersonalRetrospectiveServiceTest {
 
             // then
             assertThat(response.retrospectiveId()).isEqualTo(retrospectiveId);
-            assertThat(response.changedThoughts()).hasSize(1);
-            assertThat(response.othersPerspectives()).hasSize(1);
-            assertThat(response.freeTexts()).hasSize(1);
+            assertThat(response.retrospective().changedThoughts()).hasSize(1);
+            assertThat(response.retrospective().othersPerspectives()).hasSize(1);
+            assertThat(response.retrospective().freeTexts()).hasSize(1);
 
             verify(meetingValidator).validateMeeting(meetingId);
             verify(meetingValidator).validateMeetingMember(meetingId, userId);
@@ -742,7 +746,9 @@ class PersonalRetrospectiveServiceTest {
             verify(changedThoughtRepository).findByPersonalMeetingRetrospective(retrospectiveId);
             verify(othersPerspectiveRepository).findByPersonalMeetingRetrospective(retrospectiveId);
             verify(freeTextRepository).findByPersonalMeetingRetrospective_Id(retrospectiveId);
-            verify(assembler).assembleDetail(retrospectiveId, changedThoughts, othersPerspectives, freeTexts);
+            verify(topicValidator).getConfirmedTopics(meetingId);
+            verify(meetingMemberRepository).findOtherMembersByMeetingId(meetingId, userId);
+            verify(assembler).assembleDetail(retrospectiveId, changedThoughts, othersPerspectives, freeTexts, topics, meetingMembers);
         }
     }
 
@@ -757,9 +763,13 @@ class PersonalRetrospectiveServiceTest {
         List<RetrospectiveChangedThought> changedThoughts = List.of();
         List<RetrospectiveOthersPerspective> othersPerspectives = List.of();
         List<RetrospectiveFreeText> freeTexts = List.of();
+        List<Topic> topics = List.of();
+        List<MeetingMember> meetingMembers = List.of();
 
         PersonalRetrospectiveDetailResponse expectedResponse = PersonalRetrospectiveDetailResponse.from(
                 retrospectiveId,
+                List.of(),
+                List.of(),
                 List.of(),
                 List.of(),
                 List.of()
@@ -777,7 +787,9 @@ class PersonalRetrospectiveServiceTest {
                     .thenReturn(othersPerspectives);
             when(freeTextRepository.findByPersonalMeetingRetrospective_Id(retrospectiveId))
                     .thenReturn(freeTexts);
-            when(assembler.assembleDetail(retrospectiveId, changedThoughts, othersPerspectives, freeTexts))
+            when(topicValidator.getConfirmedTopics(meetingId)).thenReturn(topics);
+            when(meetingMemberRepository.findOtherMembersByMeetingId(meetingId, userId)).thenReturn(meetingMembers);
+            when(assembler.assembleDetail(retrospectiveId, changedThoughts, othersPerspectives, freeTexts, topics, meetingMembers))
                     .thenReturn(expectedResponse);
 
             // when
@@ -785,9 +797,9 @@ class PersonalRetrospectiveServiceTest {
                     personalRetrospectiveService.getPersonalRetrospectiveEditForm(meetingId, retrospectiveId);
 
             // then
-            assertThat(response.changedThoughts()).isEmpty();
-            assertThat(response.othersPerspectives()).isEmpty();
-            assertThat(response.freeTexts()).isEmpty();
+            assertThat(response.retrospective().changedThoughts()).isEmpty();
+            assertThat(response.retrospective().othersPerspectives()).isEmpty();
+            assertThat(response.retrospective().freeTexts()).isEmpty();
         }
     }
 


### PR DESCRIPTION
## PR 요약
> 이 PR이 어떤 변경을 하는지 간단히 설명하고, 체크 표시는 괄호 사이에 소문자 'x'를 삽입하세요.

- [ ] 기능 추가
- [ ] 버그 수정
- [x] 코드 리팩토링
- [ ] 문서 수정
- [ ] 기타 (설명)

---

## 이슈 번호
- #139

---

## 주요 변경 사항
> 주요 파일, 로직, 컴포넌트 등을 구체적으로 적어주세요.

- `src/main/java/com/dokdok/meeting`: +5/-1 (1 files) — 요구사항 반영
- `src/main/java/com/dokdok/retrospective`: +109/-59 (7 files) — 요구사항 반영
- `src/test/java/com/dokdok/retrospective`: +35/-23 (1 files) — 요구사항 반영

---

## 참고 사항
> 리뷰어가 알아야 할 추가 정보, 테스트 방법 등을 작성해주세요.

예:
- 테스트 계정 정보
- 관련 API 엔드포인트
- 로컬 테스트 방법

---
