### PR TITLE
[#235][FEAT] 독서기록에 사전답변 불러오기 api

### DIFF
--- a/src/main/java/com/dokdok/book/api/BookReviewApi.java
+++ b/src/main/java/com/dokdok/book/api/BookReviewApi.java
@@ -43,14 +43,18 @@ public interface BookReviewApi {
                             schema = @Schema(implementation = BookReviewResponse.class),
                             examples = @ExampleObject(value = """
                                     {
-                                      "reviewId": 101,
-                                      "bookId": 12,
-                                      "userId": 5,
-                                      "rating": 4.5,
-                                      "keywords": [
-                                        { "id": 3, "name": "감동" },
-                                        { "id": 7, "name": "몰입" }
-                                      ]
+                                      "code": "CREATED",
+                                      "message": "책 리뷰가 저장되었습니다.",
+                                      "data": {
+                                        "reviewId": 101,
+                                        "bookId": 12,
+                                        "userId": 5,
+                                        "rating": 4.5,
+                                        "keywords": [
+                                          { "id": 3, "name": "판타지", "type": "BOOK" },
+                                          { "id": 7, "name": "몰입", "type": "IMPRESSION" }
+                                        ]
+                                      }
                                     }
                                     """))
             ),
@@ -121,14 +125,18 @@ public interface BookReviewApi {
                             schema = @Schema(implementation = BookReviewResponse.class),
                             examples = @ExampleObject(value = """
                                     {
-                                      "reviewId": 101,
-                                      "bookId": 12,
-                                      "userId": 5,
-                                      "rating": 4.5,
-                                      "keywords": [
-                                        { "id": 3, "name": "감동" },
-                                        { "id": 7, "name": "몰입" }
-                                      ]
+                                      "code": "SUCCESS",
+                                      "message": "책 리뷰 조회가 완료되었습니다.",
+                                      "data": {
+                                        "reviewId": 101,
+                                        "bookId": 12,
+                                        "userId": 5,
+                                        "rating": 4.5,
+                                        "keywords": [
+                                          { "id": 3, "name": "감동", "type": "BOOK" },
+                                          { "id": 7, "name": "몰입", "type": "IMPRESSION" }
+                                        ]
+                                      }
                                     }
                                     """))
             ),
@@ -167,14 +175,18 @@ public interface BookReviewApi {
                             schema = @Schema(implementation = BookReviewResponse.class),
                             examples = @ExampleObject(value = """
                                     {
-                                      "reviewId": 101,
-                                      "bookId": 12,
-                                      "userId": 5,
-                                      "rating": 3.5,
-                                      "keywords": [
-                                        { "id": 5, "name": "희망" },
-                                        { "id": 8, "name": "위로" }
-                                      ]
+                                      "code": "SUCCESS",
+                                      "message": "책 리뷰가 수정되었습니다.",
+                                      "data": {
+                                        "reviewId": 101,
+                                        "bookId": 12,
+                                        "userId": 5,
+                                        "rating": 3.5,
+                                        "keywords": [
+                                          { "id": 5, "name": "희망", "type": "BOOK" },
+                                          { "id": 8, "name": "위로", "type": "IMPRESSION" }
+                                        ]
+                                      }
                                     }
                                     """))
             ),

--- a/src/main/java/com/dokdok/book/api/PersonalBookRecordApi.java
+++ b/src/main/java/com/dokdok/book/api/PersonalBookRecordApi.java
@@ -294,9 +294,32 @@ public interface PersonalBookRecordApi {
                                     }
                                     """))
             ),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 실패 - 로그인이 필요합니다."),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "책 또는 약속을 찾을 수 없음"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 오류")
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 실패 - 로그인이 필요합니다.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(value = """
+                                    {"code": "G102", "message": "인증이 필요합니다.", "data": null}
+                                    """))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "책 또는 약속을 찾을 수 없음",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            examples = {
+                                    @ExampleObject(
+                                            name = "책장에 없는 책",
+                                            value = """
+                                                    {"code": "B003", "message": "책장에 해당 책이 존재하지 않습니다.", "data": null}
+                                                    """
+                                    ),
+                                    @ExampleObject(
+                                            name = "약속 없음",
+                                            value = """
+                                                    {"code": "M001", "message": "약속을 찾을 수 없습니다.", "data": null}
+                                                    """
+                                    )
+                            })),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 오류",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(value = """
+                                    {"code": "E000", "message": "서버 에러가 발생했습니다. 담당자에게 문의 바랍니다.", "data": null}
+                                    """)))
     })
     @GetMapping("/{personalBookId}/records/topic-answer")
     ResponseEntity<ApiResponse<PersonalReadingTopicAnswerResponse>> getMyTopicAnswer(

--- a/src/main/java/com/dokdok/book/api/PersonalBookRecordApi.java
+++ b/src/main/java/com/dokdok/book/api/PersonalBookRecordApi.java
@@ -7,6 +7,7 @@ import com.dokdok.global.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -258,5 +259,48 @@ public interface PersonalBookRecordApi {
             @RequestParam(required = false) Long cursorRecordId,
             @Parameter(description = "한 페이지당 아이템 수", example = "10")
             @RequestParam(required = false) Integer size
+    );
+
+    @Operation(
+            summary = "사전 의견 조회",
+            description = """
+                    독서 기록의 사전 의견 정보를 조회합니다.
+                    - 경로의 personalBookId로 책을 지정합니다.
+                    - 로그인한 사용자 기준으로 본인 사전 의견만 조회됩니다.
+                    """
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "사전 의견 조회 성공",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = PersonalReadingTopicAnswerResponse.class),
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "code": "SUCCESS",
+                                      "message": "사전 의견 조회 성공",
+                                      "data": {
+                                        "type": "PRE_OPINION",
+                                        "gatheringName": "책책책 책을 읽자",
+                                        "sharedAt": "2026-01-05T21:38:00",
+                                        "topics": [
+                                          {
+                                            "topicTitle": "가짜 욕망, 유사 욕망",
+                                            "topicDescription": "가짜 욕망, 유사 욕망에 대해 이야기해봅시다.",
+                                            "answer": "가짜 욕망과 유사 욕망은 비슷해 보이지만 결이 다르다고 느꼈다."
+                                          }
+                                        ]
+                                      }
+                                    }
+                                    """))
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 실패 - 로그인이 필요합니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "책 또는 약속을 찾을 수 없음"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 오류")
+    })
+    @GetMapping("/{personalBookId}/records/topic-answer")
+    ResponseEntity<ApiResponse<PersonalReadingTopicAnswerResponse>> getMyTopicAnswer(
+            @Parameter(description = "개인 책장 ID (personal_book 테이블 PK)", required = true, example = "10")
+            @PathVariable Long personalBookId
     );
 }

--- a/src/main/java/com/dokdok/book/api/PersonalBookRecordApi.java
+++ b/src/main/java/com/dokdok/book/api/PersonalBookRecordApi.java
@@ -262,7 +262,7 @@ public interface PersonalBookRecordApi {
     );
 
     @Operation(
-            summary = "사전 의견 조회",
+            summary = "사전 의견 조회 (developer: 양재웅)",
             description = """
                     독서 기록의 사전 의견 정보를 조회합니다.
                     - 경로의 personalBookId로 책을 지정합니다.

--- a/src/main/java/com/dokdok/book/controller/PersonalBookRecordController.java
+++ b/src/main/java/com/dokdok/book/controller/PersonalBookRecordController.java
@@ -56,4 +56,13 @@ public class PersonalBookRecordController implements PersonalBookRecordApi {
         return ApiResponse.success(response, "기록 조회 성공");
 
     }
+
+    @Override
+    @GetMapping("/{personalBookId}/records/topic-answer")
+    public ResponseEntity<ApiResponse<PersonalReadingTopicAnswerResponse>> getMyTopicAnswer(
+            @PathVariable Long personalBookId
+    ) {
+        PersonalReadingTopicAnswerResponse response = personalReadingRecordService.getTopicAnswers(personalBookId);
+        return ApiResponse.success(response, "사전 의견 조회 성공");
+    }
 }

--- a/src/main/java/com/dokdok/book/dto/response/BookReviewResponse.java
+++ b/src/main/java/com/dokdok/book/dto/response/BookReviewResponse.java
@@ -1,6 +1,7 @@
 package com.dokdok.book.dto.response;
 
 import com.dokdok.book.entity.BookReview;
+import com.dokdok.book.entity.KeywordType;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.math.BigDecimal;
@@ -24,7 +25,8 @@ public record BookReviewResponse(
         List<KeywordInfo> keywordInfos = review.getKeywords().stream()
                 .map(reviewKeyword -> new KeywordInfo(
                         reviewKeyword.getKeyword().getId(),
-                        reviewKeyword.getKeyword().getKeywordName()
+                        reviewKeyword.getKeyword().getKeywordName(),
+                        reviewKeyword.getKeyword().getKeywordType()
                 ))
                 .collect(Collectors.toList());
 
@@ -41,8 +43,10 @@ public record BookReviewResponse(
     public record KeywordInfo(
             @Schema(description = "키워드 ID", example = "3")
             Long id,
-            @Schema(description = "키워드 이름", example = "인상적")
-            String name
+            @Schema(description = "키워드 이름", example = "판타지")
+            String name,
+            @Schema(description = "키워드 타입", example = "BOOK")
+            KeywordType type
     ) {
     }
 }

--- a/src/main/java/com/dokdok/book/dto/response/PersonalReadingTopicAnswerResponse.java
+++ b/src/main/java/com/dokdok/book/dto/response/PersonalReadingTopicAnswerResponse.java
@@ -1,0 +1,29 @@
+package com.dokdok.book.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Schema(description = "사전 의견 조회 응답")
+public record PersonalReadingTopicAnswerResponse(
+        @Schema(description = "응답 타입", example = "PRE_OPINION")
+        String type,
+        @Schema(description = "모임명", example = "책책책 책을 읽자")
+        String gatheringName,
+        @Schema(description = "공유일", example = "2026-01-05T21:38:00")
+        LocalDateTime sharedAt,
+        @Schema(description = "주제 목록")
+        List<TopicAnswerInfo> topics
+) {
+    @Schema(description = "주제별 사전 의견")
+    public record TopicAnswerInfo(
+            @Schema(description = "주제명", example = "가짜 욕망, 유사 욕망")
+            String topicTitle,
+            @Schema(description = "주제 설명", example = "가짜 욕망, 유사 욕망에 대해 이야기해봅시다.")
+            String topicDescription,
+            @Schema(description = "주제 답변", example = "가짜 욕망과 유사 욕망은 비슷해 보이지만 결이 다르다고 느꼈다.")
+            String answer
+    ) {
+    }
+}

--- a/src/main/java/com/dokdok/book/service/PersonalReadingRecordService.java
+++ b/src/main/java/com/dokdok/book/service/PersonalReadingRecordService.java
@@ -1,9 +1,10 @@
 package com.dokdok.book.service;
 
 import com.dokdok.book.dto.request.PersonalReadingRecordCreateRequest;
+import com.dokdok.book.dto.response.CursorPageResponse;
 import com.dokdok.book.dto.response.PersonalReadingRecordCreateResponse;
 import com.dokdok.book.dto.response.PersonalReadingRecordListResponse;
-import com.dokdok.book.dto.response.CursorPageResponse;
+import com.dokdok.book.dto.response.PersonalReadingTopicAnswerResponse;
 import com.dokdok.book.dto.response.ReadingRecordCursor;
 import com.dokdok.book.entity.PersonalBook;
 import com.dokdok.book.entity.PersonalReadingRecord;
@@ -13,6 +14,15 @@ import com.dokdok.book.exception.RecordException;
 import com.dokdok.book.dto.request.PersonalReadingRecordUpdateRequest;
 import com.dokdok.book.repository.PersonalReadingRecordRepository;
 import com.dokdok.global.util.SecurityUtil;
+import com.dokdok.meeting.entity.Meeting;
+import com.dokdok.meeting.entity.MeetingStatus;
+import com.dokdok.meeting.exception.MeetingErrorCode;
+import com.dokdok.meeting.exception.MeetingException;
+import com.dokdok.meeting.repository.MeetingRepository;
+import com.dokdok.topic.entity.Topic;
+import com.dokdok.topic.entity.TopicAnswer;
+import com.dokdok.topic.repository.TopicAnswerRepository;
+import com.dokdok.topic.repository.TopicRepository;
 import com.dokdok.user.entity.User;
 import com.dokdok.user.service.UserValidator;
 import lombok.RequiredArgsConstructor;
@@ -21,10 +31,13 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Comparator;
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -36,6 +49,9 @@ public class PersonalReadingRecordService {
     private final PersonalReadingRecordRepository personalReadingRecordRepository;
     private final UserValidator userValidator;
     private final BookValidator bookValidator;
+    private final MeetingRepository meetingRepository;
+    private final TopicRepository topicRepository;
+    private final TopicAnswerRepository topicAnswerRepository;
 
     @Transactional
     public PersonalReadingRecordCreateResponse create(Long personalBookId, PersonalReadingRecordCreateRequest request) {
@@ -141,6 +157,49 @@ public class PersonalReadingRecordService {
         }
 
         return CursorPageResponse.of(items, pageSize, hasNext, nextCursor);
+    }
+
+    public PersonalReadingTopicAnswerResponse getTopicAnswers(Long personalBookId) {
+        User userEntity = userValidator.findUserOrThrow(SecurityUtil.getCurrentUserId());
+        PersonalBook personalBookEntity = bookValidator.validatePersonalBook(userEntity.getId(), personalBookId);
+
+        if (personalBookEntity.getGathering() == null || personalBookEntity.getBook() == null) {
+            throw new MeetingException(MeetingErrorCode.MEETING_NOT_FOUND);
+        }
+
+        Meeting meeting = meetingRepository
+                .findTopByGatheringIdAndBookIdAndMeetingStatusOrderByMeetingStartDateDescIdDesc(
+                        personalBookEntity.getGathering().getId(),
+                        personalBookEntity.getBook().getId(),
+                        MeetingStatus.CONFIRMED
+                )
+                .orElseThrow(() -> new MeetingException(MeetingErrorCode.MEETING_NOT_FOUND));
+
+        List<Topic> topics = topicRepository.findTopicsInfoByMeetingId(meeting.getId());
+        List<TopicAnswer> topicAnswers = topicAnswerRepository.findByMeetingIdUserId(meeting.getId(), userEntity.getId());
+
+        Map<Long, TopicAnswer> topicAnswerMap = topicAnswers.stream()
+                .collect(Collectors.toMap(ta -> ta.getTopic().getId(), Function.identity()));
+
+        List<PersonalReadingTopicAnswerResponse.TopicAnswerInfo> items = topics.stream()
+                .sorted(Comparator
+                        .comparing(Topic::getConfirmOrder, Comparator.nullsLast(Integer::compareTo))
+                        .thenComparing(Topic::getId))
+                .map(topic -> new PersonalReadingTopicAnswerResponse.TopicAnswerInfo(
+                        topic.getTitle(),
+                        topic.getDescription(),
+                        topicAnswerMap.containsKey(topic.getId())
+                                ? topicAnswerMap.get(topic.getId()).getContent()
+                                : null
+                ))
+                .toList();
+
+        return new PersonalReadingTopicAnswerResponse(
+                "PRE_OPINION",
+                meeting.getGathering().getGatheringName(),
+                meeting.getMeetingStartDate(),
+                items
+        );
     }
 
     private Map<String, Object> normalizeMeta(RecordType recordType, Map<String, Object> meta) {

--- a/src/main/java/com/dokdok/meeting/repository/MeetingRepository.java
+++ b/src/main/java/com/dokdok/meeting/repository/MeetingRepository.java
@@ -12,6 +12,7 @@ import org.springframework.stereotype.Repository;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface MeetingRepository extends JpaRepository<Meeting, Long> {
@@ -95,6 +96,12 @@ public interface MeetingRepository extends JpaRepository<Meeting, Long> {
     // Scheduler용: 종료 시간이 지난 CONFIRMED 상태의 Meeting 조회
     List<Meeting> findByMeetingEndDateBeforeAndMeetingStatus(
             LocalDateTime endDate,
+            MeetingStatus meetingStatus
+    );
+
+    Optional<Meeting> findTopByGatheringIdAndBookIdAndMeetingStatusOrderByMeetingStartDateDescIdDesc(
+            Long gatheringId,
+            Long bookId,
             MeetingStatus meetingStatus
     );
 

--- a/src/main/resources/data/keyword_data.sql
+++ b/src/main/resources/data/keyword_data.sql
@@ -1,46 +1,46 @@
 BEGIN;
 
 WITH parents AS (
-    INSERT INTO keyword (keyword_type, keyword_name, parent_id, level, sort_order, is_selectable, created_at, updated_at)
-        VALUES
-            ('BOOK',    '인간관계',  NULL, 1, 1, false, CURRENT_DATE, CURRENT_DATE),
-            ('BOOK',    '개인',      NULL, 1, 2, false, CURRENT_DATE, CURRENT_DATE),
-            ('BOOK',    '삶과 죽음', NULL, 1, 3, false, CURRENT_DATE, CURRENT_DATE),
-            ('BOOK',    '사회',      NULL, 1, 4, false, CURRENT_DATE, CURRENT_DATE),
-            ('BOOK',    '기타',      NULL, 1, 5, false, CURRENT_DATE, CURRENT_DATE),
-            ('EMOTION', '긍정',      NULL, 1, 1, false, CURRENT_DATE, CURRENT_DATE),
-            ('EMOTION', '감상',      NULL, 1, 2, false, CURRENT_DATE, CURRENT_DATE),
-            ('EMOTION', '부정',      NULL, 1, 3, false, CURRENT_DATE, CURRENT_DATE)
-        RETURNING keyword_id, keyword_name, keyword_type
-),
-     book_children AS (
-         INSERT INTO keyword (keyword_type, keyword_name, parent_id, level, sort_order, is_selectable, created_at, updated_at)
-             SELECT 'BOOK', v.name, p.keyword_id, 2, v.sort_order, true, CURRENT_DATE, CURRENT_DATE
-             FROM (VALUES
-                       ('인간관계','사랑',1), ('인간관계','관계',2), ('인간관계','가족',3), ('인간관계','우정',4), ('인간관계','이별',5),
-                       ('개인','성장',1), ('개인','자아',2), ('개인','고독',3), ('개인','선택',4), ('개인','자유',5),
-                       ('삶과 죽음','삶',1), ('삶과 죽음','죽음',2), ('삶과 죽음','상실',3), ('삶과 죽음','치유',4), ('삶과 죽음','기억',5),
-                       ('사회','사회',1), ('사회','현실',2), ('사회','역사',3), ('사회','노동',4), ('사회','여성',5), ('사회','윤리',6),
-                       ('기타','청춘',1), ('기타','모험',2), ('기타','판타지',3), ('기타','추리',4)
-                  ) AS v(parent_name, name, sort_order)
-                      JOIN parents p
-                           ON p.keyword_name = v.parent_name AND p.keyword_type = 'BOOK'
-     ),
-     emotion_children AS (
-         INSERT INTO keyword (keyword_type, keyword_name, parent_id, level, sort_order, is_selectable, created_at, updated_at)
-             SELECT 'EMOTION', v.name, p.keyword_id, 2, v.sort_order, true, CURRENT_DATE, CURRENT_DATE
-             FROM (VALUES
-                       ('긍정','즐거운',1), ('긍정','감동적인',2), ('긍정','위로받은',3), ('긍정','뭉클한',4), ('긍정','후련한',5),
-                       ('긍정','벅찬',6), ('긍정','안도한',7), ('긍정','희망이 생긴',8), ('긍정','설레는',9), ('긍정','흥미로운',10), ('긍정','빠져든',11),
-                       ('감상','여운이 남는',1), ('감상','먹먹한',2), ('감상','울컥한',3), ('감상','찡한',4),
-                       ('감상','그리운',5), ('감상','익숙한',6), ('감상','이해가 되는',7), ('감상','의문이 남는',8),
-                       ('부정','지루한',1), ('부정','씁쓸한',2), ('부정','허무한',3), ('부정','찝찝한',4),
-                       ('부정','공허한',5), ('부정','서글픈',6), ('부정','분노가 이는',7), ('부정','복잡한',8),
-                       ('부정','허탈한',9), ('부정','불안한',10), ('부정','괴로운',11), ('부정','안타까운',12), ('부정','답답한',13), ('부정','슬픈',14)
-                  ) AS v(parent_name, name, sort_order)
-                      JOIN parents p
-                           ON p.keyword_name = v.parent_name AND p.keyword_type = 'EMOTION'
-     )
+INSERT INTO keyword (keyword_type, keyword_name, parent_id, level, sort_order, is_selectable, created_at, updated_at)
+VALUES
+    ('BOOK',    '인간관계',  NULL, 1, 1, false, CURRENT_DATE, CURRENT_DATE),
+    ('BOOK',    '개인',      NULL, 1, 2, false, CURRENT_DATE, CURRENT_DATE),
+    ('BOOK',    '삶과 죽음', NULL, 1, 3, false, CURRENT_DATE, CURRENT_DATE),
+    ('BOOK',    '사회',      NULL, 1, 4, false, CURRENT_DATE, CURRENT_DATE),
+    ('BOOK',    '기타',      NULL, 1, 5, false, CURRENT_DATE, CURRENT_DATE),
+    ('IMPRESSION', '긍정',      NULL, 1, 1, false, CURRENT_DATE, CURRENT_DATE),
+    ('IMPRESSION', '감상',      NULL, 1, 2, false, CURRENT_DATE, CURRENT_DATE),
+    ('IMPRESSION', '부정',      NULL, 1, 3, false, CURRENT_DATE, CURRENT_DATE)
+    RETURNING keyword_id, keyword_name, keyword_type
+    ),
+    book_children AS (
+INSERT INTO keyword (keyword_type, keyword_name, parent_id, level, sort_order, is_selectable, created_at, updated_at)
+SELECT 'BOOK', v.name, p.keyword_id, 2, v.sort_order, true, CURRENT_DATE, CURRENT_DATE
+FROM (VALUES
+    ('인간관계','사랑',1), ('인간관계','관계',2), ('인간관계','가족',3), ('인간관계','우정',4), ('인간관계','이별',5),
+    ('개인','성장',1), ('개인','자아',2), ('개인','고독',3), ('개인','선택',4), ('개인','자유',5),
+    ('삶과 죽음','삶',1), ('삶과 죽음','죽음',2), ('삶과 죽음','상실',3), ('삶과 죽음','치유',4), ('삶과 죽음','기억',5),
+    ('사회','사회',1), ('사회','현실',2), ('사회','역사',3), ('사회','노동',4), ('사회','여성',5), ('사회','윤리',6),
+    ('기타','청춘',1), ('기타','모험',2), ('기타','판타지',3), ('기타','추리',4)
+    ) AS v(parent_name, name, sort_order)
+    JOIN parents p
+ON p.keyword_name = v.parent_name AND p.keyword_type = 'BOOK'
+    ),
+    impression_children AS (
+INSERT INTO keyword (keyword_type, keyword_name, parent_id, level, sort_order, is_selectable, created_at, updated_at)
+SELECT 'IMPRESSION', v.name, p.keyword_id, 2, v.sort_order, true, CURRENT_DATE, CURRENT_DATE
+FROM (VALUES
+    ('긍정','즐거운',1), ('긍정','감동적인',2), ('긍정','위로받은',3), ('긍정','뭉클한',4), ('긍정','후련한',5),
+    ('긍정','벅찬',6), ('긍정','안도한',7), ('긍정','희망이 생긴',8), ('긍정','설레는',9), ('긍정','흥미로운',10), ('긍정','빠져든',11),
+    ('감상','여운이 남는',1), ('감상','먹먹한',2), ('감상','울컥한',3), ('감상','찡한',4),
+    ('감상','그리운',5), ('감상','익숙한',6), ('감상','이해가 되는',7), ('감상','의문이 남는',8),
+    ('부정','지루한',1), ('부정','씁쓸한',2), ('부정','허무한',3), ('부정','찝찝한',4),
+    ('부정','공허한',5), ('부정','서글픈',6), ('부정','분노가 이는',7), ('부정','복잡한',8),
+    ('부정','허탈한',9), ('부정','불안한',10), ('부정','괴로운',11), ('부정','안타까운',12), ('부정','답답한',13), ('부정','슬픈',14)
+    ) AS v(parent_name, name, sort_order)
+    JOIN parents p
+ON p.keyword_name = v.parent_name AND p.keyword_type = 'IMPRESSION'
+    )
 SELECT 1;
 
 COMMIT;

--- a/src/test/java/com/dokdok/book/service/BookReviewServiceTest.java
+++ b/src/test/java/com/dokdok/book/service/BookReviewServiceTest.java
@@ -5,6 +5,7 @@ import com.dokdok.book.dto.response.BookReviewResponse;
 import com.dokdok.book.entity.Book;
 import com.dokdok.book.entity.BookReview;
 import com.dokdok.book.entity.BookReviewKeyword;
+import com.dokdok.book.entity.KeywordType;
 import com.dokdok.book.exception.BookErrorCode;
 import com.dokdok.book.exception.BookException;
 import com.dokdok.book.repository.BookReviewRepository;
@@ -53,8 +54,8 @@ class BookReviewServiceTest {
     @DisplayName("책 리뷰를 정상적으로 생성한다")
     void createReview_success() {
         Book book = Book.builder().id(1L).build();
-        Keyword keyword = Keyword.builder().id(2L).keywordName("감동").build();
-        Keyword keywordSecond = Keyword.builder().id(4L).keywordName("몰입").build();
+        Keyword keyword = Keyword.builder().id(2L).keywordName("감동").keywordType(KeywordType.BOOK).build();
+        Keyword keywordSecond = Keyword.builder().id(4L).keywordName("몰입").keywordType(KeywordType.IMPRESSION).build();
         User user = User.builder().id(3L).build();
         BookReviewRequest request = new BookReviewRequest(new BigDecimal("4.5"), List.of(2L, 4L));
 
@@ -86,8 +87,8 @@ class BookReviewServiceTest {
             assertThat(response.userId()).isEqualTo(3L);
             assertThat(response.rating()).isEqualTo(new BigDecimal("4.5"));
             assertThat(response.keywords()).containsExactly(
-                    new BookReviewResponse.KeywordInfo(2L, "감동"),
-                    new BookReviewResponse.KeywordInfo(4L, "몰입")
+                    new BookReviewResponse.KeywordInfo(2L, "감동", KeywordType.BOOK),
+                    new BookReviewResponse.KeywordInfo(4L, "몰입", KeywordType.IMPRESSION)
             );
 
             verify(bookValidator).validateReviewNotExists(1L, 3L);
@@ -206,8 +207,8 @@ class BookReviewServiceTest {
     @DisplayName("내 책 리뷰를 정상적으로 조회한다")
     void getMyReview_success() {
         Book book = Book.builder().id(1L).build();
-        Keyword keyword = Keyword.builder().id(2L).keywordName("감동").build();
-        Keyword keywordSecond = Keyword.builder().id(4L).keywordName("몰입").build();
+        Keyword keyword = Keyword.builder().id(2L).keywordName("감동").keywordType(KeywordType.BOOK).build();
+        Keyword keywordSecond = Keyword.builder().id(4L).keywordName("몰입").keywordType(KeywordType.IMPRESSION).build();
         User user = User.builder().id(3L).build();
         BookReview review = BookReview.builder()
                 .id(10L)
@@ -233,8 +234,8 @@ class BookReviewServiceTest {
             assertThat(response.userId()).isEqualTo(3L);
             assertThat(response.rating()).isEqualTo(new BigDecimal("4.5"));
             assertThat(response.keywords()).containsExactly(
-                    new BookReviewResponse.KeywordInfo(2L, "감동"),
-                    new BookReviewResponse.KeywordInfo(4L, "몰입")
+                    new BookReviewResponse.KeywordInfo(2L, "감동", KeywordType.BOOK),
+                    new BookReviewResponse.KeywordInfo(4L, "몰입", KeywordType.IMPRESSION)
             );
         }
     }
@@ -258,9 +259,9 @@ class BookReviewServiceTest {
     @DisplayName("내 책 리뷰를 수정한다")
     void updateMyReview_success() {
         Book book = Book.builder().id(1L).build();
-        Keyword keyword = Keyword.builder().id(2L).keywordName("감동").build();
-        Keyword newKeyword = Keyword.builder().id(5L).keywordName("희망").build();
-        Keyword newKeywordSecond = Keyword.builder().id(8L).keywordName("위로").build();
+        Keyword keyword = Keyword.builder().id(2L).keywordName("감동").keywordType(KeywordType.BOOK).build();
+        Keyword newKeyword = Keyword.builder().id(5L).keywordName("희망").keywordType(KeywordType.BOOK).build();
+        Keyword newKeywordSecond = Keyword.builder().id(8L).keywordName("위로").keywordType(KeywordType.IMPRESSION).build();
         User user = User.builder().id(3L).build();
         BookReview review = BookReview.builder()
                 .id(10L)
@@ -285,8 +286,8 @@ class BookReviewServiceTest {
             assertThat(review.getRating()).isEqualTo(new BigDecimal("3.5"));
             assertThat(review.getKeywords()).hasSize(2);
             assertThat(response.keywords()).containsExactly(
-                    new BookReviewResponse.KeywordInfo(5L, "희망"),
-                    new BookReviewResponse.KeywordInfo(8L, "위로")
+                    new BookReviewResponse.KeywordInfo(5L, "희망", KeywordType.BOOK),
+                    new BookReviewResponse.KeywordInfo(8L, "위로", KeywordType.IMPRESSION)
             );
             assertThat(response.reviewId()).isEqualTo(10L);
         }


### PR DESCRIPTION
 ## PR 요약

  > 이 PR이 어떤 변경을 하는지 간단히 설명하고, 체크 표시는 괄호 사이에 소문자 'x'를 삽입하세요.                                                                                     

  - [x] 기능 추가
  - [ ] 버그 수정
  - [x] 코드 리팩토링
  - [x] 문서 수정
  - [ ] 기타 (설명)

  ———

  ## 이슈 번호

  - #235 

  ———

  ## 주요 변경 사항

  > 주요 파일, 로직, 컴포넌트 등을 구체적으로 적어주세요.                                                                                                                            

  - src/main/java/com/dokdok/book/api/PersonalBookRecordApi.java: 사전 의견 조회 엔드포인트 추가 및 스웨거 예시/실패 응답 형식 정리
  - src/main/java/com/dokdok/book/service/PersonalReadingRecordService.java: 개인 책장 기반 사전 의견 조회 로직 구현
  - src/main/java/com/dokdok/book/dto/response/PersonalReadingTopicAnswerResponse.java: 사전 의견 응답 DTO(type 포함) 추가
  - src/main/java/com/dokdok/meeting/repository/MeetingRepository.java: 모임+책 기준 최신 확정 약속 조회 메서드 추가
  - src/main/java/com/dokdok/book/dto/response/BookReviewResponse.java: 리뷰 키워드에 type(KeywordType) 포함
  - src/test/java/com/dokdok/book/service/BookReviewServiceTest.java: 키워드 타입 포함 검증 반영
  - src/main/java/com/dokdok/book/api/BookReviewApi.java: 리뷰 응답 예시를 code/message/data 형식과 타입 포함으로 갱신

  ———

  ## 참고 사항

  > 리뷰어가 알아야 할 추가 정보, 테스트 방법 등을 작성해주세요.                                                                                                                     
