### PR TITLE
[#222][FEAT]공동회고 AI 요약 api 구현

### DIFF
--- a/docs/ErrorCode.md
+++ b/docs/ErrorCode.md
@@ -153,6 +153,7 @@
 | R103 | MEETING_RETROSPECTIVE_NOT_FOUND | 공동 회고 내용을 찾을 수 없습니다. | 404 |
 | R104 | RETROSPECTIVE_ALREADY_DELETED | 이미 삭제된 개인 회고입니다. | 404 |
 | R105 | NO_ACCESS_RETROSPECTIVE | 회고에 접근할 권한이 없습니다. | 403 |
+| R106 | SUMMARY_NOT_FOUND | AI 요약을 찾을 수 없습니다. | 404 |
 
 ---
 

--- a/src/main/java/com/dokdok/meeting/service/MeetingValidator.java
+++ b/src/main/java/com/dokdok/meeting/service/MeetingValidator.java
@@ -108,4 +108,16 @@ public class MeetingValidator {
     public int countActiveMembers(Long meetingId) {
         return meetingMemberRepository.countActiveMembers(meetingId);
     }
+
+    /**
+     * 요청한 사용자가 약속장인지 검증한다.
+     */
+    public boolean isMeetingLeader(Long meetingId, Long userId) {
+        Meeting meeting = meetingRepository.findById(meetingId)
+                .orElseThrow(() -> new MeetingException(MeetingErrorCode.MEETING_NOT_FOUND));
+
+        return meeting.getMeetingLeader() != null
+                && meeting.getMeetingLeader().getId() != null
+                && meeting.getMeetingLeader().getId().equals(userId);
+    }
 }

--- a/src/main/java/com/dokdok/retrospective/api/MeetingRetrospectiveApi.java
+++ b/src/main/java/com/dokdok/retrospective/api/MeetingRetrospectiveApi.java
@@ -40,65 +40,45 @@ public interface MeetingRetrospectiveApi {
                     description = "공동 회고 조회 성공",
                     content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
                             schema = @Schema(implementation = MeetingRetrospectiveResponse.class),
-                            examples = @ExampleObject(value = """
-                                    {
-                                      "code": "SUCCESS",
-                                      "message": "공동 회고 조회 성공",
-                                      "data": {
-                                        "meetingId": 1,
-                                        "meetingName": "데미안을 읽어보아요 데미안을 읽어보아요 데미",
-                                        "meetingDate": "2026-01-15",
-                                        "meetingTime": "19:00-20:00",
-                                        "topics": [
-                                          {
-                                            "topicId": 1,
-                                            "topicName": "가볍 목업, 유사 목업",
-                                            "summarizedOpinions": [
-                                              "실제적인 것에 찾기 과정이 없어 학습해야 고려할 때마다 알도다",
-                                              "데미안이라는 인물이 실존하는지, 아니면 내면의 동일시인 때문에 찾아 온미팅다",
-                                              "아브락시스 과잉이 실제 역에 아브발달 남아되는 결과적 때시대를 안정한다"
-                                            ],
-                                            "comments": [
-                                              {
-                                                "meetingRetrospectiveId": 1,
-                                                "userId": 1,
-                                                "nickname": "사용자1",
-                                                "profileImageUrl": "https://...",
-                                                "comment": "모임 하기전엔 이랬는데, 누구의 이런 발을 듣고 이렇게 생각이 바뀌었다.",
-                                                "createdAt": "2026-01-15T15:30:00"
-                                              },
-                                              {
-                                                "meetingRetrospectiveId": 2,
-                                                "userId": 2,
-                                                "nickname": "사용자2",
-                                                "profileImageUrl": "https://...",
-                                                "comment": "모임 하기전엔 이랬는데, 누구의 이런 발을 듣고 이렇게 생각이 바뀌었다.",
-                                                "createdAt": "2026-01-15T15:35:00"
-                                              }
-                                            ]
-                                          },
-                                          {
-                                            "topicId": 2,
-                                            "topicName": "신과 악",
-                                            "summarizedOpinions": [
-                                              "세가 앞에서 나으는 일만은 자연의 언성을 실질적는 감정전 아이라",
-                                              "발과 어둠의 세계가 대조적으로 묘사되며 갈등을 고조한다다"
-                                            ],
-                                            "comments": [
-                                              {
-                                                "meetingRetrospectiveId": 3,
-                                                "userId": 1,
-                                                "nickname": "사용자1",
-                                                "profileImageUrl": "https://...",
-                                                "comment": "또 다른 의견 내용",
-                                                "createdAt": "2026-01-15T15:40:00"
-                                              }
-                                            ]
-                                          }
-                                        ]
-                                      }
-                                    }
-                                    """)
+                            examples = @ExampleObject(value = """                                                                                                                
+                                      {                                                                                                                                            
+                                        "code": "SUCCESS",                                                                                                                         
+                                        "message": "공동 회고 조회 성공",                                                                                                          
+                                        "data": {                                                                                                                                  
+                                          "meetingId": 1,                                                                                                                          
+                                          "meetingName": "데미안을 읽어보아요",                                                                                                    
+                                          "meetingDate": "2026-01-15",                                                                                                             
+                                          "meetingTime": "19:00-20:00",                                                                                                            
+                                          "topics": [                                                                                                                              
+                                            {                                                                                                                                      
+                                              "topicId": 1,                                                                                                                        
+                                              "topicTitle": "가짜 욕망, 유사 욕망",                                                                                                
+                                              "topicDescription": "가짜욕망, 유사욕망에 대해 이야기해봅시다.",                                                                     
+                                              "summary": "참여자들은 『데미안』 속 싱클레어가 느꼈던 혼란을 자신들의 경험과 연결하며...",                                          
+                                              "keyPoint": "1) 사회가 만든 욕망의 구조...",                                                                                         
+                                              "comments": [                                                                                                                        
+                                                {                                                                                                                                  
+                                                  "meetingRetrospectiveId": 1,                                                                                                     
+                                                  "userId": 1,                                                                                                                     
+                                                  "nickname": "사용자1",                                                                                                           
+                                                  "profileImageUrl": "https://example.com/profile.jpg",                                                                            
+                                                  "comment": "모임 하기전엔 이랬는데, 누구의 이런 말을 듣고 이렇게 생각이 바뀌었다.",                                              
+                                                  "createdAt": "2026-01-15T15:30:00"                                                                                               
+                                                }                                                                                                                                  
+                                              ]                                                                                                                                    
+                                            },                                                                                                                                     
+                                            {                                                                                                                                      
+                                              "topicId": 2,                                                                                                                        
+                                              "topicTitle": "선과 악",                                                                                                             
+                                              "topicDescription": "인간의 세계에서 선과 악 어느 것이 힘이 더 셀까",                                                                
+                                              "summary": "선과 악 중 어느 쪽이 더 강한지를 묻기보다...",                                                                           
+                                              "keyPoint": "악이 더 강해보이는 이유",                                                                                               
+                                              "comments": []                                                                                                                       
+                                            }                                                                                                                                      
+                                          ]                                                                                                                                        
+                                        }                                                                                                                                          
+                                      }                                                                                                                                            
+                                      """)
                     )
             ),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "접근 권한 없음",
@@ -138,9 +118,20 @@ public interface MeetingRetrospectiveApi {
                     description = "공동 회고 작성 완료",
                     content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
                             schema = @Schema(implementation = MeetingRetrospectiveResponse.CommentResponse.class),
-                            examples = @ExampleObject(value = """
-                                    {"code": "CREATED", "message": "공동 회고 작성 완료", "data": {"meetingRetrospectiveId": 1, "userId": 1, "nickname": "독서왕", "profileImageUrl": "https://example.com/profile.jpg", "comment": "좋았습니다.", "createdAt": "2025-02-01T16:30:00"}}
-                                    """)
+                            examples = @ExampleObject(value = """                                                                                                                
+                                      {                                                                                                                                            
+                                        "code": "CREATED",                                                                                                                         
+                                        "message": "공동 회고 작성 완료",                                                                                                          
+                                        "data": {                                                                                                                                  
+                                          "meetingRetrospectiveId": 1,                                                                                                             
+                                          "userId": 1,                                                                                                                             
+                                          "nickname": "독서왕",                                                                                                                    
+                                          "profileImageUrl": "https://example.com/profile.jpg",                                                                                    
+                                          "comment": "좋았습니다.",                                                                                                                
+                                          "createdAt": "2025-02-01T16:30:00"                                                                                                       
+                                        }                                                                                                                                          
+                                      }                                                                                                                                            
+                                      """)
                     )
             ),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청",

--- a/src/main/java/com/dokdok/retrospective/api/RetrospectiveSummaryApi.java
+++ b/src/main/java/com/dokdok/retrospective/api/RetrospectiveSummaryApi.java
@@ -1,0 +1,153 @@
+package com.dokdok.retrospective.api;
+
+import com.dokdok.global.response.ApiResponse;
+import com.dokdok.retrospective.dto.request.RetrospectiveSummaryUpdateRequest;
+import com.dokdok.retrospective.dto.response.RetrospectiveSummaryResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Tag(name = "AI 요약", description = "AI 요약 관련 API")
+public interface RetrospectiveSummaryApi {
+
+    @Operation(
+            summary = "AI 요약 조회 (developer: 오주현)",
+            description = """                                                                                                                                                    
+                      약속에 대한 AI 요약을 조회합니다.
+                      - 권한: 모임장, 약속장, 약속 참여자
+                      - 제약: 약속에 참여한 사용자만 조회 가능
+                      """,
+            parameters = {
+                    @Parameter(name = "meetingId", description = "약속 식별자", in = ParameterIn.PATH, required = true)
+            }
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "AI 요약 조회 성공",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = RetrospectiveSummaryResponse.class),
+                            examples = @ExampleObject(value = """                                                                                                                
+                                      {
+                                        "code": "SUCCESS",
+                                        "message": "AI 요약 조회 성공",
+                                        "data": {
+                                          "meetingId": 1,
+                                          "topics": [
+                                            {
+                                              "topicId": 1,
+                                              "topicTitle": "가짜 욕망, 유사 욕망",
+                                              "topicDescription": "가짜욕망, 유사욕망에 대해 이야기해봅시다.",
+                                              "summary": "참여자들은 『데미안』 속 싱클레어가 느꼈던 혼란을 자신들의 경험과 연결하며...",
+                                              "keyPoint": "1) 사회가 만든 욕망의 구조..."
+                                            },
+                                            {
+                                              "topicId": 2,
+                                              "topicTitle": "선과 악",
+                                              "topicDescription": "인간의 세계에서 선과 악 어느 것이 힘이 더 셀까",
+                                              "summary": "선과 악 중 어느 쪽이 더 강한지를 묻기보다...",
+                                              "keyPoint": "악이 더 강해보이는 이유"
+                                            }
+                                          ]
+                                        }
+                                      }
+                                      """)
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "접근 권한 없음",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(value = """                                                                                                                
+                                      {"code": "R105", "message": "회고에 접근할 권한이 없습니다.", "data": null}
+                                      """))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "약속을 찾을 수 없음",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(value = """                                                                                                                
+                                      {"code": "M001", "message": "약속을 찾을 수 없습니다.", "data": null}
+                                      """))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 오류",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(value = """                                                                                                                
+                                      {"code": "E000", "message": "서버 에러가 발생했습니다. 담당자에게 문의 바랍니다.", "data": null}
+                                      """)))
+    })
+    @GetMapping(produces = MediaType.APPLICATION_JSON_VALUE)
+    ResponseEntity<ApiResponse<RetrospectiveSummaryResponse>> getRetrospectiveSummary(
+            @PathVariable Long meetingId
+    );
+
+    @Operation(
+            summary = "AI 요약 수정 (developer: 오주현)",
+            description = """                                                                                                                                                    
+                      약속에 대한 AI 요약을 수정합니다.
+                      - 권한: 모임장, 약속장
+                      - 제약: 모임장 또는 약속장만 수정 가능
+                      """,
+            parameters = {
+                    @Parameter(name = "meetingId", description = "약속 식별자", in = ParameterIn.PATH, required = true)
+            }
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "AI 요약 수정 성공",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = RetrospectiveSummaryResponse.class),
+                            examples = @ExampleObject(value = """                                                                                                                
+                                      {
+                                        "code": "SUCCESS",
+                                        "message": "AI 요약 수정 성공",
+                                        "data": {
+                                          "meetingId": 1,                                                                                                                          
+                                          "topics": [                                                                                                                              
+                                            {                                                                                                                                      
+                                              "topicId": 1,                                                                                                                        
+                                              "topicTitle": "가짜 욕망, 유사 욕망",                                                                                                
+                                              "topicDescription": "가짜욕망, 유사욕망에 대해 이야기해봅시다.",                                                                     
+                                              "summary": "수정된 핵심 요약...",                                                                                                    
+                                              "keyPoint": "수정된 주요 포인트..."                                                                                                  
+                                            }                                                                                                                                      
+                                          ]                                                                                                                                        
+                                        }                                                                                                                                          
+                                      }                                                                                                                                            
+                                      """)
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(value = """                                                                                                                
+                                      {"code": "G002", "message": "입력값이 올바르지 않습니다.", "data": null}
+                                      """))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "접근 권한 없음",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(value = """                                                                                                                
+                                      {"code": "R105", "message": "회고에 접근할 권한이 없습니다.", "data": null}
+                                      """))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "약속 또는 AI 요약을 찾을 수 없음",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(value = """                                                                                                                
+                                      {"code": "R106", "message": "AI 요약을 찾을 수 없습니다.", "data": null}
+                                      """))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 오류",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(value = """                                                                                                                
+                                      {"code": "E000", "message": "서버 에러가 발생했습니다. 담당자에게 문의 바랍니다.", "data": null}
+                                      """)))
+    })
+    @PatchMapping(consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
+    ResponseEntity<ApiResponse<RetrospectiveSummaryResponse>> updateRetrospectiveSummary(
+            @PathVariable Long meetingId,
+            @Valid @RequestBody RetrospectiveSummaryUpdateRequest request
+    );
+}

--- a/src/main/java/com/dokdok/retrospective/controller/RetrospectiveSummaryController.java
+++ b/src/main/java/com/dokdok/retrospective/controller/RetrospectiveSummaryController.java
@@ -1,0 +1,41 @@
+package com.dokdok.retrospective.controller;
+
+import com.dokdok.global.response.ApiResponse;
+import com.dokdok.retrospective.api.RetrospectiveSummaryApi;
+import com.dokdok.retrospective.dto.request.RetrospectiveSummaryUpdateRequest;
+import com.dokdok.retrospective.dto.response.RetrospectiveSummaryResponse;
+import com.dokdok.retrospective.service.RetrospectiveSummaryService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/meetings/{meetingId}/retrospectives/summary")
+public class RetrospectiveSummaryController implements RetrospectiveSummaryApi {
+
+    private final RetrospectiveSummaryService retrospectiveSummaryService;
+
+    @Override
+    @GetMapping
+    public ResponseEntity<ApiResponse<RetrospectiveSummaryResponse>> getRetrospectiveSummary(
+            @PathVariable Long meetingId
+    ) {
+        RetrospectiveSummaryResponse response = retrospectiveSummaryService.getRetrospectiveSummary(meetingId);
+
+        return ApiResponse.success(response, "AI 요약 조회 성공");
+    }
+
+    @Override
+    @PatchMapping
+    public ResponseEntity<ApiResponse<RetrospectiveSummaryResponse>> updateRetrospectiveSummary(
+            @PathVariable Long meetingId,
+            @Valid @RequestBody RetrospectiveSummaryUpdateRequest request
+    ) {
+        RetrospectiveSummaryResponse response = retrospectiveSummaryService.updateRetrospectiveSummary(meetingId, request);
+
+        return ApiResponse.success(response, "AI 요약 수정 성공");
+    }
+}

--- a/src/main/java/com/dokdok/retrospective/dto/request/RetrospectiveSummaryUpdateRequest.java
+++ b/src/main/java/com/dokdok/retrospective/dto/request/RetrospectiveSummaryUpdateRequest.java
@@ -1,0 +1,35 @@
+package com.dokdok.retrospective.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+
+import java.util.List;
+
+@Schema(description = "AI 요약 수정 요청")
+@Builder
+public record RetrospectiveSummaryUpdateRequest(
+        @Schema(description = "수정할 토픽 목록")
+        @NotEmpty(message = "수정할 토픽 목록은 필수입니다.")
+        @Valid
+        List<TopicSummaryUpdateRequest> topics
+) {
+    @Schema(description = "토픽별 수정 요청")
+    @Builder
+    public record TopicSummaryUpdateRequest(
+            @Schema(description = "토픽 ID", example = "1")
+            @NotNull(message = "토픽 ID는 필수입니다.")
+            Long topicId,
+
+            @Schema(description = "핵심 요약", example = "수정된 핵심 요약...")
+            @NotBlank(message = "핵심 요약은 필수입니다.")
+            String summary,
+
+            @Schema(description = "주요 포인트", example = "수정된 주요 포인트...")
+            @NotBlank(message = "주요 포인트는 필수입니다.")
+            String keyPoint
+    ){}
+}

--- a/src/main/java/com/dokdok/retrospective/dto/response/MeetingRetrospectiveResponse.java
+++ b/src/main/java/com/dokdok/retrospective/dto/response/MeetingRetrospectiveResponse.java
@@ -44,9 +44,11 @@ public record MeetingRetrospectiveResponse(
             @Schema(description = "주제 ID", example = "1")
             Long topicId,
             @Schema(description = "주제 제목", example = "가짜 욕망, 유사 욕망에 대해 이야기해봅시다.")
-            String topicName,
-            @Schema(description = "요약된 의견 목록", example = "[\"의견1\", \"의견2\"]")
-            List<String> summarizedOpinions,
+            String topicTitle,
+            @Schema(description = "핵심 요약", example = "참여자들은 『데미안』 속 싱클레어가...")
+            String summary,
+            @Schema(description = "주요 포인트", example = "1) 사회가 만든 욕망의 구조...")
+            String keyPoint,
             @Schema(description = "코멘트 목록")
             List<CommentResponse> comments
     ){
@@ -57,8 +59,9 @@ public record MeetingRetrospectiveResponse(
         ) {
             return TopicResponse.builder()
                     .topicId(topic.getId())
-                    .topicName(topic.getTitle())
-                    .summarizedOpinions(summary.getSummarizedOpinions())
+                    .topicTitle(topic.getTitle())
+                    .summary(summary != null ? summary.getSummary() : null)
+                    .keyPoint(summary != null ? summary.getKeyPoint() : null)
                     .comments(comments)
                     .build();
         }

--- a/src/main/java/com/dokdok/retrospective/dto/response/RetrospectiveSummaryResponse.java
+++ b/src/main/java/com/dokdok/retrospective/dto/response/RetrospectiveSummaryResponse.java
@@ -1,0 +1,54 @@
+package com.dokdok.retrospective.dto.response;
+
+import com.dokdok.retrospective.entity.TopicRetrospectiveSummary;
+import com.dokdok.topic.entity.Topic;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+import java.util.List;
+
+@Schema(description = "AI 요약 조회 응답")
+@Builder
+public record RetrospectiveSummaryResponse(
+        @Schema(description = "약속 ID", example = "1")
+        Long meetingId,
+
+        @Schema(description = "토픽 목록")
+        List<TopicSummaryResponse> topics
+) {
+    public static RetrospectiveSummaryResponse from(Long meetingId, List<TopicSummaryResponse> topics) {
+        return RetrospectiveSummaryResponse.builder()
+                .meetingId(meetingId)
+                .topics(topics)
+                .build();
+    }
+
+    @Schema(description = "토픽별 AI 요약")
+    @Builder
+    public record TopicSummaryResponse(
+            @Schema(description = "토픽 ID", example = "1")
+            Long topicId,
+
+            @Schema(description = "토픽 제목", example = "가짜 욕망, 유사 욕망")
+            String topicTitle,
+
+            @Schema(description = "토픽 설명", example = "가짜욕망, 유사욕망에 대해 이야기해봅시다.")
+            String topicDescription,
+
+            @Schema(description = "핵심 요약", example = "참여자들은 『데미안』 속 싱클레어가...")
+            String summary,
+
+            @Schema(description = "주요 포인트", example = "1) 사회가 만든 욕망의 구조...")
+            String keyPoint
+    ) {
+        public static TopicSummaryResponse from(Topic topic, TopicRetrospectiveSummary summary) {
+            return TopicSummaryResponse.builder()
+                    .topicId(topic.getId())
+                    .topicTitle(topic.getTitle())
+                    .topicDescription(topic.getDescription())
+                    .summary(summary != null ? summary.getSummary() : null)
+                    .keyPoint(summary != null ? summary.getKeyPoint() : null)
+                    .build();
+        }
+    }
+}

--- a/src/main/java/com/dokdok/retrospective/entity/TopicRetrospectiveSummary.java
+++ b/src/main/java/com/dokdok/retrospective/entity/TopicRetrospectiveSummary.java
@@ -35,7 +35,14 @@ public class TopicRetrospectiveSummary extends BaseTimeEntity {
     @JoinColumn(name = "topic_id")
     private Topic topic;
 
-    @JdbcTypeCode(SqlTypes.JSON)
-    @Column(name = "summarized_opinions", columnDefinition = "jsonb")
-    private List<String> summarizedOpinions;
+    @Column(name = "summary", columnDefinition = "TEXT")
+    private String summary;
+
+    @Column(name = "key_point", columnDefinition = "TEXT")
+    private String keyPoint;
+
+    public void update(String summary, String keyPoint) {
+        this.summary = summary;
+        this.keyPoint = keyPoint;
+    }
 }

--- a/src/main/java/com/dokdok/retrospective/exception/RetrospectiveErrorCode.java
+++ b/src/main/java/com/dokdok/retrospective/exception/RetrospectiveErrorCode.java
@@ -13,7 +13,8 @@ public enum RetrospectiveErrorCode implements BaseErrorCode {
     RETROSPECTIVE_NOT_FOUND("R102", "회고를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
     MEETING_RETROSPECTIVE_NOT_FOUND("R103", "공동 회고 내용을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
     RETROSPECTIVE_ALREADY_DELETED("R104", "이미 삭제된 개인 회고입니다.", HttpStatus.NOT_FOUND),
-    NO_ACCESS_RETROSPECTIVE("R105", "회고에 접근할 권한이 없습니다.", HttpStatus.FORBIDDEN);
+    NO_ACCESS_RETROSPECTIVE("R105", "회고에 접근할 권한이 없습니다.", HttpStatus.FORBIDDEN),
+    SUMMARY_NOT_FOUND("R106", "AI 요약을 찾을 수 없습니다.", HttpStatus.NOT_FOUND);
 
     private final String code;
     private final String message;

--- a/src/main/java/com/dokdok/retrospective/repository/TopicRetrospectiveSummaryRepository.java
+++ b/src/main/java/com/dokdok/retrospective/repository/TopicRetrospectiveSummaryRepository.java
@@ -13,4 +13,5 @@ public interface TopicRetrospectiveSummaryRepository extends JpaRepository<Topic
 
     List<TopicRetrospectiveSummary> findAllByTopicIdIn(Collection<Long> topicIds);
 
+    Optional<TopicRetrospectiveSummary> findByTopicId(Long topicId);
 }

--- a/src/main/java/com/dokdok/retrospective/service/RetrospectiveSummaryService.java
+++ b/src/main/java/com/dokdok/retrospective/service/RetrospectiveSummaryService.java
@@ -1,0 +1,95 @@
+package com.dokdok.retrospective.service;
+
+import com.dokdok.global.util.SecurityUtil;
+import com.dokdok.meeting.entity.Meeting;
+import com.dokdok.meeting.service.MeetingValidator;
+import com.dokdok.retrospective.dto.request.RetrospectiveSummaryUpdateRequest;
+import com.dokdok.retrospective.dto.response.RetrospectiveSummaryResponse;
+import com.dokdok.retrospective.entity.TopicRetrospectiveSummary;
+import com.dokdok.retrospective.exception.RetrospectiveErrorCode;
+import com.dokdok.retrospective.exception.RetrospectiveException;
+import com.dokdok.retrospective.repository.TopicRetrospectiveSummaryRepository;
+import com.dokdok.topic.entity.Topic;
+import com.dokdok.topic.entity.TopicStatus;
+import com.dokdok.topic.repository.TopicRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class RetrospectiveSummaryService {
+
+    private final TopicRepository topicRepository;
+    private final TopicRetrospectiveSummaryRepository topicRetrospectiveSummaryRepository;
+    private final MeetingValidator meetingValidator;
+    private final RetrospectiveValidator retrospectiveValidator;
+
+    public RetrospectiveSummaryResponse getRetrospectiveSummary(Long meetingId) {
+        Long userId = SecurityUtil.getCurrentUserId();
+
+        Meeting meeting = meetingValidator.findMeetingOrThrow(meetingId);
+
+        retrospectiveValidator.validateMeetingRetrospectiveAccess(meeting.getGathering().getId(), meetingId, userId);
+
+        // 확정된 토픽 조회
+        List<Topic> topics = topicRepository.findByMeetingIdAndTopicStatusOrderByConfirmOrderAsc(
+                meetingId,
+                TopicStatus.CONFIRMED
+        );
+
+        // 토픽별 요약 조회
+        List<Long> topicIds = topics.stream()
+                .map(Topic::getId)
+                .toList();
+
+        Map<Long, TopicRetrospectiveSummary> summaryMap = topicRetrospectiveSummaryRepository
+                .findAllByTopicIdIn(topicIds)
+                .stream()
+                .collect(Collectors.toMap(s -> s.getTopic().getId(), s-> s));
+
+        // Response 생성
+        List<RetrospectiveSummaryResponse.TopicSummaryResponse> topicResponses = topics.stream()
+                .map(topic -> RetrospectiveSummaryResponse.TopicSummaryResponse.from(
+                        topic,
+                        summaryMap.get(topic.getId())
+                ))
+                .toList();
+
+        return RetrospectiveSummaryResponse.from(meetingId, topicResponses);
+    }
+
+    @Transactional
+    public RetrospectiveSummaryResponse updateRetrospectiveSummary(
+            Long meetingId,
+            RetrospectiveSummaryUpdateRequest request
+    ) {
+        Long userId = SecurityUtil.getCurrentUserId();
+
+        Meeting meeting = meetingValidator.findMeetingOrThrow(meetingId);
+
+        // 권한 검증 (모임장/약속장만 수정 가능)
+        retrospectiveValidator.validateSummaryUpdatePermission(
+                meeting.getGathering().getId(),
+                meetingId,
+                userId
+        );
+
+        // 각 토픽별 요약 수정
+        for (RetrospectiveSummaryUpdateRequest.TopicSummaryUpdateRequest topicRequest : request.topics()) {
+            TopicRetrospectiveSummary summary = topicRetrospectiveSummaryRepository
+                    .findByTopicId(topicRequest.topicId())
+                    .orElseThrow(() -> new RetrospectiveException(RetrospectiveErrorCode.SUMMARY_NOT_FOUND));
+
+            summary.update(topicRequest.summary(), topicRequest.keyPoint());
+        }
+
+        // 수정된 결과 반환
+        return getRetrospectiveSummary(meetingId);
+    }
+}

--- a/src/main/java/com/dokdok/retrospective/service/RetrospectiveValidator.java
+++ b/src/main/java/com/dokdok/retrospective/service/RetrospectiveValidator.java
@@ -89,4 +89,22 @@ public class RetrospectiveValidator {
 
         return retrospectives;
     }
+
+    public void validateSummaryUpdatePermission(Long gatheringId, Long meetingId, Long userId) {
+        meetingValidator.validateMeetingInGathering(meetingId, gatheringId);
+
+        // 약속장인지 확인
+        boolean isMeetingLeader = meetingValidator.isMeetingLeader(meetingId, userId);
+        if (isMeetingLeader) {
+            return;
+        }
+
+        // 모임장인지 확인
+        GatheringMember member = gatheringMemberRepository.findByGatheringIdAndUserId(gatheringId, userId)
+                .orElseThrow(() -> new RetrospectiveException(RetrospectiveErrorCode.NO_ACCESS_RETROSPECTIVE));
+
+        if (member.getRole() != GatheringRole.LEADER) {
+            throw new RetrospectiveException(RetrospectiveErrorCode.NO_ACCESS_RETROSPECTIVE);
+        }
+    }
 }

--- a/src/test/java/com/dokdok/retrospective/service/MeetingRetrospectiveServiceTest.java
+++ b/src/test/java/com/dokdok/retrospective/service/MeetingRetrospectiveServiceTest.java
@@ -43,9 +43,6 @@ import static org.mockito.Mockito.*;
 class MeetingRetrospectiveServiceTest {
 
 	@Mock
-	private MeetingRepository meetingRepository;
-
-	@Mock
 	private TopicRepository topicRepository;
 
 	@Mock
@@ -183,7 +180,8 @@ class MeetingRetrospectiveServiceTest {
 		TopicRetrospectiveSummary summary = TopicRetrospectiveSummary.builder()
 				.id(1L)
 				.topic(topic)
-				.summarizedOpinions(List.of("요약1"))
+				.summary("요약1")
+				.keyPoint("핵심 포인트")
 				.build();
 
 		try (MockedStatic<SecurityUtil> securityUtilMock = mockStatic(SecurityUtil.class)) {
@@ -199,7 +197,8 @@ class MeetingRetrospectiveServiceTest {
 			MeetingRetrospectiveResponse response = meetingRetrospectiveService.getMeetingRetrospective(meetingId);
 
 			assertThat(response.topics()).hasSize(1);
-			assertThat(response.topics().get(0).summarizedOpinions()).containsExactly("요약1");
+			assertThat(response.topics().get(0).summary()).isEqualTo("요약1");
+			assertThat(response.topics().get(0).keyPoint()).isEqualTo("핵심 포인트");
 			assertThat(response.topics().get(0).comments()).isEmpty();
 		}
 	}

--- a/src/test/java/com/dokdok/retrospective/service/RetrospectiveSummaryServiceTest.java
+++ b/src/test/java/com/dokdok/retrospective/service/RetrospectiveSummaryServiceTest.java
@@ -1,0 +1,138 @@
+package com.dokdok.retrospective.service;
+
+import com.dokdok.gathering.entity.Gathering;
+import com.dokdok.global.util.SecurityUtil;
+import com.dokdok.meeting.entity.Meeting;
+import com.dokdok.meeting.service.MeetingValidator;
+import com.dokdok.retrospective.dto.request.RetrospectiveSummaryUpdateRequest;
+import com.dokdok.retrospective.dto.response.RetrospectiveSummaryResponse;
+import com.dokdok.retrospective.entity.TopicRetrospectiveSummary;
+import com.dokdok.retrospective.repository.TopicRetrospectiveSummaryRepository;
+import com.dokdok.topic.entity.Topic;
+import com.dokdok.topic.entity.TopicStatus;
+import com.dokdok.topic.repository.TopicRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class RetrospectiveSummaryServiceTest {
+
+    @Mock
+    private TopicRepository topicRepository;
+
+    @Mock
+    private TopicRetrospectiveSummaryRepository topicRetrospectiveSummaryRepository;
+
+    @Mock
+    private MeetingValidator meetingValidator;
+
+    @Mock
+    private RetrospectiveValidator retrospectiveValidator;
+
+    @InjectMocks
+    private RetrospectiveSummaryService retrospectiveSummaryService;
+
+    private Long meetingId;
+    private Long userId;
+    private Long gatheringId;
+    private Meeting meeting;
+    private Topic topic;
+    private TopicRetrospectiveSummary summary;
+
+    @BeforeEach
+    void setUp() {
+        meetingId = 1L;
+        userId = 1L;
+        gatheringId = 1L;
+
+        Gathering gathering = Gathering.builder().id(gatheringId).build();
+        meeting = Meeting.builder().id(meetingId).gathering(gathering).build();
+        topic = Topic.builder()
+                .id(10L)
+                .meeting(meeting)
+                .title("토픽 제목")
+                .description("토픽 설명")
+                .topicStatus(TopicStatus.CONFIRMED)
+                .build();
+        summary = TopicRetrospectiveSummary.builder()
+                .id(100L)
+                .topic(topic)
+                .summary("기존 요약")
+                .keyPoint("기존 포인트")
+                .build();
+    }
+
+    @Test
+    @DisplayName("AI 요약 조회 시 토픽과 요약이 매핑되어 반환된다")
+    void getRetrospectiveSummary_returnsMappedSummary() {
+        try (MockedStatic<SecurityUtil> securityUtilMock = mockStatic(SecurityUtil.class)) {
+            securityUtilMock.when(SecurityUtil::getCurrentUserId).thenReturn(userId);
+
+            when(meetingValidator.findMeetingOrThrow(meetingId)).thenReturn(meeting);
+            doNothing().when(retrospectiveValidator)
+                    .validateMeetingRetrospectiveAccess(gatheringId, meetingId, userId);
+            when(topicRepository.findByMeetingIdAndTopicStatusOrderByConfirmOrderAsc(meetingId, TopicStatus.CONFIRMED))
+                    .thenReturn(List.of(topic));
+            when(topicRetrospectiveSummaryRepository.findAllByTopicIdIn(List.of(topic.getId())))
+                    .thenReturn(List.of(summary));
+
+            RetrospectiveSummaryResponse response = retrospectiveSummaryService.getRetrospectiveSummary(meetingId);
+
+            assertThat(response.meetingId()).isEqualTo(meetingId);
+            assertThat(response.topics()).hasSize(1);
+            assertThat(response.topics().get(0).topicId()).isEqualTo(topic.getId());
+            assertThat(response.topics().get(0).summary()).isEqualTo("기존 요약");
+            assertThat(response.topics().get(0).keyPoint()).isEqualTo("기존 포인트");
+        }
+    }
+
+    @Test
+    @DisplayName("AI 요약 수정 시 요약이 갱신되고 결과를 반환한다")
+    void updateRetrospectiveSummary_updatesSummaryAndReturns() {
+        RetrospectiveSummaryUpdateRequest request = RetrospectiveSummaryUpdateRequest.builder()
+                .topics(List.of(RetrospectiveSummaryUpdateRequest.TopicSummaryUpdateRequest.builder()
+                        .topicId(topic.getId())
+                        .summary("수정 요약")
+                        .keyPoint("수정 포인트")
+                        .build()))
+                .build();
+
+        try (MockedStatic<SecurityUtil> securityUtilMock = mockStatic(SecurityUtil.class)) {
+            securityUtilMock.when(SecurityUtil::getCurrentUserId).thenReturn(userId);
+
+            when(meetingValidator.findMeetingOrThrow(meetingId)).thenReturn(meeting);
+            doNothing().when(retrospectiveValidator)
+                    .validateSummaryUpdatePermission(gatheringId, meetingId, userId);
+            when(topicRetrospectiveSummaryRepository.findByTopicId(topic.getId()))
+                    .thenReturn(Optional.of(summary));
+            when(topicRepository.findByMeetingIdAndTopicStatusOrderByConfirmOrderAsc(meetingId, TopicStatus.CONFIRMED))
+                    .thenReturn(List.of(topic));
+            when(topicRetrospectiveSummaryRepository.findAllByTopicIdIn(List.of(topic.getId())))
+                    .thenReturn(List.of(summary));
+
+            RetrospectiveSummaryResponse response =
+                    retrospectiveSummaryService.updateRetrospectiveSummary(meetingId, request);
+
+            assertThat(summary.getSummary()).isEqualTo("수정 요약");
+            assertThat(summary.getKeyPoint()).isEqualTo("수정 포인트");
+            assertThat(response.topics().get(0).summary()).isEqualTo("수정 요약");
+            assertThat(response.topics().get(0).keyPoint()).isEqualTo("수정 포인트");
+            verify(retrospectiveValidator).validateSummaryUpdatePermission(gatheringId, meetingId, userId);
+        }
+    }
+}


### PR DESCRIPTION
## PR 요약
> 이 PR이 어떤 변경을 하는지 간단히 설명하고, 체크 표시는 괄호 사이에 소문자 'x'를 삽입하세요.

- [x] 기능 추가
- [ ] 버그 수정
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 기타 (설명)

---

## 이슈 번호
- #222 

---

## 주요 변경 사항
> 주요 파일, 로직, 컴포넌트 등을 구체적으로 적어주세요.

• - src/main/java/com/dokdok/meeting/service/MeetingValidator.java: 약속장 여부 확인 로직 추가(회고 요약 수정 권한 검증용).
  - src/main/java/com/dokdok/retrospective/api/MeetingRetrospectiveApi.java: 공동 회고 Swagger 응답/문서 정리(응답 DTO 기준으로 표기).
  - src/main/java/com/dokdok/retrospective/api/RetrospectiveSummaryApi.java: 회고 요약 조회/수정 API 스펙 정의.
  - src/main/java/com/dokdok/retrospective/controller/RetrospectiveSummaryController.java: 회고 요약 조회/수정 엔드포인트 구현.
  - src/main/java/com/dokdok/retrospective/dto/request/RetrospectiveSummaryUpdateRequest.java: 요약 수정 요청 DTO 추가.
  - src/main/java/com/dokdok/retrospective/dto/response/MeetingRetrospectiveResponse.java: 요약 응답 필드 구조를 summary/keyPoint 중심으로 변경.
  - src/main/java/com/dokdok/retrospective/dto/response/RetrospectiveSummaryResponse.java: AI 요약 조회 응답 DTO 추가.
  - src/main/java/com/dokdok/retrospective/entity/TopicRetrospectiveSummary.java: 요약 저장 구조를 JSON 리스트 → summary/keyPoint 텍스트로 변경.
  - src/main/java/com/dokdok/retrospective/exception/RetrospectiveErrorCode.java: 요약 관련 에러 코드 추가/정리.
  - src/main/java/com/dokdok/retrospective/repository/TopicRetrospectiveSummaryRepository.java: 요약 조회/수정용 리포지토리 메서드 추가.
  - src/main/java/com/dokdok/retrospective/service/RetrospectiveSummaryService.java: 요약 조회/수정 비즈니스 로직 추가.
  - src/main/java/com/dokdok/retrospective/service/RetrospectiveValidator.java: 요약 접근/수정 권한 검증 로직 추가.
  - src/test/java/com/dokdok/retrospective/service/MeetingRetrospectiveServiceTest.java: 변경된 응답 필드에 맞춰 테스트 보정.
  - src/test/java/com/dokdok/retrospective/service/RetrospectiveSummaryServiceTest.java: 요약 조회/수정 서비스 테스트 신규 추가.

---

## 참고 사항
> 리뷰어가 알아야 할 추가 정보, 테스트 방법 등을 작성해주세요.

예:  
- 테스트 계정 정보  
- 관련 API 엔드포인트  
- 로컬 테스트 방법  

---