### PR TITLE
[#148][FEAT] 사전 의견 조회 API 구현

### DIFF
--- a/src/main/java/com/dokdok/book/entity/KeywordType.java
+++ b/src/main/java/com/dokdok/book/entity/KeywordType.java
@@ -1,0 +1,6 @@
+package com.dokdok.book.entity;
+
+public enum KeywordType {
+    BOOK,
+    IMPRESSION
+}

--- a/src/main/java/com/dokdok/book/exception/BookErrorCode.java
+++ b/src/main/java/com/dokdok/book/exception/BookErrorCode.java
@@ -17,7 +17,8 @@ public enum BookErrorCode implements BaseErrorCode {
     KEYWORD_NOT_FOUND("B006", "키워드를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
     KEYWORD_NOT_SELECTABLE("B007", "선택할 수 없는 키워드입니다.", HttpStatus.BAD_REQUEST),
     BOOK_REVIEW_INVALID_RATING("B008", "별점은 0.5 단위의 5점 만점 값이어야 합니다.", HttpStatus.BAD_REQUEST),
-    BOOK_REVIEW_DELETED("B009", "삭제된 책 리뷰입니다.", HttpStatus.BAD_REQUEST);
+    BOOK_REVIEW_DELETED("B009", "삭제된 책 리뷰입니다.", HttpStatus.BAD_REQUEST),
+    BOOK_REVIEW_ACCESS_DENIED_NOT_WRITTEN("B010", "평가를 작성한 사용자만 조회할 수 있습니다.", HttpStatus.FORBIDDEN);
 
     private final String code;
     private final String message;

--- a/src/main/java/com/dokdok/book/repository/BookReviewKeywordRepository.java
+++ b/src/main/java/com/dokdok/book/repository/BookReviewKeywordRepository.java
@@ -14,7 +14,7 @@ public interface BookReviewKeywordRepository extends JpaRepository<BookReviewKey
                 SELECT brk
                 FROM BookReviewKeyword brk
                 JOIN FETCH brk.keyword k
-                WHERE brk.bookReview IN :bookReviewIds
+                WHERE brk.bookReview.id IN :bookReviewIds
             """)
     List<BookReviewKeyword> findByBookReviewIds(List<Long> bookReviewIds);
 }

--- a/src/main/java/com/dokdok/book/repository/BookReviewKeywordRepository.java
+++ b/src/main/java/com/dokdok/book/repository/BookReviewKeywordRepository.java
@@ -1,0 +1,20 @@
+package com.dokdok.book.repository;
+
+import com.dokdok.book.entity.BookReviewKeyword;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface BookReviewKeywordRepository extends JpaRepository<BookReviewKeyword, Long> {
+
+    @Query("""
+                SELECT brk
+                FROM BookReviewKeyword brk
+                JOIN FETCH brk.keyword k
+                WHERE brk.bookReview IN :bookReviewIds
+            """)
+    List<BookReviewKeyword> findByBookReviewIds(List<Long> bookReviewIds);
+}

--- a/src/main/java/com/dokdok/book/repository/BookReviewRepository.java
+++ b/src/main/java/com/dokdok/book/repository/BookReviewRepository.java
@@ -2,11 +2,18 @@ package com.dokdok.book.repository;
 
 import com.dokdok.book.entity.BookReview;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface BookReviewRepository extends JpaRepository<BookReview, Long> {
     Optional<BookReview> findByBookIdAndUserId(Long bookId, Long userId);
 
     boolean existsByBookIdAndUserId(Long bookId, Long userId);
+
+    List<BookReview> findByMeetingId(Long meetingId);
+
+    boolean existsByMeetingIdAndUserId(Long userId);
+
 }

--- a/src/main/java/com/dokdok/book/repository/BookReviewRepository.java
+++ b/src/main/java/com/dokdok/book/repository/BookReviewRepository.java
@@ -12,6 +12,28 @@ public interface BookReviewRepository extends JpaRepository<BookReview, Long> {
 
     boolean existsByBookIdAndUserId(Long bookId, Long userId);
 
-    List<BookReview> findByMeetingId(Long meetingId);
+    @Query("""
+            SELECT br
+            FROM BookReview br
+            WHERE br.user.id = :userId
+            AND br.createdAt = (
+                    SELECT MAX(br2.createdAt)
+                    FROM BookReview br2
+                    WHERE br2.user.id = br.user.id
+                )
+            """)
+    List<BookReview> findByUserId(Long userId);
+
+    @Query("""
+            SELECT br
+            FROM BookReview br
+            WHERE br.user.id IN :userIds
+            AND br.createdAt = (
+                    SELECT MAX(br2.createdAt)
+                    FROM BookReview br2
+                    WHERE br2.user.id = br.user.id
+                )
+            """)
+    List<BookReview> findByUserIdIn(List<Long> userIds);
 
 }

--- a/src/main/java/com/dokdok/book/service/BookValidator.java
+++ b/src/main/java/com/dokdok/book/service/BookValidator.java
@@ -12,6 +12,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 import java.math.BigDecimal;
+import java.util.List;
 
 @Component
 @RequiredArgsConstructor
@@ -80,6 +81,15 @@ public class BookValidator {
         BigDecimal scaled = rating.multiply(BigDecimal.TEN);
         if (scaled.remainder(new BigDecimal("5")).compareTo(BigDecimal.ZERO) != 0) {
             throw new BookException(BookErrorCode.BOOK_REVIEW_INVALID_RATING);
+        }
+    }
+
+    public void validateUserHasWrittenBookReview(Long meetingId, Long userId) {
+
+        boolean exists = bookReviewRepository.existsByMeetingIdAndUserId(meetingId, userId);
+
+        if(!exists) {
+            throw new BookException(BookErrorCode.BOOK_REVIEW_ACCESS_DENIED_NOT_WRITTEN);
         }
     }
 }

--- a/src/main/java/com/dokdok/keyword/entity/Keyword.java
+++ b/src/main/java/com/dokdok/keyword/entity/Keyword.java
@@ -1,5 +1,6 @@
 package com.dokdok.keyword.entity;
 
+import com.dokdok.book.entity.KeywordType;
 import com.dokdok.global.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.*;
@@ -23,7 +24,7 @@ public class Keyword extends BaseTimeEntity {
     private Long id;
 
     @Column(name = "keyword_type", nullable = false, length = 30)
-    private String keywordType;
+    private KeywordType keywordType;
 
     @Column(name = "keyword_name", nullable = false, length = 50)
     private String keywordName;

--- a/src/main/java/com/dokdok/keyword/entity/Keyword.java
+++ b/src/main/java/com/dokdok/keyword/entity/Keyword.java
@@ -23,6 +23,7 @@ public class Keyword extends BaseTimeEntity {
     @Column(name = "keyword_id")
     private Long id;
 
+    @Enumerated(EnumType.STRING)
     @Column(name = "keyword_type", nullable = false, length = 30)
     private KeywordType keywordType;
 

--- a/src/main/java/com/dokdok/retrospective/controller/PersonalRetrospectiveController.java
+++ b/src/main/java/com/dokdok/retrospective/controller/PersonalRetrospectiveController.java
@@ -39,7 +39,7 @@ public class PersonalRetrospectiveController implements PersonalRetrospectiveApi
         PersonalRetrospectiveFormResponse response
                 = personalRetrospectiveService.getPersonalRetrospectiveForm(meetingId);
 
-        return ApiResponse.success(response, "개인 회고 입력 폼 조회 성공했습니다.");
+        return ApiResponse.success(response, "개인 회고 입력 폼 조회를 성공했습니다.");
     }
 
 
@@ -52,7 +52,7 @@ public class PersonalRetrospectiveController implements PersonalRetrospectiveApi
         PersonalRetrospectiveDetailResponse response
                 = personalRetrospectiveService.getPersonalRetrospectiveEditForm(meetingId, retrospectiveId);
 
-        return ApiResponse.success(response, "개인 회고 조회를 성공했습니다.");
+        return ApiResponse.success(response, "개인 회고 수정 폼 조회를 성공했습니다.");
     }
 
     @Override

--- a/src/main/java/com/dokdok/retrospective/dto/response/MemberInfo.java
+++ b/src/main/java/com/dokdok/retrospective/dto/response/MemberInfo.java
@@ -3,13 +3,13 @@ package com.dokdok.retrospective.dto.response;
 public record MemberInfo(
         Long meetingMemberId,
         String nickname,
-        String profileImageUrl
+        String profileImage
 ) {
-    public static MemberInfo of(Long meetingMemberId, String nickname, String profileImageUrl) {
+    public static MemberInfo of(Long meetingMemberId, String nickname, String profileImage) {
         return new MemberInfo(
                 meetingMemberId,
                 nickname,
-                profileImageUrl
+                profileImage
         );
     }
 }

--- a/src/main/java/com/dokdok/retrospective/service/PersonalRetrospectiveService.java
+++ b/src/main/java/com/dokdok/retrospective/service/PersonalRetrospectiveService.java
@@ -262,42 +262,6 @@ public class PersonalRetrospectiveService {
         );
     }
 
-    @Transactional(readOnly = true)
-    public PersonalRetrospectiveDetailResponse getPersonalRetrospective(
-            Long meetingId,
-            Long retrospectiveId
-    ) {
-
-        Long userId = SecurityUtil.getCurrentUserId();
-
-        meetingValidator.validateMeeting(meetingId);
-        meetingValidator.validateMeetingMember(meetingId, userId);
-        retrospectiveValidator.validateRetrospective(retrospectiveId);
-
-        List<RetrospectiveChangedThought> changedThoughts
-                = changedThoughtRepository.findByPersonalMeetingRetrospective(retrospectiveId);
-
-        List<RetrospectiveOthersPerspective> othersPerspectives
-                = othersPerspectiveRepository.findByPersonalMeetingRetrospective(retrospectiveId);
-
-        List<RetrospectiveFreeText> freeTexts =
-                freeTextRepository.findByPersonalMeetingRetrospective_Id(retrospectiveId);
-
-        List<Topic> topics = topicValidator.getConfirmedTopics(meetingId);
-
-        List<MeetingMember> meetingMembers
-                = meetingMemberRepository.findOtherMembersByMeetingId(meetingId, userId);
-
-        return assembler.assembleDetail(
-                retrospectiveId,
-                changedThoughts,
-                othersPerspectives,
-                freeTexts,
-                topics,
-                meetingMembers
-        );
-    }
-
     private void setRetrospectiveData(
             PersonalMeetingRetrospective retrospective,
             PersonalRetrospectiveRequest request,

--- a/src/main/java/com/dokdok/retrospective/service/PersonalRetrospectiveService.java
+++ b/src/main/java/com/dokdok/retrospective/service/PersonalRetrospectiveService.java
@@ -218,6 +218,42 @@ public class PersonalRetrospectiveService {
         retrospective.softDelete();
     }
 
+    @Transactional(readOnly = true)
+    public PersonalRetrospectiveDetailResponse getPersonalRetrospective(
+            Long meetingId,
+            Long retrospectiveId
+    ) {
+
+        Long userId = SecurityUtil.getCurrentUserId();
+
+        meetingValidator.validateMeeting(meetingId);
+        meetingValidator.validateMeetingMember(meetingId, userId);
+        retrospectiveValidator.validateRetrospective(retrospectiveId);
+
+        List<RetrospectiveChangedThought> changedThoughts
+                = changedThoughtRepository.findByPersonalMeetingRetrospective(retrospectiveId);
+
+        List<RetrospectiveOthersPerspective> othersPerspectives
+                = othersPerspectiveRepository.findByPersonalMeetingRetrospective(retrospectiveId);
+
+        List<RetrospectiveFreeText> freeTexts =
+                freeTextRepository.findByPersonalMeetingRetrospective_Id(retrospectiveId);
+
+        List<Topic> topics = topicValidator.getConfirmedTopics(meetingId);
+
+        List<MeetingMember> meetingMembers
+                = meetingMemberRepository.findOtherMembersByMeetingId(meetingId, userId);
+
+        return assembler.assembleDetail(
+                retrospectiveId,
+                changedThoughts,
+                othersPerspectives,
+                freeTexts,
+                topics,
+                meetingMembers
+        );
+    }
+
     private void setRetrospectiveData(
             PersonalMeetingRetrospective retrospective,
             PersonalRetrospectiveRequest request,

--- a/src/main/java/com/dokdok/topic/api/PreOpinionApi.java
+++ b/src/main/java/com/dokdok/topic/api/PreOpinionApi.java
@@ -5,7 +5,6 @@ import com.dokdok.topic.dto.response.PreOpinionResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
-import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -15,8 +14,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
-
-import java.util.List;
 
 @Tag(name = "사전 의견", description = "약속의 사전 의견 관련 API")
 @RequestMapping("/api/gatherings/{gatheringId}/meetings/{meetingId}/answers")
@@ -35,7 +32,7 @@ public interface PreOpinionApi {
                     responseCode = "200",
                     description = "사전 의견 목록 조회 성공",
                     content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
-                            array = @ArraySchema(schema = @Schema(implementation = PreOpinionResponse.class)))
+                            schema = @Schema(implementation = PreOpinionResponse.class))
             ),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "본인이 독서 리뷰를 작성하지 않은 경우"),
@@ -43,7 +40,7 @@ public interface PreOpinionApi {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 오류")
     })
     @GetMapping(produces = MediaType.APPLICATION_JSON_VALUE)
-    ResponseEntity<ApiResponse<List<PreOpinionResponse>>> findAnswers(
+    ResponseEntity<ApiResponse<PreOpinionResponse>> findAnswers(
             @PathVariable("gatheringId") Long gatheringId,
             @PathVariable("meetingId") Long meetingId
     );

--- a/src/main/java/com/dokdok/topic/api/PreOpinionApi.java
+++ b/src/main/java/com/dokdok/topic/api/PreOpinionApi.java
@@ -1,0 +1,50 @@
+package com.dokdok.topic.api;
+
+import com.dokdok.global.response.ApiResponse;
+import com.dokdok.topic.dto.response.PreOpinionResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import java.util.List;
+
+@Tag(name = "사전 의견", description = "약속의 사전 의견 관련 API")
+@RequestMapping("/api/gatherings/{gatheringId}/meetings/{meetingId}/answers")
+public interface PreOpinionApi {
+
+    @Operation(
+            summary = "사전 의견 목록 조회",
+            description = "약속에 참여한 멤버들의 사전 의견(독서 리뷰, 토픽 답변)을 조회합니다.",
+            parameters = {
+                    @Parameter(name = "gatheringId", description = "모임 식별자", in = ParameterIn.PATH, required = true),
+                    @Parameter(name = "meetingId", description = "약속 식별자", in = ParameterIn.PATH, required = true)
+            }
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "사전 의견 목록 조회 성공",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            array = @ArraySchema(schema = @Schema(implementation = PreOpinionResponse.class)))
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "본인이 독서 리뷰를 작성하지 않은 경우"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "모임 또는 약속을 찾을 수 없음"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 오류")
+    })
+    @GetMapping(produces = MediaType.APPLICATION_JSON_VALUE)
+    ResponseEntity<ApiResponse<List<PreOpinionResponse>>> findAnswers(
+            @PathVariable("gatheringId") Long gatheringId,
+            @PathVariable("meetingId") Long meetingId
+    );
+}

--- a/src/main/java/com/dokdok/topic/api/PreOpinionApi.java
+++ b/src/main/java/com/dokdok/topic/api/PreOpinionApi.java
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -21,7 +22,11 @@ public interface PreOpinionApi {
 
     @Operation(
             summary = "사전 의견 목록 조회",
-            description = "약속에 참여한 멤버들의 사전 의견(독서 리뷰, 토픽 답변)을 조회합니다.",
+            description = """
+                    약속에 참여한 멤버들의 사전 의견(독서 리뷰, 토픽 답변)을 조회합니다.
+                    - 본인이 사전 의견을 작성한 경우에만 조회 가능합니다.
+                    - 각 멤버의 독서 평가 및 토픽 답변을 포함합니다.
+                    """,
             parameters = {
                     @Parameter(name = "gatheringId", description = "모임 식별자", in = ParameterIn.PATH, required = true),
                     @Parameter(name = "meetingId", description = "약속 식별자", in = ParameterIn.PATH, required = true)
@@ -34,10 +39,79 @@ public interface PreOpinionApi {
                     content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
                             schema = @Schema(implementation = PreOpinionResponse.class))
             ),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "본인이 독서 리뷰를 작성하지 않은 경우"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "모임 또는 약속을 찾을 수 없음"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 오류")
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "400",
+                    description = "잘못된 요청",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(
+                                    value = "{\"code\":\"G002\",\"message\":\"입력값이 올바르지 않습니다.\"}"
+                            )
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "401",
+                    description = "인증되지 않은 사용자",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(
+                                    value = "{\"code\":\"G102\",\"message\":\"인증이 필요합니다.\"}"
+                            )
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "403",
+                    description = "접근 권한 없음",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            examples = {
+                                    @ExampleObject(
+                                            name = "약속 멤버 아님",
+                                            description = "약속의 멤버가 아닌 경우",
+                                            value = "{\"code\":\"M004\",\"message\":\"약속의 멤버가 아닙니다.\"}"
+                                    ),
+                                    @ExampleObject(
+                                            name = "사전 의견 미작성",
+                                            description = "본인이 사전 의견을 작성하지 않은 경우",
+                                            value = "{\"code\":\"B010\",\"message\":\"평가를 작성한 사용자만 조회할 수 있습니다.\"}"
+                                    )
+                            }
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "모임 또는 약속을 찾을 수 없음",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            examples = {
+                                    @ExampleObject(
+                                            name = "모임 없음",
+                                            description = "모임을 찾을 수 없는 경우",
+                                            value = "{\"code\":\"G001\",\"message\":\"모임을 찾을 수 없습니다.\"}"
+                                    ),
+                                    @ExampleObject(
+                                            name = "약속 없음",
+                                            description = "약속을 찾을 수 없는 경우",
+                                            value = "{\"code\":\"M001\",\"message\":\"약속을 찾을 수 없습니다.\"}"
+                                    ),
+                                    @ExampleObject(
+                                            name = "약속이 모임에 속하지 않음",
+                                            description = "약속이 해당 모임에 속하지 않는 경우",
+                                            value = "{\"code\":\"M003\",\"message\":\"해당 약속은 해당 모임에 속해있지 않습니다.\"}"
+                                    )
+                            }
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "500",
+                    description = "서버 오류",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(
+                                    value = "{\"code\":\"G001\",\"message\":\"서버 내부 오류가 발생했습니다.\"}"
+                            )
+                    )
+            )
     })
     @GetMapping(produces = MediaType.APPLICATION_JSON_VALUE)
     ResponseEntity<ApiResponse<PreOpinionResponse>> findAnswers(

--- a/src/main/java/com/dokdok/topic/api/TopicAnswerApi.java
+++ b/src/main/java/com/dokdok/topic/api/TopicAnswerApi.java
@@ -24,16 +24,16 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 @Tag(name = "토픽 답변", description = "토픽 답변 관련 API")
-@RequestMapping("/api/gatherings/{gathering_id}/meetings/{meeting_id}/topics/{topic_id}/answers")
+@RequestMapping("/api/gatherings/{gatheringId}/meetings/{meetingId}/topics/{topicId}/answers")
 public interface TopicAnswerApi {
 
     @Operation(
             summary = "토픽 답변 저장",
             description = "토픽 답변을 저장합니다.",
             parameters = {
-                    @Parameter(name = "gathering_id", description = "모임 식별자", in = ParameterIn.PATH, required = true),
-                    @Parameter(name = "meeting_id", description = "약속 식별자", in = ParameterIn.PATH, required = true),
-                    @Parameter(name = "topic_id", description = "토픽 식별자", in = ParameterIn.PATH, required = true)
+                    @Parameter(name = "gatheringId", description = "모임 식별자", in = ParameterIn.PATH, required = true),
+                    @Parameter(name = "meetingId", description = "약속 식별자", in = ParameterIn.PATH, required = true),
+                    @Parameter(name = "topicId", description = "토픽 식별자", in = ParameterIn.PATH, required = true)
             }
     )
     @ApiResponses({
@@ -49,9 +49,9 @@ public interface TopicAnswerApi {
     })
     @PostMapping(consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     ResponseEntity<ApiResponse<TopicAnswerResponse>> createAnswer(
-            @PathVariable("gathering_id") Long gatheringId,
-            @PathVariable("meeting_id") Long meetingId,
-            @PathVariable("topic_id") Long topicId,
+            @PathVariable("gatheringId") Long gatheringId,
+            @PathVariable("meetingId") Long meetingId,
+            @PathVariable("topicId") Long topicId,
             @Valid @RequestBody TopicAnswerRequest request
     );
 
@@ -102,9 +102,9 @@ public interface TopicAnswerApi {
     })
     @PatchMapping(value = "/me", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     ResponseEntity<ApiResponse<TopicAnswerResponse>> updateMyAnswer(
-            @PathVariable("gathering_id") Long gatheringId,
-            @PathVariable("meeting_id") Long meetingId,
-            @PathVariable("topic_id") Long topicId,
+            @PathVariable("gatheringId") Long gatheringId,
+            @PathVariable("meetingId") Long meetingId,
+            @PathVariable("topicId") Long topicId,
             @Valid @RequestBody TopicAnswerRequest request
     );
 
@@ -112,9 +112,9 @@ public interface TopicAnswerApi {
             summary = "내 토픽 답변 제출",
             description = "현재 로그인 사용자의 토픽 답변을 제출합니다.",
             parameters = {
-                    @Parameter(name = "gathering_id", description = "모임 식별자", in = ParameterIn.PATH, required = true),
-                    @Parameter(name = "meeting_id", description = "약속 식별자", in = ParameterIn.PATH, required = true),
-                    @Parameter(name = "topic_id", description = "토픽 식별자", in = ParameterIn.PATH, required = true)
+                    @Parameter(name = "gatheringId", description = "모임 식별자", in = ParameterIn.PATH, required = true),
+                    @Parameter(name = "meetingId", description = "약속 식별자", in = ParameterIn.PATH, required = true),
+                    @Parameter(name = "topicId", description = "토픽 식별자", in = ParameterIn.PATH, required = true)
             }
     )
     @ApiResponses({
@@ -130,18 +130,18 @@ public interface TopicAnswerApi {
     })
     @PatchMapping(value = "/submit", produces = MediaType.APPLICATION_JSON_VALUE)
     ResponseEntity<ApiResponse<TopicAnswerSubmitResponse>> submitMyAnswer(
-            @PathVariable("gathering_id") Long gatheringId,
-            @PathVariable("meeting_id") Long meetingId,
-            @PathVariable("topic_id") Long topicId
+            @PathVariable("gatheringId") Long gatheringId,
+            @PathVariable("meetingId") Long meetingId,
+            @PathVariable("topicId") Long topicId
     );
 
     @Operation(
             summary = "내 토픽 답변 삭제",
             description = "현재 로그인 사용자의 토픽 답변을 삭제합니다.",
             parameters = {
-                    @Parameter(name = "gathering_id", description = "모임 식별자", in = ParameterIn.PATH, required = true),
-                    @Parameter(name = "meeting_id", description = "약속 식별자", in = ParameterIn.PATH, required = true),
-                    @Parameter(name = "topic_id", description = "토픽 식별자", in = ParameterIn.PATH, required = true)
+                    @Parameter(name = "gatheringId", description = "모임 식별자", in = ParameterIn.PATH, required = true),
+                    @Parameter(name = "meetingId", description = "약속 식별자", in = ParameterIn.PATH, required = true),
+                    @Parameter(name = "topicId", description = "토픽 식별자", in = ParameterIn.PATH, required = true)
             }
     )
     @ApiResponses({
@@ -154,8 +154,8 @@ public interface TopicAnswerApi {
     })
     @DeleteMapping(value = "/me", produces = MediaType.APPLICATION_JSON_VALUE)
     ResponseEntity<ApiResponse<Void>> deleteMyAnswer(
-            @PathVariable("gathering_id") Long gatheringId,
-            @PathVariable("meeting_id") Long meetingId,
-            @PathVariable("topic_id") Long topicId
+            @PathVariable("gatheringId") Long gatheringId,
+            @PathVariable("meetingId") Long meetingId,
+            @PathVariable("topicId") Long topicId
     );
 }

--- a/src/main/java/com/dokdok/topic/controller/PreOpinionController.java
+++ b/src/main/java/com/dokdok/topic/controller/PreOpinionController.java
@@ -12,8 +12,6 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.util.List;
-
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/gatherings/{gatheringId}/meetings/{meetingId}/answers")
@@ -23,13 +21,11 @@ public class PreOpinionController implements PreOpinionApi {
 
     @Override
     @GetMapping(produces = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity<ApiResponse<List<PreOpinionResponse>>> findAnswers(
+    public ResponseEntity<ApiResponse<PreOpinionResponse>> findAnswers(
             @PathVariable("gatheringId") Long gatheringId,
             @PathVariable("meetingId") Long meetingId
     ) {
-
-        List<PreOpinionResponse> responses = preOpinionService.findPreOpinions(gatheringId, meetingId);
-
-        return ApiResponse.success(responses, "약속의 사전 의견 목록 조회를 성공했습니다.");
+        PreOpinionResponse response = preOpinionService.findPreOpinions(gatheringId, meetingId);
+        return ApiResponse.success(response, "약속의 사전 의견 목록 조회를 성공했습니다.");
     }
 }

--- a/src/main/java/com/dokdok/topic/controller/PreOpinionController.java
+++ b/src/main/java/com/dokdok/topic/controller/PreOpinionController.java
@@ -1,0 +1,35 @@
+package com.dokdok.topic.controller;
+
+import com.dokdok.global.response.ApiResponse;
+import com.dokdok.topic.api.PreOpinionApi;
+import com.dokdok.topic.dto.response.PreOpinionResponse;
+import com.dokdok.topic.service.PreOpinionService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/gatherings/{gatheringId}/meetings/{meetingId}/answers")
+public class PreOpinionController implements PreOpinionApi {
+
+    private final PreOpinionService preOpinionService;
+
+    @Override
+    @GetMapping(produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<ApiResponse<List<PreOpinionResponse>>> findAnswers(
+            @PathVariable("gatheringId") Long gatheringId,
+            @PathVariable("meetingId") Long meetingId
+    ) {
+
+        List<PreOpinionResponse> responses = preOpinionService.findPreOpinions(gatheringId, meetingId);
+
+        return ApiResponse.success(responses, "약속의 사전 의견 목록 조회를 성공했습니다.");
+    }
+}

--- a/src/main/java/com/dokdok/topic/controller/TopicAnswerController.java
+++ b/src/main/java/com/dokdok/topic/controller/TopicAnswerController.java
@@ -9,14 +9,11 @@ import com.dokdok.topic.dto.response.TopicAnswerSubmitResponse;
 import com.dokdok.topic.service.TopicAnswerService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/gatherings/{gathering_id}/meetings/{meeting_id}/topics/{topic_id}/answers")
+@RequestMapping("/api/gatherings/{gatheringId}/meetings/{meetingId}/topics/{topicId}/answers")
 public class TopicAnswerController implements TopicAnswerApi {
 
     private final TopicAnswerService topicAnswerService;
@@ -77,9 +74,9 @@ public class TopicAnswerController implements TopicAnswerApi {
 
     @Override
     public ResponseEntity<ApiResponse<Void>> deleteMyAnswer(
-            @PathVariable("gathering_id") Long gatheringId,
-            @PathVariable("meeting_id") Long meetingId,
-            @PathVariable("topic_id") Long topicId
+            @PathVariable("gatheringId") Long gatheringId,
+            @PathVariable("meetingId") Long meetingId,
+            @PathVariable("topicId") Long topicId
     ) {
 
         topicAnswerService.deleteMyAnswer(gatheringId, meetingId, topicId);

--- a/src/main/java/com/dokdok/topic/dto/response/CreatedByInfo.java
+++ b/src/main/java/com/dokdok/topic/dto/response/CreatedByInfo.java
@@ -5,8 +5,8 @@ public record CreatedByInfo(
         String nickname
 ) {
 
-    public static CreatedByInfo of(Long userId, String nickName) {
-        return new CreatedByInfo(userId, nickName);
+    public static CreatedByInfo of(Long userId, String nickname) {
+        return new CreatedByInfo(userId, nickname);
     }
 
 }

--- a/src/main/java/com/dokdok/topic/dto/response/PreOpinionResponse.java
+++ b/src/main/java/com/dokdok/topic/dto/response/PreOpinionResponse.java
@@ -1,0 +1,83 @@
+package com.dokdok.topic.dto.response;
+
+import com.dokdok.topic.entity.TopicAnswer;
+import com.dokdok.topic.entity.TopicType;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+public record PreOpinionResponse(
+        UserInfo userInfo,
+        BookReviewInfo BookReviewInfo,
+        List<TopicAnswerInfo> topicAnswers
+) {
+
+    public record UserInfo(
+            Long userId,
+            String nickname,
+            String profileImage
+    ) {
+        public static UserInfo of(Long userId, String nickname, String profileImage) {
+            return new UserInfo(
+                    userId,
+                    nickname,
+                    profileImage
+            );
+        }
+    }
+
+    public record BookReviewInfo(
+            Long userId,
+            BigDecimal rating,
+            List<String> bookKeyword,
+            List<String> impressionKeyword
+    ) {
+        public static BookReviewInfo of(
+                Long userId,
+                BigDecimal rating,
+                List<String> bookKeyword,
+                List<String> impressionKeyword
+        ) {
+            return new BookReviewInfo(
+                    userId,
+                    rating,
+                    bookKeyword,
+                    impressionKeyword
+            );
+        }
+    }
+
+    public record TopicAnswerInfo(
+            Long userId,
+            Long topicId,
+            String title,
+            String topicDescription,
+            TopicType topicType,
+            String content
+    ) {
+        public static TopicAnswerInfo of(
+                TopicAnswer topicAnswer
+        ) {
+            return new TopicAnswerInfo(
+                    topicAnswer.getUser().getId(),
+                    topicAnswer.getTopic().getId(),
+                    topicAnswer.getTopic().getTitle(),
+                    topicAnswer.getTopic().getDescription(),
+                    topicAnswer.getTopic().getTopicType(),
+                    topicAnswer.getContent()
+            );
+        }
+    }
+
+    public static PreOpinionResponse from(
+            UserInfo userInfo,
+            BookReviewInfo BookReviewInfo,
+            List<TopicAnswerInfo> topicAnswers
+    ) {
+        return new PreOpinionResponse(
+                userInfo,
+                BookReviewInfo,
+                topicAnswers
+        );
+    }
+}

--- a/src/main/java/com/dokdok/topic/dto/response/PreOpinionResponse.java
+++ b/src/main/java/com/dokdok/topic/dto/response/PreOpinionResponse.java
@@ -1,83 +1,78 @@
 package com.dokdok.topic.dto.response;
 
+import com.dokdok.topic.entity.Topic;
 import com.dokdok.topic.entity.TopicAnswer;
-import com.dokdok.topic.entity.TopicType;
 
 import java.math.BigDecimal;
 import java.util.List;
 
 public record PreOpinionResponse(
-        UserInfo userInfo,
-        BookReviewInfo BookReviewInfo,
-        List<TopicAnswerInfo> topicAnswers
+        List<TopicInfo> topics,
+        List<MemberPreOpinion> members
 ) {
 
-    public record UserInfo(
-            Long userId,
+    public record TopicInfo(
+            Long topicId,
+            String topicName,
+            String topicDescription,
+            String topicType
+    ) {
+        public static TopicInfo from(Topic topic) {
+            return new TopicInfo(
+                    topic.getId(),
+                    topic.getTitle(),
+                    topic.getDescription(),
+                    topic.getTopicType().getDisplayName()
+            );
+        }
+    }
+
+    public record MemberPreOpinion(
+            MemberInfo memberInfo,
+            BookReviewInfo bookReview,
+            List<TopicOpinion> topicOpinions
+    ) { }
+
+    public record MemberInfo(
+            Long memberId,
             String nickname,
             String profileImage
     ) {
-        public static UserInfo of(Long userId, String nickname, String profileImage) {
-            return new UserInfo(
-                    userId,
-                    nickname,
-                    profileImage
-            );
+        public static MemberInfo of(Long memberId, String nickname, String profileImage) {
+            return new MemberInfo(memberId, nickname, profileImage);
         }
     }
 
     public record BookReviewInfo(
-            Long userId,
             BigDecimal rating,
-            List<String> bookKeyword,
-            List<String> impressionKeyword
+            List<String> bookKeywords,
+            List<String> impressionKeywords
     ) {
         public static BookReviewInfo of(
-                Long userId,
                 BigDecimal rating,
-                List<String> bookKeyword,
-                List<String> impressionKeyword
+                List<String> bookKeywords,
+                List<String> impressionKeywords
         ) {
-            return new BookReviewInfo(
-                    userId,
-                    rating,
-                    bookKeyword,
-                    impressionKeyword
-            );
+            return new BookReviewInfo(rating, bookKeywords, impressionKeywords);
         }
     }
 
-    public record TopicAnswerInfo(
-            Long userId,
+    public record TopicOpinion(
             Long topicId,
-            String title,
-            String topicDescription,
-            TopicType topicType,
             String content
     ) {
-        public static TopicAnswerInfo of(
-                TopicAnswer topicAnswer
-        ) {
-            return new TopicAnswerInfo(
-                    topicAnswer.getUser().getId(),
+        public static TopicOpinion of(TopicAnswer topicAnswer) {
+            return new TopicOpinion(
                     topicAnswer.getTopic().getId(),
-                    topicAnswer.getTopic().getTitle(),
-                    topicAnswer.getTopic().getDescription(),
-                    topicAnswer.getTopic().getTopicType(),
                     topicAnswer.getContent()
             );
         }
     }
 
-    public static PreOpinionResponse from(
-            UserInfo userInfo,
-            BookReviewInfo BookReviewInfo,
-            List<TopicAnswerInfo> topicAnswers
+    public static PreOpinionResponse of(
+            List<TopicInfo> topics,
+            List<MemberPreOpinion> members
     ) {
-        return new PreOpinionResponse(
-                userInfo,
-                BookReviewInfo,
-                topicAnswers
-        );
+        return new PreOpinionResponse(topics, members);
     }
 }

--- a/src/main/java/com/dokdok/topic/repository/TopicAnswerRepository.java
+++ b/src/main/java/com/dokdok/topic/repository/TopicAnswerRepository.java
@@ -24,6 +24,18 @@ public interface TopicAnswerRepository extends JpaRepository<TopicAnswer, Long> 
     boolean existsByTopicIdAndUserId(Long topicId, Long userId);
 
     @Query("""
+                SELECT CASE WHEN COUNT(ta) > 0 THEN true ELSE false END
+                FROM TopicAnswer ta
+                JOIN ta.topic t
+                JOIN t.meeting m
+                WHERE m.id = :meetingId
+                  AND ta.user.id = :userId
+            """)
+    boolean existsByMeetingIdAndUserId(@Param("meetingId") Long meetingId,
+                                       @Param("userId") Long userId);
+
+
+    @Query("""
                     SELECT ta
                     FROM TopicAnswer ta
                     JOIN FETCH ta.topic t
@@ -44,4 +56,15 @@ public interface TopicAnswerRepository extends JpaRepository<TopicAnswer, Long> 
             AND ta.deletedAt IS NULL
             """)
     void softDeleteByMeetingId(@Param("meetingId") Long meetingId);
+
+    @Query("""
+                    SELECT ta
+                    FROM TopicAnswer ta
+                    LEFT JOIN FETCH ta.user u
+                    JOIN FETCH ta.topic t
+                    WHERE t.meeting.id = :meetingId
+                    ORDER BY ta.createdAt DESC
+            """
+    )
+    List<TopicAnswer> findByMeetingId(Long meetingId);
 }

--- a/src/main/java/com/dokdok/topic/repository/TopicAnswerRepository.java
+++ b/src/main/java/com/dokdok/topic/repository/TopicAnswerRepository.java
@@ -28,7 +28,8 @@ public interface TopicAnswerRepository extends JpaRepository<TopicAnswer, Long> 
                 JOIN ta.topic t
                 JOIN t.meeting m
                 WHERE m.id = :meetingId
-                  AND ta.user.id = :userId
+                AND ta.user.id = :userId
+                AND ta.isSubmitted = true
             """)
     boolean existsByMeetingIdAndUserId(@Param("meetingId") Long meetingId,
                                        @Param("userId") Long userId);
@@ -71,6 +72,7 @@ public interface TopicAnswerRepository extends JpaRepository<TopicAnswer, Long> 
                     LEFT JOIN FETCH ta.user u
                     JOIN FETCH ta.topic t
                     WHERE t.meeting.id = :meetingId
+                    AND ta.isSubmitted = true
                     ORDER BY ta.createdAt DESC
             """
     )

--- a/src/main/java/com/dokdok/topic/repository/TopicRepository.java
+++ b/src/main/java/com/dokdok/topic/repository/TopicRepository.java
@@ -26,6 +26,14 @@ public interface TopicRepository extends JpaRepository<Topic, Long> {
             TopicStatus topicStatus
     );
 
+    @Query("""
+            SELECT t
+            FROM Topic t
+            WHERE t.meeting.id = :meetingId
+            AND t.topicStatus = com.dokdok.topic.entity.TopicStatus.CONFIRMED
+    """)
+    List<Topic> findConfirmedTopics(Long meetingId);
+
     @Query("SELECT t " +
             "FROM Topic t " +
             "LEFT JOIN FETCH t.meeting m " +
@@ -143,7 +151,5 @@ public interface TopicRepository extends JpaRepository<Topic, Long> {
     List<Topic> findTopicsInfoByMeetingId(
             @Param("meetingId") Long meetingId
     );
-
-    List<Topic> findByIdIn(List<Long> topicIds);
 
 }

--- a/src/main/java/com/dokdok/topic/service/PreOpinionService.java
+++ b/src/main/java/com/dokdok/topic/service/PreOpinionService.java
@@ -64,22 +64,10 @@ public class PreOpinionService {
                 .toList();
     }
 
-    private List<PreOpinionResponse.MemberInfo> buildMemberInfos(List<MeetingMember> meetingMembers) {
-        return meetingMembers.stream()
-                .map(mm -> {
-                    User user = mm.getUser();
-                    String presignedUrl = storageService.getPresignedProfileImage(user.getProfileImageUrl());
-                    return PreOpinionResponse.MemberInfo.of(user.getId(), user.getNickname(), presignedUrl);
-                })
-                .toList();
-    }
-
     private List<PreOpinionResponse.MemberPreOpinion> buildPreOpinionData(Long meetingId, List<MeetingMember> meetingMembers) {
         List<Long> userIds = meetingMembers.stream()
                 .map(mm -> mm.getUser().getId())
                 .toList();
-
-        List<PreOpinionResponse.MemberInfo> memberInfos = buildMemberInfos(meetingMembers);
 
         // 모든 멤버의 책 평가 일괄 조회
         Map<Long, BookReview> bookReviewByUserId = bookReviewRepository.findByUserIdIn(userIds).stream()

--- a/src/main/java/com/dokdok/topic/service/PreOpinionService.java
+++ b/src/main/java/com/dokdok/topic/service/PreOpinionService.java
@@ -1,0 +1,128 @@
+package com.dokdok.topic.service;
+
+import com.dokdok.book.entity.BookReview;
+import com.dokdok.book.entity.BookReviewKeyword;
+import com.dokdok.book.entity.KeywordType;
+import com.dokdok.book.repository.BookRepository;
+import com.dokdok.book.repository.BookReviewKeywordRepository;
+import com.dokdok.book.repository.BookReviewRepository;
+import com.dokdok.book.service.BookValidator;
+import com.dokdok.gathering.service.GatheringValidator;
+import com.dokdok.global.util.SecurityUtil;
+import com.dokdok.keyword.entity.Keyword;
+import com.dokdok.meeting.service.MeetingValidator;
+import com.dokdok.retrospective.dto.response.PersonalRetrospectiveFormResponse;
+import com.dokdok.retrospective.entity.PersonalMeetingRetrospective;
+import com.dokdok.storage.service.StorageService;
+import com.dokdok.topic.dto.response.PreOpinionResponse;
+import com.dokdok.topic.entity.TopicAnswer;
+import com.dokdok.topic.repository.TopicAnswerRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class PreOpinionService {
+
+    private final GatheringValidator gatheringValidator;
+    private final MeetingValidator meetingValidator;
+    private final TopicAnswerRepository topicAnswerRepository;
+    private final BookReviewRepository bookReviewRepository;
+    private final BookReviewKeywordRepository bookReviewKeywordRepository;
+    private final BookValidator bookValidator;
+    private final StorageService storageService;
+
+    @Transactional(readOnly = true)
+    public List<PreOpinionResponse> findPreOpinions(
+            Long gatheringId,
+            Long meetingId
+    ) {
+        Long userId = SecurityUtil.getCurrentUserId();
+
+        gatheringValidator.validateGathering(gatheringId);
+        meetingValidator.validateMeetingInGathering(meetingId, gatheringId);
+        meetingValidator.validateMeetingMember(meetingId, userId);
+        bookValidator.validateUserHasWrittenBookReview(meetingId, userId);
+
+        List<BookReview> bookReviews = bookReviewRepository.findByMeetingId(meetingId);
+
+        List<Long> bookReviewIds = bookReviews.stream()
+                .map(BookReview::getId)
+                .toList();
+
+        List<BookReviewKeyword> keywords = bookReviewKeywordRepository.findByBookReviewIds(bookReviewIds);
+
+        Map<Long, List<BookReviewKeyword>> keywordsByReviewId =
+                keywords.stream()
+                        .collect(Collectors.groupingBy(
+                                k -> k.getBookReview().getId()
+                        ));
+
+        Map<Long, PreOpinionResponse.BookReviewInfo> bookReviewInfoByUserId = bookReviews.stream()
+                .collect(Collectors.toMap(
+                        bookReview -> bookReview.getUser().getId(),
+                        bookReview -> {
+                            List<BookReviewKeyword> reviewKeywords = keywordsByReviewId
+                                    .getOrDefault(bookReview.getId(), List.of());
+                            Map<KeywordType, List<String>> keywordMap = toKeywordMap(reviewKeywords);
+                            return PreOpinionResponse.BookReviewInfo.of(
+                                    bookReview.getUser().getId(),
+                                    bookReview.getRating(),
+                                    keywordMap.getOrDefault(KeywordType.BOOK, List.of()),
+                                    keywordMap.getOrDefault(KeywordType.IMPRESSION, List.of())
+                            );
+                        }
+                ));
+
+        List<TopicAnswer> topicAnswers = topicAnswerRepository.findByMeetingId(meetingId);
+
+        Map<Long, List<PreOpinionResponse.TopicAnswerInfo>> topicAnswersByUserId = topicAnswers.stream()
+                .map(PreOpinionResponse.TopicAnswerInfo::of)
+                .collect(Collectors.groupingBy(PreOpinionResponse.TopicAnswerInfo::userId));
+
+        Map<Long, PreOpinionResponse.UserInfo> userInfoByUserId = bookReviews.stream()
+                .collect(Collectors.toMap(
+                        bookReview -> bookReview.getUser().getId(),
+                        bookReview -> {
+                            String presignedUrl = storageService.getPresignedProfileImage(
+                                    bookReview.getUser().getProfileImageUrl()
+                            );
+                            return PreOpinionResponse.UserInfo.of(
+                                    bookReview.getUser().getId(),
+                                    bookReview.getUser().getNickname(),
+                                    presignedUrl
+                            );
+                        },
+                        (existing, replacement) -> existing // 중복 시 기존 값 유지
+                ));
+
+        return userInfoByUserId.keySet().stream()
+                .map(uid -> PreOpinionResponse.from(
+                        userInfoByUserId.get(uid),
+                        bookReviewInfoByUserId.get(uid),
+                        topicAnswersByUserId.getOrDefault(uid, List.of())
+                ))
+                .toList();
+    }
+
+
+    // 타입별로 Map 저장
+    private Map<KeywordType, List<String>> toKeywordMap(List<BookReviewKeyword> keywords) {
+        return keywords.stream()
+                .collect(Collectors.groupingBy(
+                        k -> k.getKeyword().getKeywordType(),
+                        Collectors.mapping(
+                                k -> k.getKeyword().getKeywordName(),
+                                Collectors.toList()
+                        )
+
+                ));
+    }
+
+}

--- a/src/main/java/com/dokdok/topic/service/PreOpinionService.java
+++ b/src/main/java/com/dokdok/topic/service/PreOpinionService.java
@@ -3,25 +3,23 @@ package com.dokdok.topic.service;
 import com.dokdok.book.entity.BookReview;
 import com.dokdok.book.entity.BookReviewKeyword;
 import com.dokdok.book.entity.KeywordType;
-import com.dokdok.book.repository.BookRepository;
 import com.dokdok.book.repository.BookReviewKeywordRepository;
 import com.dokdok.book.repository.BookReviewRepository;
-import com.dokdok.book.service.BookValidator;
 import com.dokdok.gathering.service.GatheringValidator;
 import com.dokdok.global.util.SecurityUtil;
-import com.dokdok.keyword.entity.Keyword;
+import com.dokdok.meeting.entity.MeetingMember;
+import com.dokdok.meeting.repository.MeetingMemberRepository;
 import com.dokdok.meeting.service.MeetingValidator;
-import com.dokdok.retrospective.dto.response.PersonalRetrospectiveFormResponse;
-import com.dokdok.retrospective.entity.PersonalMeetingRetrospective;
 import com.dokdok.storage.service.StorageService;
 import com.dokdok.topic.dto.response.PreOpinionResponse;
-import com.dokdok.topic.entity.TopicAnswer;
+import com.dokdok.topic.dto.response.PreOpinionResponse.BookReviewInfo;
 import com.dokdok.topic.repository.TopicAnswerRepository;
+import com.dokdok.topic.repository.TopicRepository;
+import com.dokdok.user.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -33,96 +31,124 @@ public class PreOpinionService {
     private final GatheringValidator gatheringValidator;
     private final MeetingValidator meetingValidator;
     private final TopicValidator topicValidator;
+    private final TopicRepository topicRepository;
+    private final MeetingMemberRepository meetingMemberRepository;
     private final TopicAnswerRepository topicAnswerRepository;
     private final BookReviewRepository bookReviewRepository;
     private final BookReviewKeywordRepository bookReviewKeywordRepository;
     private final StorageService storageService;
 
     @Transactional(readOnly = true)
-    public List<PreOpinionResponse> findPreOpinions(
-            Long gatheringId,
-            Long meetingId
-    ) {
+    public PreOpinionResponse findPreOpinions(Long gatheringId, Long meetingId) {
         Long userId = SecurityUtil.getCurrentUserId();
+        validateAccess(gatheringId, meetingId, userId);
 
-        gatheringValidator.validateGathering(gatheringId); // 모임 검증
-        meetingValidator.validateMeetingInGathering(meetingId, gatheringId); // 모임에 포함된 약속인지
-        meetingValidator.validateMeetingMember(meetingId, userId); // 로그인한 사용자가 약속에 포함된 멤버인지
-        topicValidator.validateUserHasWrittenBookReview(meetingId, userId); // 주제 답변을 작성한 멤버인지
+        List<PreOpinionResponse.TopicInfo> topicInfos = buildTopicInfos(meetingId);
+        List<MeetingMember> meetingMembers = meetingMemberRepository.findAllByMeetingId(meetingId);
 
-        List<BookReview> bookReviews = bookReviewRepository.findByMeetingId(meetingId);
+        List<PreOpinionResponse.MemberPreOpinion> preOpinionData = buildPreOpinionData(meetingId, meetingMembers);
 
-        List<Long> bookReviewIds = bookReviews.stream()
-                .map(BookReview::getId)
-                .toList();
+        return new PreOpinionResponse(topicInfos, preOpinionData);
+    }
 
-        List<BookReviewKeyword> keywords = bookReviewKeywordRepository.findByBookReviewIds(bookReviewIds);
+    private void validateAccess(Long gatheringId, Long meetingId, Long userId) {
+        gatheringValidator.validateGathering(gatheringId);
+        meetingValidator.validateMeetingInGathering(meetingId, gatheringId);
+        meetingValidator.validateMeetingMember(meetingId, userId);
+        topicValidator.validateUserHasWrittenAnswer(meetingId, userId);
+    }
 
-        Map<Long, List<BookReviewKeyword>> keywordsByReviewId =
-                keywords.stream()
-                        .collect(Collectors.groupingBy(
-                                k -> k.getBookReview().getId()
-                        ));
-
-        Map<Long, PreOpinionResponse.BookReviewInfo> bookReviewInfoByUserId = bookReviews.stream()
-                .collect(Collectors.toMap(
-                        bookReview -> bookReview.getUser().getId(),
-                        bookReview -> {
-                            List<BookReviewKeyword> reviewKeywords = keywordsByReviewId
-                                    .getOrDefault(bookReview.getId(), List.of());
-                            Map<KeywordType, List<String>> keywordMap = toKeywordMap(reviewKeywords);
-                            return PreOpinionResponse.BookReviewInfo.of(
-                                    bookReview.getUser().getId(),
-                                    bookReview.getRating(),
-                                    keywordMap.getOrDefault(KeywordType.BOOK, List.of()),
-                                    keywordMap.getOrDefault(KeywordType.IMPRESSION, List.of())
-                            );
-                        }
-                ));
-
-        List<TopicAnswer> topicAnswers = topicAnswerRepository.findByMeetingId(meetingId);
-
-        Map<Long, List<PreOpinionResponse.TopicAnswerInfo>> topicAnswersByUserId = topicAnswers.stream()
-                .map(PreOpinionResponse.TopicAnswerInfo::of)
-                .collect(Collectors.groupingBy(PreOpinionResponse.TopicAnswerInfo::userId));
-
-        Map<Long, PreOpinionResponse.UserInfo> userInfoByUserId = bookReviews.stream()
-                .collect(Collectors.toMap(
-                        bookReview -> bookReview.getUser().getId(),
-                        bookReview -> {
-                            String presignedUrl = storageService.getPresignedProfileImage(
-                                    bookReview.getUser().getProfileImageUrl()
-                            );
-                            return PreOpinionResponse.UserInfo.of(
-                                    bookReview.getUser().getId(),
-                                    bookReview.getUser().getNickname(),
-                                    presignedUrl
-                            );
-                        },
-                        (existing, replacement) -> existing // 중복 시 기존 값 유지
-                ));
-
-        return userInfoByUserId.keySet().stream()
-                .map(uid -> PreOpinionResponse.from(
-                        userInfoByUserId.get(uid),
-                        bookReviewInfoByUserId.get(uid),
-                        topicAnswersByUserId.getOrDefault(uid, List.of())
-                ))
+    private List<PreOpinionResponse.TopicInfo> buildTopicInfos(Long meetingId) {
+        return topicRepository.findConfirmedTopics(meetingId).stream()
+                .map(PreOpinionResponse.TopicInfo::from)
                 .toList();
     }
 
+    private List<PreOpinionResponse.MemberInfo> buildMemberInfos(List<MeetingMember> meetingMembers) {
+        return meetingMembers.stream()
+                .map(mm -> {
+                    User user = mm.getUser();
+                    String presignedUrl = storageService.getPresignedProfileImage(user.getProfileImageUrl());
+                    return PreOpinionResponse.MemberInfo.of(user.getId(), user.getNickname(), presignedUrl);
+                })
+                .toList();
+    }
 
-    // 타입별로 Map 저장
+    private List<PreOpinionResponse.MemberPreOpinion> buildPreOpinionData(Long meetingId, List<MeetingMember> meetingMembers) {
+        List<Long> userIds = meetingMembers.stream()
+                .map(mm -> mm.getUser().getId())
+                .toList();
+
+        List<PreOpinionResponse.MemberInfo> memberInfos = buildMemberInfos(meetingMembers);
+
+        // 모든 멤버의 책 평가 일괄 조회
+        Map<Long, BookReview> bookReviewByUserId = bookReviewRepository.findByUserIdIn(userIds).stream()
+                .collect(Collectors.toMap(
+                        br -> br.getUser().getId(),
+                        br -> br,
+                        (existing, replacement) -> existing
+                ));
+
+        // 책 평가별 키워드 일괄 조회
+        List<Long> bookReviewIds = bookReviewByUserId.values().stream()
+                .map(BookReview::getId)
+                .toList();
+        Map<Long, List<BookReviewKeyword>> keywordsByReviewId = bookReviewKeywordRepository
+                .findByBookReviewIds(bookReviewIds).stream()
+                .collect(Collectors.groupingBy(k -> k.getBookReview().getId()));
+
+        // 주제 답변 일괄 조회
+        Map<Long, List<PreOpinionResponse.TopicOpinion>> topicAnswersByUserId =
+                topicAnswerRepository.findByMeetingId(meetingId).stream()
+                        .collect(Collectors.groupingBy(
+                                ta -> ta.getUser().getId(),
+                                Collectors.mapping(
+                                        PreOpinionResponse.TopicOpinion::of,
+                                        Collectors.toList()
+                                )
+                        ));
+
+
+        return meetingMembers.stream()
+                .map(mm -> {
+                    User user = mm.getUser();
+                    Long memberId = user.getId();
+
+                    String presignedUrl = storageService.getPresignedProfileImage(user.getProfileImageUrl());
+                    PreOpinionResponse.MemberInfo memberInfo
+                            = PreOpinionResponse.MemberInfo.of(memberId, user.getNickname(), presignedUrl);
+
+                    BookReview review = bookReviewByUserId.get(memberId);
+                    BookReviewInfo bookReviewInfo = review != null
+                            ? toBookReviewInfo(review, keywordsByReviewId)
+                            : null;
+
+                    List<PreOpinionResponse.TopicOpinion> topicAnswers = topicAnswersByUserId.getOrDefault(memberId, List.of());
+
+                    return new PreOpinionResponse.MemberPreOpinion(memberInfo, bookReviewInfo, topicAnswers);
+                })
+                .toList();
+    }
+
+    private BookReviewInfo toBookReviewInfo(
+            BookReview bookReview,
+            Map<Long, List<BookReviewKeyword>> keywordsByReviewId) {
+        List<BookReviewKeyword> reviewKeywords =
+                keywordsByReviewId.getOrDefault(bookReview.getId(), List.of());
+        Map<KeywordType, List<String>> keywordMap = toKeywordMap(reviewKeywords);
+
+        return BookReviewInfo.of(
+                bookReview.getRating(),
+                keywordMap.getOrDefault(KeywordType.BOOK, List.of()),
+                keywordMap.getOrDefault(KeywordType.IMPRESSION, List.of())
+        );
+    }
+
     private Map<KeywordType, List<String>> toKeywordMap(List<BookReviewKeyword> keywords) {
         return keywords.stream()
                 .collect(Collectors.groupingBy(
                         k -> k.getKeyword().getKeywordType(),
-                        Collectors.mapping(
-                                k -> k.getKeyword().getKeywordName(),
-                                Collectors.toList()
-                        )
-
+                        Collectors.mapping(k -> k.getKeyword().getKeywordName(), Collectors.toList())
                 ));
     }
-
 }

--- a/src/main/java/com/dokdok/topic/service/TopicAnswerService.java
+++ b/src/main/java/com/dokdok/topic/service/TopicAnswerService.java
@@ -137,5 +137,4 @@ public class TopicAnswerService {
 
         answer.softDelete();
     }
-
 }

--- a/src/main/java/com/dokdok/topic/service/TopicValidator.java
+++ b/src/main/java/com/dokdok/topic/service/TopicValidator.java
@@ -35,7 +35,6 @@ public class TopicValidator {
         return topics;
     }
 
-
     /**
      * 해당 약속에 속한 주제인지 검증하고 Topic을 반환한다.
      */
@@ -63,6 +62,15 @@ public class TopicValidator {
 
     public TopicAnswer getTopicAnswer(Long topicId, Long userId) {
         return topicAnswerRepository.findByTopicIdAndUserId(topicId, userId)
+                .orElseThrow(() -> new TopicException(TopicErrorCode.TOPIC_ANSWER_NOT_FOUND));
+    }
+
+    public TopicAnswer validateTopicAnswerByUser(Long meetingId, Long userId) {
+        boolean exists = topicAnswerRepository.existsByMeetingIdAndUserId(meetingId, userId);
+
+        if (!exists) {
+
+        }
                 .orElseThrow(() -> new TopicException(TopicErrorCode.TOPIC_ANSWER_NOT_FOUND));
     }
 

--- a/src/main/java/com/dokdok/topic/service/TopicValidator.java
+++ b/src/main/java/com/dokdok/topic/service/TopicValidator.java
@@ -11,7 +11,6 @@ import com.dokdok.topic.repository.TopicRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
-import java.util.Collections;
 import java.util.List;
 
 

--- a/src/main/java/com/dokdok/topic/service/TopicValidator.java
+++ b/src/main/java/com/dokdok/topic/service/TopicValidator.java
@@ -1,5 +1,7 @@
 package com.dokdok.topic.service;
 
+import com.dokdok.book.exception.BookErrorCode;
+import com.dokdok.book.exception.BookException;
 import com.dokdok.topic.entity.TopicAnswer;
 import com.dokdok.topic.entity.Topic;
 import com.dokdok.topic.exception.TopicErrorCode;
@@ -34,7 +36,6 @@ public class TopicValidator {
 
         return topics;
     }
-
 
     /**
      * 해당 약속에 속한 주제인지 검증하고 Topic을 반환한다.
@@ -77,5 +78,17 @@ public class TopicValidator {
 
         return topicRepository.findTopicWithDeletePermission(topicId, userId)
                 .orElseThrow(() -> new TopicException(TopicErrorCode.TOPIC_USER_CANNOT_DELETE));
+    }
+
+    /**
+     * 사전 의견을 발행한 사용자인지 검증한다.
+     */
+    public void validateUserHasWrittenAnswer(Long meetingId, Long userId) {
+
+        boolean exists = topicAnswerRepository.existsByMeetingIdAndUserId(meetingId, userId);
+
+        if(!exists) {
+            throw new BookException(BookErrorCode.BOOK_REVIEW_ACCESS_DENIED_NOT_WRITTEN);
+        }
     }
 }


### PR DESCRIPTION
## PR 요약
> 이 PR이 어떤 변경을 하는지 간단히 설명하고, 체크 표시는 괄호 사이에 소문자 'x'를 삽입하세요.

- [x] 기능 추가
- [ ] 버그 수정
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 기타 (설명)

---

## 이슈 번호
- #148

---

## 주요 변경 사항
> 주요 파일, 로직, 컴포넌트 등을 구체적으로 적어주세요.

- `src/main/java/com/dokdok/book`: +59/-3 (5 files) — 사전 의견 조회 API 구현 외 2건
- `src/main/java/com/dokdok/keyword`: +3/-1 (1 files) — 사전 의견 조회 API 구현
- `src/main/java/com/dokdok/retrospective`: +1/-1 (1 files) — 사전 의견 조회 API 구현 외 1건
- `src/main/java/com/dokdok/topic`: +733/-59 (12 files) — 사전 의견 조회 API 구현 외 3건

---

## 참고 사항
> 리뷰어가 알아야 할 추가 정보, 테스트 방법 등을 작성해주세요.

예:
- 테스트 계정 정보
- 관련 API 엔드포인트
- 로컬 테스트 방법

---
