### PR TITLE
[#54][REFACTOR] 약속 상세 조회에 대한 응답 구조 개선

### DIFF
--- a/src/main/java/com/dokdok/meeting/api/MeetingApi.java
+++ b/src/main/java/com/dokdok/meeting/api/MeetingApi.java
@@ -2,6 +2,7 @@ package com.dokdok.meeting.api;
 
 import com.dokdok.global.response.ApiResponse;
 import com.dokdok.meeting.dto.MeetingCreateRequest;
+import com.dokdok.meeting.dto.MeetingDetailResponse;
 import com.dokdok.meeting.dto.MeetingResponse;
 import com.dokdok.meeting.dto.MeetingStatusResponse;
 import com.dokdok.meeting.dto.MeetingTabCountsResponse;
@@ -39,7 +40,7 @@ public interface MeetingApi {
                     responseCode = "200",
                     description = "약속 상세 조회 성공",
                     content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
-                            schema = @Schema(implementation = MeetingResponse.class))
+                            schema = @Schema(implementation = MeetingDetailResponse.class))
             ),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청",
                     content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
@@ -57,7 +58,7 @@ public interface MeetingApi {
                                     {"code": "E000", "message": "서버 에러가 발생했습니다. 담당자에게 문의 바랍니다.", "data": null}
                                     """)))
     })
-    ResponseEntity<ApiResponse<MeetingResponse>> findMeeting(
+    ResponseEntity<ApiResponse<MeetingDetailResponse>> findMeeting(
             Long meetingId
     );
 

--- a/src/main/java/com/dokdok/meeting/controller/MeetingController.java
+++ b/src/main/java/com/dokdok/meeting/controller/MeetingController.java
@@ -3,6 +3,7 @@ package com.dokdok.meeting.controller;
 import com.dokdok.global.response.ApiResponse;
 import com.dokdok.meeting.api.MeetingApi;
 import com.dokdok.meeting.dto.MeetingCreateRequest;
+import com.dokdok.meeting.dto.MeetingDetailResponse;
 import com.dokdok.meeting.dto.MeetingResponse;
 import com.dokdok.meeting.dto.MeetingStatusResponse;
 import com.dokdok.meeting.dto.MeetingTabCountsResponse;
@@ -24,7 +25,7 @@ public class MeetingController implements MeetingApi {
 
     @Override
     @GetMapping(value = "/{meetingId}", produces = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity<ApiResponse<MeetingResponse>> findMeeting(
+    public ResponseEntity<ApiResponse<MeetingDetailResponse>> findMeeting(
             @PathVariable Long meetingId
     ) {
         return ApiResponse.success(meetingService.findMeeting(meetingId), "약속 상세 조회에 성공했습니다.");

--- a/src/main/java/com/dokdok/meeting/dto/MeetingActionType.java
+++ b/src/main/java/com/dokdok/meeting/dto/MeetingActionType.java
@@ -1,0 +1,19 @@
+package com.dokdok.meeting.dto;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum MeetingActionType {
+    CAN_EDIT("수정하기", true),
+    EDIT_TIME_EXPIRED("수정 가능 시간이 지났어요", false),
+    CAN_JOIN("참가 신청하기", true),
+    CAN_CANCEL("참가 신청 취소하기", true),
+    RECRUITMENT_CLOSED("모집인원이 마감되었어요", false),
+    DONE("약속이 끝났어요", false),
+    REJECTED("약속 신청이 거절됐어요", false);
+
+    private final String buttonLabel;
+    private final boolean enabled;
+}

--- a/src/main/java/com/dokdok/meeting/dto/MeetingDetailResponse.java
+++ b/src/main/java/com/dokdok/meeting/dto/MeetingDetailResponse.java
@@ -1,0 +1,303 @@
+package com.dokdok.meeting.dto;
+
+import com.dokdok.book.entity.Book;
+import com.dokdok.gathering.entity.Gathering;
+import com.dokdok.meeting.entity.Meeting;
+import com.dokdok.meeting.entity.MeetingMember;
+import com.dokdok.meeting.entity.MeetingMemberRole;
+import com.dokdok.meeting.entity.MeetingStatus;
+import com.dokdok.user.entity.User;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.DayOfWeek;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+@Schema(description = "약속 상세 응답")
+public record MeetingDetailResponse(
+        @Schema(description = "약속 ID", example = "1")
+        Long meetingId,
+
+        @Schema(description = "약속 이름", example = "1월 독서 모임")
+        String meetingName,
+
+        @Schema(description = "약속 상태", example = "CONFIRMED")
+        MeetingStatus meetingStatus,
+
+        @Schema(description = "모임 정보")
+        GatheringInfo gathering,
+
+        @Schema(description = "책 정보")
+        BookInfo book,
+
+        @Schema(description = "일정 정보")
+        ScheduleInfo schedule,
+
+        @Schema(description = "장소", example = "강남역 스타벅스")
+        String place,
+
+        @Schema(description = "참가자 정보")
+        ParticipantsInfo participants,
+
+        @Schema(description = "화면 버튼 상태")
+        ActionState actionState
+) {
+
+    public static MeetingDetailResponse from(
+            Meeting meeting,
+            List<MeetingMember> meetingMembers,
+            Long requestUserId
+    ) {
+        List<MeetingMember> safeMembers = meetingMembers == null ? Collections.emptyList() : meetingMembers;
+        List<MeetingMember> activeMembers = safeMembers.stream()
+                .filter(member -> member.getCanceledAt() == null)
+                .toList();
+
+        ParticipantsInfo participantsInfo = ParticipantsInfo.from(activeMembers, meeting.getMaxParticipants());
+
+        ActionState actionState = calculateActionState(
+                meeting,
+                requestUserId,
+                activeMembers,
+                participantsInfo.currentCount(),
+                participantsInfo.maxCount()
+        );
+
+        return new MeetingDetailResponse(
+                meeting.getId(),
+                meeting.getMeetingName(),
+                meeting.getMeetingStatus(),
+                GatheringInfo.from(meeting.getGathering()),
+                BookInfo.from(meeting.getBook()),
+                ScheduleInfo.from(meeting.getMeetingStartDate(), meeting.getMeetingEndDate()),
+                meeting.getPlace(),
+                participantsInfo,
+                actionState
+        );
+    }
+
+    private static ActionState calculateActionState(
+            Meeting meeting,
+            Long requestUserId,
+            List<MeetingMember> activeMembers,
+            int currentCount,
+            Integer maxCount
+    ) {
+        if (meeting.getMeetingStatus() == MeetingStatus.DONE) {
+            return ActionState.done();
+        }
+        if (meeting.getMeetingStatus() == MeetingStatus.REJECTED) {
+            return ActionState.rejected();
+        }
+
+        User meetingLeader = meeting.getMeetingLeader();
+        if (meetingLeader != null && meetingLeader.getId().equals(requestUserId)) {
+            if (isEditTimeExpired(meeting.getMeetingStartDate())) {
+                return ActionState.editTimeExpired();
+            }
+            return ActionState.canEdit();
+        }
+
+        boolean isParticipant = activeMembers.stream()
+                .anyMatch(member -> member.getUser().getId().equals(requestUserId));
+        if (isParticipant) {
+            return ActionState.canCancel();
+        }
+
+        if (isRecruitmentClosed(currentCount, maxCount)) {
+            return ActionState.recruitmentClosed();
+        }
+
+        return ActionState.canJoin();
+    }
+
+    private static boolean isRecruitmentClosed(int currentCount, Integer maxCount) {
+        return maxCount != null && currentCount >= maxCount;
+    }
+
+    private static boolean isEditTimeExpired(LocalDateTime meetingStartDate) {
+        return meetingStartDate != null
+                && meetingStartDate.isBefore(LocalDateTime.now().plusHours(24));
+    }
+
+    @Schema(description = "모임 정보")
+    public record GatheringInfo(
+            @Schema(description = "모임 ID", example = "1")
+            Long gatheringId,
+
+            @Schema(description = "모임 이름", example = "독서 모임")
+            String gatheringName
+    ) {
+        public static GatheringInfo from(Gathering gathering) {
+            if (gathering == null) {
+                return null;
+            }
+            return new GatheringInfo(gathering.getId(), gathering.getGatheringName());
+        }
+    }
+
+    @Schema(description = "책 정보")
+    public record BookInfo(
+            @Schema(description = "책 ID", example = "1")
+            Long bookId,
+
+            @Schema(description = "책 이름", example = "클린 코드")
+            String bookName,
+
+            @Schema(description = "책 썸네일 URL", example = "https://example.com/thumb.jpg")
+            String thumbnail
+    ) {
+        public static BookInfo from(Book book) {
+            if (book == null) {
+                return null;
+            }
+            return new BookInfo(book.getId(), book.getBookName(), book.getThumbnail());
+        }
+    }
+
+    @Schema(description = "일정 정보")
+    public record ScheduleInfo(
+            @Schema(description = "시작 일시", example = "2025-02-01T14:00:00")
+            LocalDateTime startDateTime,
+
+            @Schema(description = "종료 일시", example = "2025-02-01T16:00:00")
+            LocalDateTime endDateTime,
+
+            @Schema(description = "표시 문자열", example = "2026.01.01(목) 11:00 ~ 2026.01.01(목) 11:30")
+            String displayDate
+    ) {
+        private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy.MM.dd");
+        private static final DateTimeFormatter TIME_FORMATTER = DateTimeFormatter.ofPattern("HH:mm");
+        private static final Map<DayOfWeek, String> DAY_OF_WEEK_KR = Map.of(
+                DayOfWeek.MONDAY, "월",
+                DayOfWeek.TUESDAY, "화",
+                DayOfWeek.WEDNESDAY, "수",
+                DayOfWeek.THURSDAY, "목",
+                DayOfWeek.FRIDAY, "금",
+                DayOfWeek.SATURDAY, "토",
+                DayOfWeek.SUNDAY, "일"
+        );
+
+        public static ScheduleInfo from(LocalDateTime start, LocalDateTime end) {
+            if (start == null && end == null) {
+                return null;
+            }
+            String displayDate = formatDisplayDate(start, end);
+            return new ScheduleInfo(start, end, displayDate);
+        }
+
+        private static String formatDisplayDate(LocalDateTime start, LocalDateTime end) {
+            if (start == null) {
+                return null;
+            }
+
+            String startDateStr = start.format(DATE_FORMATTER);
+            String startDayOfWeek = DAY_OF_WEEK_KR.get(start.getDayOfWeek());
+            String startTimeStr = start.format(TIME_FORMATTER);
+
+            if (end == null) {
+                return String.format("%s(%s) %s", startDateStr, startDayOfWeek, startTimeStr);
+            }
+
+            String endDateStr = end.format(DATE_FORMATTER);
+            String endDayOfWeek = DAY_OF_WEEK_KR.get(end.getDayOfWeek());
+            String endTimeStr = end.format(TIME_FORMATTER);
+
+            return String.format("%s(%s) %s ~ %s(%s) %s",
+                    startDateStr, startDayOfWeek, startTimeStr,
+                    endDateStr, endDayOfWeek, endTimeStr);
+        }
+    }
+
+    @Schema(description = "참가자 정보")
+    public record ParticipantsInfo(
+            @Schema(description = "현재 참가자 수", example = "5")
+            Integer currentCount,
+
+            @Schema(description = "최대 참가자 수", example = "10")
+            Integer maxCount,
+
+            @Schema(description = "참가자 목록")
+            List<MemberInfo> members
+    ) {
+        public static ParticipantsInfo from(List<MeetingMember> activeMembers, Integer maxCount) {
+            List<MemberInfo> members = activeMembers.stream()
+                    .map(MemberInfo::from)
+                    .toList();
+
+            return new ParticipantsInfo(members.size(), maxCount, members);
+        }
+    }
+
+    @Schema(description = "참가자 정보")
+    public record MemberInfo(
+            @Schema(description = "사용자 ID", example = "1")
+            Long userId,
+
+            @Schema(description = "닉네임", example = "독서왕")
+            String nickname,
+
+            @Schema(description = "프로필 이미지 URL", example = "https://example.com/profile.jpg")
+            String profileImageUrl,
+
+            @Schema(description = "참가자 역할", example = "LEADER")
+            MeetingMemberRole role
+    ) {
+        public static MemberInfo from(MeetingMember meetingMember) {
+            User user = meetingMember.getUser();
+            return new MemberInfo(
+                    user.getId(),
+                    user.getNickname(),
+                    user.getProfileImageUrl(),
+                    meetingMember.getMeetingRole()
+            );
+        }
+    }
+
+    @Schema(description = "화면 버튼 상태")
+    public record ActionState(
+            @Schema(description = "버튼 타입", example = "CAN_EDIT")
+            MeetingActionType type,
+
+            @Schema(description = "버튼 라벨", example = "수정하기")
+            String buttonLabel,
+
+            @Schema(description = "버튼 활성 여부", example = "true")
+            boolean enabled
+    ) {
+        public static ActionState canEdit() {
+            return fromType(MeetingActionType.CAN_EDIT);
+        }
+
+        public static ActionState editTimeExpired() {
+            return fromType(MeetingActionType.EDIT_TIME_EXPIRED);
+        }
+
+        public static ActionState canJoin() {
+            return fromType(MeetingActionType.CAN_JOIN);
+        }
+
+        public static ActionState canCancel() {
+            return fromType(MeetingActionType.CAN_CANCEL);
+        }
+
+        public static ActionState recruitmentClosed() {
+            return fromType(MeetingActionType.RECRUITMENT_CLOSED);
+        }
+
+        public static ActionState done() {
+            return fromType(MeetingActionType.DONE);
+        }
+
+        public static ActionState rejected() {
+            return fromType(MeetingActionType.REJECTED);
+        }
+
+        private static ActionState fromType(MeetingActionType type) {
+            return new ActionState(type, type.getButtonLabel(), type.isEnabled());
+        }
+    }
+}

--- a/src/main/java/com/dokdok/meeting/dto/MeetingResponse.java
+++ b/src/main/java/com/dokdok/meeting/dto/MeetingResponse.java
@@ -5,9 +5,6 @@ import com.dokdok.gathering.entity.Gathering;
 import com.dokdok.meeting.entity.Meeting;
 import com.dokdok.meeting.entity.MeetingMember;
 import com.dokdok.meeting.entity.MeetingStatus;
-import com.dokdok.topic.entity.Topic;
-import com.dokdok.topic.entity.TopicStatus;
-import com.dokdok.topic.entity.TopicType;
 import com.dokdok.user.entity.User;
 import io.swagger.v3.oas.annotations.media.Schema;
 
@@ -17,7 +14,7 @@ import java.time.LocalTime;
 import java.util.Collections;
 import java.util.List;
 
-@Schema(description = "약속 상세 응답")
+@Schema(description = "약속 응답")
 public record MeetingResponse(
         @Schema(description = "약속 ID", example = "1")
         Long meetingId,
@@ -41,15 +38,11 @@ public record MeetingResponse(
         String place,
 
         @Schema(description = "참가자 정보")
-        ParticipantsInfo participants,
-
-        @Schema(description = "주제 목록")
-        List<TopicInfo> topics
+        ParticipantsInfo participants
 ) {
 
-    public static MeetingResponse from(Meeting meeting, List<MeetingMember> meetingMembers, List<Topic> topics) {
+    public static MeetingResponse from(Meeting meeting, List<MeetingMember> meetingMembers) {
         List<MeetingMember> safeMembers = meetingMembers == null ? Collections.emptyList() : meetingMembers;
-        List<Topic> safeTopics = topics == null ? Collections.emptyList() : topics;
 
         return new MeetingResponse(
                 meeting.getId(),
@@ -59,8 +52,7 @@ public record MeetingResponse(
                 BookInfo.from(meeting.getBook()),
                 ScheduleInfo.from(meeting.getMeetingStartDate(), meeting.getMeetingEndDate()),
                 meeting.getPlace(),
-                ParticipantsInfo.from(safeMembers, meeting.getMaxParticipants()),
-                safeTopics.stream().map(TopicInfo::from).toList()
+                ParticipantsInfo.from(safeMembers, meeting.getMaxParticipants())
         );
     }
 
@@ -155,34 +147,6 @@ public record MeetingResponse(
         public static MemberInfo from(MeetingMember meetingMember) {
             User user = meetingMember.getUser();
             return new MemberInfo(user.getId(), user.getNickname(), user.getProfileImageUrl());
-        }
-    }
-
-    @Schema(description = "주제 정보")
-    public record TopicInfo(
-            @Schema(description = "주제 ID", example = "1")
-            Long topicId,
-
-            @Schema(description = "주제 제목", example = "1장 깨끗한 코드")
-            String title,
-
-            @Schema(description = "주제 타입", example = "FREE")
-            TopicType topicType,
-
-            @Schema(description = "주제 상태", example = "SELECTED")
-            TopicStatus topicStatus,
-
-            @Schema(description = "투표 수", example = "3")
-            Integer voteCount
-    ) {
-        public static TopicInfo from(Topic topic) {
-            return new TopicInfo(
-                    topic.getId(),
-                    topic.getTitle(),
-                    topic.getTopicType(),
-                    topic.getTopicStatus(),
-                    topic.getLikeCount()
-            );
         }
     }
 }

--- a/src/main/java/com/dokdok/meeting/service/MeetingService.java
+++ b/src/main/java/com/dokdok/meeting/service/MeetingService.java
@@ -63,7 +63,7 @@ public class MeetingService {
      * @return 약속 응답 정보
      */
     @Transactional(readOnly = true)
-    public MeetingResponse findMeeting(Long meetingId) {
+    public MeetingDetailResponse findMeeting(Long meetingId) {
 
         Long userId = SecurityUtil.getCurrentUserId();
         Meeting meeting = meetingValidator.findMeetingOrThrow(meetingId);
@@ -72,9 +72,8 @@ public class MeetingService {
         gatheringValidator.validateMembership(meeting.getGathering().getId(), userId);
 
         List<MeetingMember> meetingMembers = meetingMemberRepository.findAllByMeetingId(meetingId);
-        List<Topic> topics = topicRepository.findAllByMeetingId(meetingId);
 
-        return MeetingResponse.from(meeting, meetingMembers, topics);
+        return MeetingDetailResponse.from(meeting, meetingMembers, userId);
     }
 
     /**
@@ -109,7 +108,7 @@ public class MeetingService {
         Meeting meeting = Meeting.create(request, gathering, book, user, maxParticipants);
         Meeting savedMeeting = meetingRepository.save(meeting);
 
-        return MeetingResponse.from(savedMeeting, List.of(), List.of());
+        return MeetingResponse.from(savedMeeting, List.of());
     }
 
     /**

--- a/src/test/java/com/dokdok/meeting/service/MeetingServiceTest.java
+++ b/src/test/java/com/dokdok/meeting/service/MeetingServiceTest.java
@@ -139,14 +139,11 @@ class MeetingServiceTest {
                 .willReturn(meeting);
         given(meetingMemberRepository.findAllByMeetingId(meetingId))
                 .willReturn(java.util.Collections.emptyList());
-        given(topicRepository.findAllByMeetingId(meetingId))
-                .willReturn(java.util.Collections.emptyList());
-
         try (MockedStatic<SecurityUtil> securityUtilMock = mockStatic(SecurityUtil.class)) {
             securityUtilMock.when(SecurityUtil::getCurrentUserId).thenReturn(userId);
 
             // when
-            MeetingResponse findMeeting = meetingService.findMeeting(meetingId);
+            MeetingDetailResponse findMeeting = meetingService.findMeeting(meetingId);
 
             // then
             assertThat(findMeeting.meetingName()).isEqualTo(meeting.getMeetingName());


### PR DESCRIPTION
## PR 요약
> 이 PR이 어떤 변경을 하는지 간단히 설명하고, 체크 표시는 괄호 사이에 소문자 'x'를 삽입하세요.

- [ ] 기능 추가
- [ ] 버그 수정
- [x] 코드 리팩토링
- [ ] 문서 수정
- [ ] 기타 (설명)

---

## 이슈 번호
- #54

---

## 주요 변경 사항
> 주요 파일, 로직, 컴포넌트 등을 구체적으로 적어주세요.

  - src/main/java/com/dokdok/meeting: +335/-48 (6 files) — 약속 상세 응답 분리(MeetingDetailResponse), 액션 상태 계산/라벨 정리, 일정 표시 문자열 추가, 컨트롤러/서비스/
    스웨거 응답 타입 갱신
  - src/test/java/com/dokdok/meeting: +1/-4 (1 files) — 상세 조회 반환 타입 변경에 맞춰 테스트 수정

---

## 참고 사항
> 리뷰어가 알아야 할 추가 정보, 테스트 방법 등을 작성해주세요.

예:
- 테스트 계정 정보
- 관련 API 엔드포인트
- 로컬 테스트 방법

---
