### PR TITLE
feat : 모든 응답 스키마 자동 래핑

### DIFF
--- a/src/main/java/com/dokdok/global/config/SwaggerResponseWrapConfig.java
+++ b/src/main/java/com/dokdok/global/config/SwaggerResponseWrapConfig.java
@@ -1,0 +1,114 @@
+package com.dokdok.global.config;
+
+import com.dokdok.global.response.ApiResponse;
+import io.swagger.v3.core.converter.AnnotatedType;
+import io.swagger.v3.core.converter.ModelConverters;
+import io.swagger.v3.core.converter.ResolvedSchema;
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.media.ComposedSchema;
+import io.swagger.v3.oas.models.media.Content;
+import io.swagger.v3.oas.models.media.MediaType;
+import io.swagger.v3.oas.models.media.Schema;
+import org.springdoc.core.customizers.OpenApiCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+@Configuration
+public class SwaggerResponseWrapConfig {
+
+    @Bean
+    public OpenApiCustomizer apiResponseSchemaRegistrar() {
+        return openApi -> {
+            Components components = openApi.getComponents();
+            if (components == null) {
+                components = new Components();
+                openApi.setComponents(components);
+            }
+
+            Map<String, Schema> schemas = components.getSchemas();
+            if (schemas == null) {
+                schemas = new LinkedHashMap<>();
+                components.setSchemas(schemas);
+            }
+
+            ResolvedSchema resolved = ModelConverters.getInstance()
+                    .resolveAsResolvedSchema(new AnnotatedType(ApiResponse.class).resolveAsRef(true));
+
+            if (resolved.referencedSchemas != null) {
+                resolved.referencedSchemas.forEach(schemas::putIfAbsent);
+            }
+
+            Schema<?> apiResponseSchema = resolved.schema;
+            if (apiResponseSchema != null) {
+                if (apiResponseSchema.getName() == null) {
+                    apiResponseSchema.setName("ApiResponse");
+                }
+                schemas.putIfAbsent("ApiResponse", apiResponseSchema);
+            }
+        };
+    }
+
+    @Bean
+    public OpenApiCustomizer wrapApiResponseSchema() {
+        return openApi -> {
+            if (openApi.getPaths() == null) {
+                return;
+            }
+
+            openApi.getPaths().values().forEach(pathItem -> {
+                if (pathItem.readOperations() == null) {
+                    return;
+                }
+
+                pathItem.readOperations().forEach(operation -> {
+                    if (operation.getResponses() == null) {
+                        return;
+                    }
+
+                    operation.getResponses().values().forEach(this::wrapApiResponse);
+                });
+            });
+        };
+    }
+
+    private void wrapApiResponse(io.swagger.v3.oas.models.responses.ApiResponse apiResponse) {
+        Content content = apiResponse.getContent();
+        if (content == null) {
+            return;
+        }
+
+        content.values().forEach(this::wrapMediaTypeSchema);
+    }
+
+    private void wrapMediaTypeSchema(MediaType mediaType) {
+        Schema<?> original = mediaType.getSchema();
+        if (original == null || isApiResponseSchema(original)) {
+            return;
+        }
+
+        ComposedSchema composed = new ComposedSchema();
+        composed.addAllOfItem(new Schema<>().$ref("#/components/schemas/ApiResponse"));
+
+        Schema<?> override = new Schema<>();
+        override.addProperties("data", original);
+
+        composed.addAllOfItem(override);
+        mediaType.setSchema(composed);
+    }
+
+    private boolean isApiResponseSchema(Schema<?> schema) {
+        if (schema.get$ref() != null && schema.get$ref().endsWith("/ApiResponse")) {
+            return true;
+        }
+
+        if (schema instanceof ComposedSchema composed && composed.getAllOf() != null) {
+            return composed.getAllOf().stream()
+                    .anyMatch(s -> s.get$ref() != null && s.get$ref().endsWith("/ApiResponse"));
+        }
+
+        return false;
+    }
+}


### PR DESCRIPTION
## PR 요약
> 이 PR이 어떤 변경을 하는지 간단히 설명하고, 체크 표시는 괄호 사이에 소문자 'x'를 삽입하세요.

- [x] 기능 추가
- [ ] 버그 수정
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 기타 (설명)

---

## 이슈 번호
- #

---

## 주요 변경 사항
> 주요 파일, 로직, 컴포넌트 등을 구체적으로 적어주세요.

  - 스웨거(OpenAPI) 문서를 생성할 때, 모든 응답 스키마를 ApiResponse<실제 DTO> 형태로 자동 래핑해서 보여준다.
  - 기존 각 API에서 정의한 스키마(예: GatheringCreateResponse)는 data 안으로 들어가도록 합성된다.
  - 그래서 스웨거 UI에 code/message/data가 보이고, data 안에 실제 DTO 필드가 펼쳐진다.

  구성 요소별 설명

  1. apiResponseSchemaRegistrar()

  - ApiResponse 클래스를 스웨거 components에 스키마로 등록한다.
  - 이걸 안 하면 #/components/schemas/ApiResponse 참조가 깨질 수 있음.

  2. wrapApiResponseSchema()

  - OpenAPI 문서 전체의 paths → operations → responses를 순회한다.
  - 각 응답의 content에서 schema를 꺼내 감쌀 준비를 한다.

  3. wrapMediaTypeSchema()

  - 원래 스키마(예: GatheringCreateResponse)를 가져온다.
  - 이미 ApiResponse로 감싸져 있으면 건너뛴다.
  - 아니라면 allOf로 합성:
      - ApiResponse 기본 스키마
      - data 속성에 “원래 스키마”를 넣은 덮어쓰기

  4. isApiResponseSchema()

  - 이미 ApiResponse로 감싸진 경우 중복 래핑 방지.

  결과적으로

  - 각 API에서 DTO만 등록해도
  - 스웨거에는 자동으로 ApiResponse<DTO>가 보인다.


---

## 참고 사항
> 리뷰어가 알아야 할 추가 정보, 테스트 방법 등을 작성해주세요.

예:  
- 테스트 계정 정보  
- 관련 API 엔드포인트  
- 로컬 테스트 방법  

---