### PR TITLE
[#185][REFACTOR] 약속 참가 신청/취소 시 책장에 책 등록,취소 기능

### DIFF
--- a/src/main/java/com/dokdok/book/dto/request/BookCreateRequest.java
+++ b/src/main/java/com/dokdok/book/dto/request/BookCreateRequest.java
@@ -21,4 +21,14 @@ public record BookCreateRequest(
                 .thumbnail(thumbnail)
                 .build();
     }
+
+    public static BookCreateRequest from(Book book) {
+        return BookCreateRequest.builder()
+                .title(book.getBookName())
+                .authors(book.getAuthor())
+                .publisher(book.getPublisher())
+                .isbn(book.getIsbn())
+                .thumbnail(book.getThumbnail())
+                .build();
+    }
 }

--- a/src/main/java/com/dokdok/book/dto/response/PersonalBookListResponse.java
+++ b/src/main/java/com/dokdok/book/dto/response/PersonalBookListResponse.java
@@ -23,7 +23,7 @@ public record PersonalBookListResponse(
                 .authors(entity.getBook().getAuthor())
                 .bookReadingStatus(entity.getReadingStatus())
                 .thumbnail(entity.getBook().getThumbnail())
-                .gatheringName(null)
+                .gatheringName(entity.getGathering() != null ? entity.getGathering().getGatheringName() : null)
                 .build();
     }
 

--- a/src/main/java/com/dokdok/book/entity/PersonalBook.java
+++ b/src/main/java/com/dokdok/book/entity/PersonalBook.java
@@ -1,6 +1,7 @@
 package com.dokdok.book.entity;
 
 import com.dokdok.user.entity.User;
+import com.dokdok.gathering.entity.Gathering;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.SQLDelete;
@@ -35,6 +36,10 @@ public class PersonalBook {
     @JoinColumn(name = "book_id", nullable = false)
     private Book book;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "gathering_id")
+    private Gathering gathering;
+
     @Enumerated(EnumType.STRING)
     private BookReadingStatus readingStatus;
 
@@ -51,12 +56,17 @@ public class PersonalBook {
     private LocalDateTime deletedAt;
 
     public static PersonalBook create(User user, Book book, BookReadingStatus readingStatus) {
+        return create(user, book, readingStatus, null);
+    }
+
+    public static PersonalBook create(User user, Book book, BookReadingStatus readingStatus, Gathering gathering) {
         if (user == null || book == null) {
             throw new EntityNotFoundException("Entity를 찾을 수 없습니다.");
         }
         return PersonalBook.builder()
                 .user(user)
                 .book(book)
+                .gathering(gathering)
                 .readingStatus(readingStatus)
                 .addedAt(LocalDateTime.now())
                 .build();

--- a/src/main/java/com/dokdok/book/repository/PersonalBookRepository.java
+++ b/src/main/java/com/dokdok/book/repository/PersonalBookRepository.java
@@ -14,6 +14,7 @@ import java.util.Optional;
 @Repository
 public interface PersonalBookRepository extends JpaRepository<PersonalBook, Long> {
     Optional<PersonalBook> findByUserIdAndBookId(Long userId, Long bookId);
+    Optional<PersonalBook> findByUserIdAndBookIdAndGatheringId(Long userId, Long bookId, Long gatheringId);
     Page<PersonalBook> findByUserId(Long userId, Pageable pageable);
     Page<PersonalBook> findAllByUserIdAndReadingStatus(Long userId, BookReadingStatus bookReadingStatus, Pageable pageable);
     @Query("""

--- a/src/main/java/com/dokdok/book/service/BookValidator.java
+++ b/src/main/java/com/dokdok/book/service/BookValidator.java
@@ -55,6 +55,10 @@ public class BookValidator {
                 });
     }
 
+    public boolean isDuplicatePersonalBook(Long userId, Long bookId) {
+        return personalBookRepository.findByUserIdAndBookId(userId, bookId).isPresent();
+    }
+
     // 삭제되지 않은 책 리뷰 존재 여부를 검증하고 반환합니다.
     public BookReview validateAndGetActiveReview(Long bookId, Long userId) {
         return bookReviewRepository.findByBookIdAndUserId(bookId, userId)

--- a/src/main/java/com/dokdok/book/service/PersonalBookService.java
+++ b/src/main/java/com/dokdok/book/service/PersonalBookService.java
@@ -12,6 +12,7 @@ import com.dokdok.book.exception.BookException;
 import com.dokdok.book.repository.BookRepository;
 import com.dokdok.book.repository.PersonalBookListProjection;
 import com.dokdok.book.repository.PersonalBookRepository;
+import com.dokdok.gathering.entity.Gathering;
 import com.dokdok.global.util.SecurityUtil;
 import com.dokdok.user.entity.User;
 import com.dokdok.user.service.UserValidator;
@@ -34,6 +35,11 @@ public class PersonalBookService {
     // 생성
     @Transactional
     public PersonalBookCreateResponse createBook(BookCreateRequest bookCreateRequest) {
+        return createBook(bookCreateRequest, null);
+    }
+
+    @Transactional
+    public PersonalBookCreateResponse createBook(BookCreateRequest bookCreateRequest, Gathering gathering) {
         // 사용자 유효성 검증
         User userEntity = userValidator.findUserOrThrow(SecurityUtil.getCurrentUserId());
         // 책 유효성 검증 && 없으면 book entity에 저장
@@ -41,7 +47,12 @@ public class PersonalBookService {
                 .orElseGet(() -> bookRepository.save(bookCreateRequest.of()));
 
         bookValidator.validateDuplicatePersonalBook(userEntity.getId(), entity.getId());
-        PersonalBook personalBookEntity = PersonalBook.create(userEntity, entity, BookReadingStatus.READING);
+        PersonalBook personalBookEntity = PersonalBook.create(
+                userEntity,
+                entity,
+                BookReadingStatus.READING,
+                gathering
+        );
 
         personalBookRepository.save(personalBookEntity);
 
@@ -81,5 +92,21 @@ public class PersonalBookService {
         PersonalBook personalBook = bookValidator.validateInBookShelf(userEntity.getId(), bookId);
 
         personalBookRepository.delete(personalBook);
+    }
+
+    /**
+     * 약속 참가 취소시에 PersonalBook에 들어가 있는 책을 삭제한다.
+     * @param bookId 책 식별자
+     * @param gatheringId 모임 식별자
+     */
+    @Transactional
+    public void deleteBookForMeeting(Long bookId, Long gatheringId) {
+        if (gatheringId == null) {
+            return;
+        }
+        User userEntity = userValidator.findUserOrThrow(SecurityUtil.getCurrentUserId());
+        personalBookRepository
+                .findByUserIdAndBookIdAndGatheringId(userEntity.getId(), bookId, gatheringId)
+                .ifPresent(personalBookRepository::delete);
     }
 }

--- a/src/main/java/com/dokdok/meeting/service/MeetingService.java
+++ b/src/main/java/com/dokdok/meeting/service/MeetingService.java
@@ -1,9 +1,13 @@
 package com.dokdok.meeting.service;
 
+import com.dokdok.book.dto.request.BookCreateRequest;
 import com.dokdok.book.entity.Book;
 import com.dokdok.book.exception.BookErrorCode;
 import com.dokdok.book.exception.BookException;
 import com.dokdok.book.repository.BookRepository;
+import com.dokdok.book.service.BookService;
+import com.dokdok.book.service.BookValidator;
+import com.dokdok.book.service.PersonalBookService;
 import com.dokdok.gathering.entity.Gathering;
 import com.dokdok.gathering.exception.GatheringErrorCode;
 import com.dokdok.gathering.exception.GatheringException;
@@ -31,13 +35,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -54,7 +53,9 @@ public class MeetingService {
     private final GatheringValidator gatheringValidator;
     private final MeetingValidator meetingValidator;
     private final BookRepository bookRepository;
+    private final BookValidator bookValidator;
     private final UserValidator userValidator;
+    private final PersonalBookService personalBookService;
 
     /**
      * 특정 약속의 정보를 확인할 수 있다. 모임에 속한 사용자만 조회 가능
@@ -221,6 +222,7 @@ public class MeetingService {
         gatheringValidator.validateMembership(meeting.getGathering().getId(), userId);
 
         if (restoreCanceledMemberIfExists(meetingId, userId, meeting.getMaxParticipants())) {
+            saveMeetingBook(meeting, meeting.getGathering());
             return meetingId;
         }
 
@@ -229,8 +231,26 @@ public class MeetingService {
         User user = userValidator.findUserOrThrow(userId);
 
         saveMeetingMember(meeting, user);
+        saveMeetingBook(meeting, meeting.getGathering());
 
         return meetingId;
+    }
+
+    /**
+     * 약속 참가 신청 성공 시 책장에 등록한다.
+     */
+    private void saveMeetingBook(Meeting meeting, Gathering gathering) {
+        Book book = meeting.getBook();
+        if (book == null) {
+            throw new BookException(BookErrorCode.BOOK_NOT_FOUND);
+        }
+
+        Long userId = SecurityUtil.getCurrentUserId();
+        if (bookValidator.isDuplicatePersonalBook(userId, book.getId())) {
+            return;
+        }
+        personalBookService.createBook(BookCreateRequest.from(book), gathering);
+
     }
 
     /**
@@ -291,6 +311,8 @@ public class MeetingService {
         meetingMember.cancel();
         // 참가 취소자가 주제까지 제안한 경우 주제 soft delete
         topicRepository.softDeleteByMeetingIdAndProposedById(meetingId, userId);
+        // 개인 책장에서도 책 삭제
+        personalBookService.deleteBookForMeeting(meeting.getBook().getId(), meeting.getGathering().getId());
 
         return meetingId;
     }

--- a/src/test/java/com/dokdok/meeting/service/MeetingServiceTest.java
+++ b/src/test/java/com/dokdok/meeting/service/MeetingServiceTest.java
@@ -4,6 +4,8 @@ import com.dokdok.book.entity.Book;
 import com.dokdok.book.exception.BookErrorCode;
 import com.dokdok.book.exception.BookException;
 import com.dokdok.book.repository.BookRepository;
+import com.dokdok.book.service.BookValidator;
+import com.dokdok.book.service.PersonalBookService;
 import com.dokdok.gathering.entity.Gathering;
 import com.dokdok.gathering.exception.GatheringErrorCode;
 import com.dokdok.gathering.exception.GatheringException;
@@ -82,7 +84,13 @@ class MeetingServiceTest {
     private BookRepository bookRepository;
 
     @Mock
+    private BookValidator bookValidator;
+
+    @Mock
     private UserValidator userValidator;
+
+    @Mock
+    private PersonalBookService personalBookService;
 
     private Meeting meeting;
     private Long meetingId;
@@ -108,6 +116,17 @@ class MeetingServiceTest {
                 .meetingStatus(MeetingStatus.PENDING)
                 .meetingLeader(leader)
                 .gathering(gathering)
+                .build();
+    }
+
+    private Book sampleBook() {
+        return Book.builder()
+                .id(50L)
+                .bookName("Sample Book")
+                .author("Author")
+                .publisher("Publisher")
+                .isbn("ISBN-0000")
+                .thumbnail("thumbnail")
                 .build();
     }
 
@@ -507,6 +526,7 @@ class MeetingServiceTest {
                         .gatheringName("gathering")
                         .invitationLink("link")
                         .build())
+                .book(sampleBook())
                 .build();
         User user = User.builder()
                 .id(userId)
@@ -547,6 +567,7 @@ class MeetingServiceTest {
                         .gatheringName("gathering")
                         .invitationLink("link")
                         .build())
+                .book(sampleBook())
                 .build();
 
         given(meetingValidator.findMeetingOrThrow(meetingId))
@@ -587,6 +608,7 @@ class MeetingServiceTest {
                         .gatheringName("gathering")
                         .invitationLink("link")
                         .build())
+                .book(sampleBook())
                 .build();
         MeetingMember canceledMember = MeetingMember.builder()
                 .meeting(meeting)
@@ -627,6 +649,7 @@ class MeetingServiceTest {
                         .gatheringName("gathering")
                         .invitationLink("link")
                         .build())
+                .book(sampleBook())
                 .build();
 
         given(meetingValidator.findMeetingOrThrow(meetingId))
@@ -659,6 +682,7 @@ class MeetingServiceTest {
                         .gatheringName("gathering")
                         .invitationLink("link")
                         .build())
+                .book(sampleBook())
                 .build();
 
         given(meetingValidator.findMeetingOrThrow(meetingId))
@@ -687,6 +711,8 @@ class MeetingServiceTest {
         Meeting meeting = Meeting.builder()
                 .id(meetingId)
                 .meetingStartDate(LocalDateTime.now().plusDays(2))
+                .book(sampleBook())
+                .gathering(gathering)
                 .build();
         MeetingMember meetingMember = MeetingMember.builder()
                 .meeting(meeting)
@@ -719,6 +745,8 @@ class MeetingServiceTest {
         Meeting meeting = Meeting.builder()
                 .id(meetingId)
                 .meetingStartDate(LocalDateTime.now().plusDays(2))
+                .book(sampleBook())
+                .gathering(gathering)
                 .build();
 
         given(meetingValidator.findMeetingOrThrow(meetingId)).willReturn(meeting);
@@ -745,6 +773,8 @@ class MeetingServiceTest {
         Meeting meeting = Meeting.builder()
                 .id(meetingId)
                 .meetingStartDate(LocalDateTime.now().plusHours(1))
+                .book(sampleBook())
+                .gathering(gathering)
                 .build();
 
         given(meetingValidator.findMeetingOrThrow(meetingId)).willReturn(meeting);
@@ -769,6 +799,8 @@ class MeetingServiceTest {
         Meeting meeting = Meeting.builder()
                 .id(meetingId)
                 .meetingStartDate(LocalDateTime.now().plusDays(2))
+                .book(sampleBook())
+                .gathering(gathering)
                 .build();
         MeetingMember meetingMember = MeetingMember.builder()
                 .meeting(meeting)


### PR DESCRIPTION
## PR 요약
> 이 PR이 어떤 변경을 하는지 간단히 설명하고, 체크 표시는 괄호 사이에 소문자 'x'를 삽입하세요.

- [ ] 기능 추가
- [ ] 버그 수정
- [x] 코드 리팩토링
- [ ] 문서 수정
- [ ] 기타 (설명)

---

## 이슈 번호
- #185

---

## 주요 변경 사항
> 주요 파일, 로직, 컴포넌트 등을 구체적으로 적어주세요.

  - src/main/java/com/dokdok/book: PersonalBook에 Gathering 연관관계 추가, PersonalBookService에 모임 기반 삭제 API 추가, BookValidator에 중복 여부 확인 메서드 추가,
    PersonalBookListResponse가 gatheringName 반영
  - src/main/java/com/dokdok/meeting: join/cancel 시 personalBook 등록/삭제 로직 보완(중복 선체크, 취소 시 모임 기반 삭제)
  - src/test/java/com/dokdok/meeting: MeetingServiceTest에 book/gathering 세팅 추가로 변경 로직 반영 및 NPE 방지

---

## 참고 사항
> 리뷰어가 알아야 할 추가 정보, 테스트 방법 등을 작성해주세요.

예:
- 테스트 계정 정보
- 관련 API 엔드포인트
- 로컬 테스트 방법

---
