### PR TITLE
[#172][FEAT] 개인 회고 삭제 API 구현

### DIFF
--- a/src/main/java/com/dokdok/retrospective/api/PersonalRetrospectiveApi.java
+++ b/src/main/java/com/dokdok/retrospective/api/PersonalRetrospectiveApi.java
@@ -15,6 +15,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -123,5 +124,28 @@ public interface PersonalRetrospectiveApi {
             @PathVariable Long meetingId,
             @PathVariable Long retrospectiveId,
             @Valid @RequestBody PersonalRetrospectiveRequest request
+    );
+
+    @Operation(
+            summary = "개인 회고 삭제",
+            description = "기존에 작성한 개인 회고를 삭제합니다. 본인이 작성한 회고만 삭제할 수 있습니다.",
+            parameters = {
+                    @Parameter(name = "meetingId", description = "약속 식별자", in = ParameterIn.PATH, required = true),
+                    @Parameter(name = "retrospectiveId", description = "개인 회고 식별자", in = ParameterIn.PATH, required = true)
+            }
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "개인 회고 삭제 성공"
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "본인이 작성한 회고가 아님"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "약속 또는 개인 회고를 찾을 수 없음"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 오류")
+    })
+    @DeleteMapping(value = "/{retrospectiveId}", produces = MediaType.APPLICATION_JSON_VALUE)
+    ResponseEntity<ApiResponse<Void>> deletePersonalRetrospective(
+            @PathVariable Long meetingId,
+            @PathVariable Long retrospectiveId
     );
 }

--- a/src/main/java/com/dokdok/retrospective/controller/PersonalRetrospectiveController.java
+++ b/src/main/java/com/dokdok/retrospective/controller/PersonalRetrospectiveController.java
@@ -55,6 +55,7 @@ public class PersonalRetrospectiveController implements PersonalRetrospectiveApi
         return ApiResponse.success(response, "개인 회고 조회를 성공했습니다.");
     }
 
+    @Override
     @PutMapping("/{retrospectiveId}")
     public ResponseEntity<ApiResponse<PersonalRetrospectiveResponse>> editPersonalRetrospective(
             @PathVariable Long meetingId,
@@ -67,4 +68,15 @@ public class PersonalRetrospectiveController implements PersonalRetrospectiveApi
         return ApiResponse.success(response, "개인 회고 수정을 성공했습니다.");
     }
 
+    @Override
+    @DeleteMapping("/{retrospectiveId}")
+    public ResponseEntity<ApiResponse<Void>> deletePersonalRetrospective(
+            @PathVariable Long meetingId,
+            @PathVariable Long retrospectiveId
+    ) {
+
+        personalRetrospectiveService.deletePersonalRetrospective(meetingId, retrospectiveId);
+
+        return ApiResponse.deleted("개인 회고 삭제를 성공했습니다.");
+    }
 }

--- a/src/main/java/com/dokdok/retrospective/entity/PersonalMeetingRetrospective.java
+++ b/src/main/java/com/dokdok/retrospective/entity/PersonalMeetingRetrospective.java
@@ -2,6 +2,10 @@ package com.dokdok.retrospective.entity;
 
 import com.dokdok.global.BaseTimeEntity;
 import com.dokdok.meeting.entity.Meeting;
+import com.dokdok.retrospective.exception.RetrospectiveErrorCode;
+import com.dokdok.retrospective.exception.RetrospectiveException;
+import com.dokdok.topic.exception.TopicErrorCode;
+import com.dokdok.topic.exception.TopicException;
 import com.dokdok.user.entity.User;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -82,5 +86,17 @@ public class PersonalMeetingRetrospective extends BaseTimeEntity {
 
     public void clearFreeTexts() {
         this.freeTexts.clear();
+    }
+
+    public void softDelete() {
+        if (isDeleted()) {
+            throw new RetrospectiveException(RetrospectiveErrorCode.RETROSPECTIVE_ALREADY_DELETED);
+        }
+
+        markDeletedNow();
+
+        changedThoughts.forEach(RetrospectiveChangedThought::softDelete);
+        freeTexts.forEach(RetrospectiveFreeText::softDelete);
+        othersPerspectives.forEach(RetrospectiveOthersPerspective::softDelete);
     }
 }

--- a/src/main/java/com/dokdok/retrospective/entity/RetrospectiveChangedThought.java
+++ b/src/main/java/com/dokdok/retrospective/entity/RetrospectiveChangedThought.java
@@ -1,6 +1,8 @@
 package com.dokdok.retrospective.entity;
 
 import com.dokdok.global.BaseTimeEntity;
+import com.dokdok.retrospective.exception.RetrospectiveErrorCode;
+import com.dokdok.retrospective.exception.RetrospectiveException;
 import com.dokdok.topic.entity.Topic;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -60,13 +62,12 @@ public class RetrospectiveChangedThought extends BaseTimeEntity {
         this.personalMeetingRetrospective = personalMeetingRetrospective;
     }
 
-    // 비즈니스 메서드
-    public void updateContent(String keyIssue, String postOpinion) {
-        this.keyIssue = keyIssue;
-        this.postOpinion = postOpinion;
-    }
 
-    public void updateTopic(Topic topic) {
-        this.topic = topic;
+    public void softDelete() {
+        if (isDeleted()) {
+            throw new RetrospectiveException(RetrospectiveErrorCode.RETROSPECTIVE_ALREADY_DELETED);
+        }
+
+        markDeletedNow();
     }
 }

--- a/src/main/java/com/dokdok/retrospective/entity/RetrospectiveChangedThought.java
+++ b/src/main/java/com/dokdok/retrospective/entity/RetrospectiveChangedThought.java
@@ -62,12 +62,9 @@ public class RetrospectiveChangedThought extends BaseTimeEntity {
         this.personalMeetingRetrospective = personalMeetingRetrospective;
     }
 
-
     public void softDelete() {
-        if (isDeleted()) {
-            throw new RetrospectiveException(RetrospectiveErrorCode.RETROSPECTIVE_ALREADY_DELETED);
+        if (!isDeleted()) {
+            markDeletedNow();
         }
-
-        markDeletedNow();
     }
 }

--- a/src/main/java/com/dokdok/retrospective/entity/RetrospectiveFreeText.java
+++ b/src/main/java/com/dokdok/retrospective/entity/RetrospectiveFreeText.java
@@ -34,9 +34,6 @@ public class RetrospectiveFreeText extends BaseTimeEntity {
     @Column(name = "content", columnDefinition = "TEXT")
     private String content;
 
-    @Column(name = "deleted_at")
-    private LocalDateTime deletedAt;
-
     @Builder
     public static RetrospectiveFreeText of(
             PersonalMeetingRetrospective personalMeetingRetrospective,
@@ -55,9 +52,10 @@ public class RetrospectiveFreeText extends BaseTimeEntity {
         this.personalMeetingRetrospective = personalMeetingRetrospective;
     }
 
-    // 비즈니스 메서드
-    public void updateContent(String title, String content) {
-        this.title = title;
-        this.content = content;
+    public void softDelete() {
+        if (!isDeleted()) {
+            markDeletedNow();
+        }
     }
+
 }

--- a/src/main/java/com/dokdok/retrospective/entity/RetrospectiveOthersPerspective.java
+++ b/src/main/java/com/dokdok/retrospective/entity/RetrospectiveOthersPerspective.java
@@ -65,10 +65,9 @@ public class RetrospectiveOthersPerspective extends BaseTimeEntity {
         this.personalMeetingRetrospective = personalMeetingRetrospective;
     }
 
-    // 비즈니스 메서드
-    public void updateContent(String opinionContent, String impressiveReason) {
-        this.opinionContent = opinionContent;
-        this.impressiveReason = impressiveReason;
+    public void softDelete() {
+        if (!isDeleted()) {
+            markDeletedNow();
+        }
     }
-
 }

--- a/src/main/java/com/dokdok/retrospective/exception/RetrospectiveErrorCode.java
+++ b/src/main/java/com/dokdok/retrospective/exception/RetrospectiveErrorCode.java
@@ -11,7 +11,8 @@ public enum RetrospectiveErrorCode implements BaseErrorCode {
 
     RETROSPECTIVE_ALREADY_EXISTS("R101", "이미 해당 약속에 대한 회고가 존재합니다.", HttpStatus.CONFLICT),
     RETROSPECTIVE_NOT_FOUND("R102", "회고를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
-    MEETING_RETROSPECTIVE_NOT_FOUND("R103", "공동 회고 내용을 찾을 수 없습니다.", HttpStatus.NOT_FOUND);
+    MEETING_RETROSPECTIVE_NOT_FOUND("R103", "공동 회고 내용을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    RETROSPECTIVE_ALREADY_DELETED("R104", "이미 삭제된 개인 회고입니다.", HttpStatus.NOT_FOUND);
 
     private final String code;
     private final String message;

--- a/src/main/java/com/dokdok/retrospective/repository/PersonalRetrospectiveRepository.java
+++ b/src/main/java/com/dokdok/retrospective/repository/PersonalRetrospectiveRepository.java
@@ -7,8 +7,9 @@ import org.springframework.stereotype.Repository;
 import com.dokdok.retrospective.entity.PersonalMeetingRetrospective;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.List;
 import java.util.Optional;
+import java.util.List;
+
 
 @Repository
 public interface PersonalRetrospectiveRepository extends JpaRepository<PersonalMeetingRetrospective, Long> {

--- a/src/main/java/com/dokdok/retrospective/service/PersonalRetrospectiveService.java
+++ b/src/main/java/com/dokdok/retrospective/service/PersonalRetrospectiveService.java
@@ -198,6 +198,19 @@ public class PersonalRetrospectiveService {
                 .toList();
     }
 
+    @Transactional
+    public void deletePersonalRetrospective(Long meetingId, Long retrospectiveId) {
+        Long userId = SecurityUtil.getCurrentUserId();
+
+        meetingValidator.validateMeeting(meetingId);
+        meetingValidator.validateMeetingMember(meetingId, userId);
+
+        PersonalMeetingRetrospective retrospective
+                = retrospectiveValidator.getRetrospective(retrospectiveId, userId);
+
+        retrospective.softDelete();
+    }
+
     private void setRetrospectiveData(
             PersonalMeetingRetrospective retrospective,
             PersonalRetrospectiveRequest request,

--- a/src/test/java/com/dokdok/retrospective/service/PersonalRetrospectiveServiceTest.java
+++ b/src/test/java/com/dokdok/retrospective/service/PersonalRetrospectiveServiceTest.java
@@ -35,9 +35,6 @@ import com.dokdok.book.service.BookValidator;
 import com.dokdok.book.exception.BookException;
 import com.dokdok.book.exception.BookErrorCode;
 import com.dokdok.retrospective.dto.response.RetrospectiveRecordResponse;
-import com.dokdok.retrospective.dto.projection.ChangedThoughtProjection;
-import com.dokdok.retrospective.dto.projection.OtherPerspectiveProjection;
-import com.dokdok.retrospective.dto.projection.FreeTextProjection;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -1399,6 +1396,136 @@ class PersonalRetrospectiveServiceTest {
                     .hasFieldOrPropertyWithValue("errorCode", GlobalErrorCode.UNAUTHORIZED);
 
             verify(bookValidator, never()).validateBook(any());
+        }
+    }
+
+    // ==================== deletePersonalRetrospective 테스트 ====================
+
+    @Test
+    @DisplayName("개인 회고를 정상적으로 삭제한다")
+    void deletePersonalRetrospective_success() {
+        // given
+        Long meetingId = 1L;
+        Long retrospectiveId = 100L;
+        Long userId = 3L;
+
+        Meeting meeting = Meeting.builder().id(meetingId).build();
+        User user = User.builder().id(userId).build();
+
+        PersonalMeetingRetrospective retrospective = PersonalMeetingRetrospective.builder()
+                .id(retrospectiveId)
+                .meeting(meeting)
+                .user(user)
+                .build();
+
+        try (MockedStatic<SecurityUtil> securityUtilMock = mockStatic(SecurityUtil.class)) {
+            securityUtilMock.when(SecurityUtil::getCurrentUserId).thenReturn(userId);
+
+            doNothing().when(meetingValidator).validateMeeting(meetingId);
+            doNothing().when(meetingValidator).validateMeetingMember(meetingId, userId);
+            when(retrospectiveValidator.getRetrospective(retrospectiveId, userId)).thenReturn(retrospective);
+
+            // when
+            personalRetrospectiveService.deletePersonalRetrospective(meetingId, retrospectiveId);
+
+            // then
+            verify(meetingValidator).validateMeeting(meetingId);
+            verify(meetingValidator).validateMeetingMember(meetingId, userId);
+            verify(retrospectiveValidator).getRetrospective(retrospectiveId, userId);
+        }
+    }
+
+    @Test
+    @DisplayName("약속이 존재하지 않으면 예외가 발생한다 - 삭제")
+    void deletePersonalRetrospective_throwsWhenMeetingNotFound() {
+        // given
+        Long meetingId = 999L;
+        Long retrospectiveId = 100L;
+        Long userId = 3L;
+
+        try (MockedStatic<SecurityUtil> securityUtilMock = mockStatic(SecurityUtil.class)) {
+            securityUtilMock.when(SecurityUtil::getCurrentUserId).thenReturn(userId);
+
+            doThrow(new MeetingException(MeetingErrorCode.MEETING_NOT_FOUND))
+                    .when(meetingValidator).validateMeeting(meetingId);
+
+            // when & then
+            assertThatThrownBy(() ->
+                    personalRetrospectiveService.deletePersonalRetrospective(meetingId, retrospectiveId))
+                    .isInstanceOf(MeetingException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", MeetingErrorCode.MEETING_NOT_FOUND);
+
+            verify(retrospectiveValidator, never()).getRetrospective(any(), any());
+        }
+    }
+
+    @Test
+    @DisplayName("약속 멤버가 아니면 예외가 발생한다 - 삭제")
+    void deletePersonalRetrospective_throwsWhenNotMeetingMember() {
+        // given
+        Long meetingId = 1L;
+        Long retrospectiveId = 100L;
+        Long userId = 999L;
+
+        try (MockedStatic<SecurityUtil> securityUtilMock = mockStatic(SecurityUtil.class)) {
+            securityUtilMock.when(SecurityUtil::getCurrentUserId).thenReturn(userId);
+
+            doNothing().when(meetingValidator).validateMeeting(meetingId);
+            doThrow(new MeetingException(MeetingErrorCode.NOT_MEETING_MEMBER))
+                    .when(meetingValidator).validateMeetingMember(meetingId, userId);
+
+            // when & then
+            assertThatThrownBy(() ->
+                    personalRetrospectiveService.deletePersonalRetrospective(meetingId, retrospectiveId))
+                    .isInstanceOf(MeetingException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", MeetingErrorCode.NOT_MEETING_MEMBER);
+
+            verify(retrospectiveValidator, never()).getRetrospective(any(), any());
+        }
+    }
+
+    @Test
+    @DisplayName("개인 회고가 존재하지 않으면 예외가 발생한다 - 삭제")
+    void deletePersonalRetrospective_throwsWhenRetrospectiveNotFound() {
+        // given
+        Long meetingId = 1L;
+        Long retrospectiveId = 999L;
+        Long userId = 3L;
+
+        try (MockedStatic<SecurityUtil> securityUtilMock = mockStatic(SecurityUtil.class)) {
+            securityUtilMock.when(SecurityUtil::getCurrentUserId).thenReturn(userId);
+
+            doNothing().when(meetingValidator).validateMeeting(meetingId);
+            doNothing().when(meetingValidator).validateMeetingMember(meetingId, userId);
+            when(retrospectiveValidator.getRetrospective(retrospectiveId, userId))
+                    .thenThrow(new RetrospectiveException(RetrospectiveErrorCode.RETROSPECTIVE_NOT_FOUND));
+
+            // when & then
+            assertThatThrownBy(() ->
+                    personalRetrospectiveService.deletePersonalRetrospective(meetingId, retrospectiveId))
+                    .isInstanceOf(RetrospectiveException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", RetrospectiveErrorCode.RETROSPECTIVE_NOT_FOUND);
+        }
+    }
+
+    @Test
+    @DisplayName("인증 정보가 없으면 예외가 발생한다 - 삭제")
+    void deletePersonalRetrospective_throwsWhenUnauthenticated() {
+        // given
+        Long meetingId = 1L;
+        Long retrospectiveId = 100L;
+
+        try (MockedStatic<SecurityUtil> securityUtilMock = mockStatic(SecurityUtil.class)) {
+            securityUtilMock.when(SecurityUtil::getCurrentUserId)
+                    .thenThrow(new GlobalException(GlobalErrorCode.UNAUTHORIZED));
+
+            // when & then
+            assertThatThrownBy(() ->
+                    personalRetrospectiveService.deletePersonalRetrospective(meetingId, retrospectiveId))
+                    .isInstanceOf(GlobalException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", GlobalErrorCode.UNAUTHORIZED);
+
+            verify(meetingValidator, never()).validateMeeting(any());
         }
     }
 }


### PR DESCRIPTION
## PR 요약
> 이 PR이 어떤 변경을 하는지 간단히 설명하고, 체크 표시는 괄호 사이에 소문자 'x'를 삽입하세요.

- [x] 기능 추가
- [ ] 버그 수정
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 기타 (설명)

---

## 이슈 번호
- #172

---

## 주요 변경 사항
> 주요 파일, 로직, 컴포넌트 등을 구체적으로 적어주세요.

- `src/main/java/com/dokdok/retrospective`: +84/-22 (9 files) — Merge branch 'dev' of https://github.com/fc-de/dokdok-server into feature/delete-personal-retrospective 외 1건
- `src/test/java/com/dokdok/retrospective`: +130/-3 (1 files) — 요구사항 반영

---

## 참고 사항
> 리뷰어가 알아야 할 추가 정보, 테스트 방법 등을 작성해주세요.

예:
- 테스트 계정 정보
- 관련 API 엔드포인트
- 로컬 테스트 방법

---
