### PR TITLE
[#246][FEAT] 메인페이지 내 약속리스트 불러오기

### DIFF
--- a/src/main/java/com/dokdok/meeting/api/MyMeetingListApi.java
+++ b/src/main/java/com/dokdok/meeting/api/MyMeetingListApi.java
@@ -1,0 +1,129 @@
+package com.dokdok.meeting.api;
+
+import com.dokdok.global.response.ApiResponse;
+import com.dokdok.global.response.CursorResponse;
+import com.dokdok.meeting.dto.MeetingListCursor;
+import com.dokdok.meeting.dto.MeetingListCursorRequest;
+import com.dokdok.meeting.dto.MyMeetingListFilter;
+import com.dokdok.meeting.dto.MyMeetingListItemCursorResponse;
+import com.dokdok.meeting.dto.MyMeetingListItemResponse;
+import com.dokdok.meeting.dto.MyMeetingTabCountsResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Tag(name = "약속 관리", description = "약속 관련 API")
+public interface MyMeetingListApi {
+
+    @Operation(
+            summary = "메인페이지 내 약속 리스트 조회 (developer: 김윤영)",
+            description = """
+            로그인 사용자의 모든 모임 내 약속 리스트를 조회합니다.
+            - 정렬 기준: 약속 시작 시간 오름차순, 약속 ID 오름차순
+            - 전체: 확정된 약속 + 완료된 약속
+            - 다가오는 약속: 3일 이내 시작하는 확정된 약속
+            - 완료된 약속: 종료된 약속
+            """,
+            parameters = {
+                    @Parameter(name = "filter", description = "필터 (ALL, UPCOMING, DONE)",
+                            in = ParameterIn.QUERY, required = true,
+                            schema = @Schema(allowableValues = {"ALL", "UPCOMING", "DONE"}))
+            }
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "내 약속 리스트 조회 성공",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = MyMeetingListItemCursorResponse.class),
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "code": "SUCCESS",
+                                      "message": "내 약속 리스트 조회 성공",
+                                      "data": {
+                                        "items": [
+                                          {
+                                            "meetingId": 1,
+                                            "meetingName": "1월 독서 모임",
+                                            "gatheringId": 10,
+                                            "gatheringName": "독서 모임",
+                                            "meetingLeaderName": "독서왕",
+                                            "bookName": "클린 코드",
+                                            "startDateTime": "2025-02-01T14:00:00",
+                                            "endDateTime": "2025-02-01T16:00:00",
+                                            "meetingStatus": "CONFIRMED",
+                                            "myRole": "LEADER",
+                                            "progressStatus": "UPCOMING"
+                                          }
+                                        ],
+                                        "pageSize": 4,
+                                        "hasNext": true,
+                                        "nextCursor": {
+                                          "meetingId": 2,
+                                          "startDateTime": "2025-02-03T14:00:00"
+                                        }
+                                      }
+                                    }
+                                    """))
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(value = """
+                                    {"code": "INVALID_INPUT_VALUE", "message": "입력값이 올바르지 않습니다.", "data": null}
+                                    """))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 오류",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(value = """
+                                    {"code": "E000", "message": "서버 에러가 발생했습니다. 담당자에게 문의 바랍니다.", "data": null}
+                                    """)))
+    })
+    ResponseEntity<ApiResponse<CursorResponse<MyMeetingListItemResponse, MeetingListCursor>>> getMyMeetingList(
+            @RequestParam MyMeetingListFilter filter,
+            @ParameterObject MeetingListCursorRequest cursor,
+            @RequestParam(defaultValue = "4") int size
+    );
+
+    @Operation(
+            summary = "메인페이지 내 약속 탭 카운트 조회 (developer: 김윤영)",
+            description = """
+            로그인 사용자의 내 약속 탭 카운트를 조회합니다.
+            - 전체: 확정된 약속 + 완료된 약속
+            - 다가오는 약속: 3일 이내 시작하는 확정된 약속
+            - 완료된 약속: 종료된 약속
+            """
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "내 약속 탭 카운트 조회 성공",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = MyMeetingTabCountsResponse.class),
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "code": "SUCCESS",
+                                      "message": "내 약속 탭 카운트 조회 성공",
+                                      "data": {
+                                        "all": 10,
+                                        "upcoming": 2,
+                                        "done": 5
+                                      }
+                                    }
+                                    """))
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 오류",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(value = """
+                                    {"code": "E000", "message": "서버 에러가 발생했습니다. 담당자에게 문의 바랍니다.", "data": null}
+                                    """)))
+    })
+    ResponseEntity<ApiResponse<MyMeetingTabCountsResponse>> getMyMeetingTabCounts();
+}

--- a/src/main/java/com/dokdok/meeting/controller/MyMeetingListController.java
+++ b/src/main/java/com/dokdok/meeting/controller/MyMeetingListController.java
@@ -1,0 +1,47 @@
+package com.dokdok.meeting.controller;
+
+import com.dokdok.global.response.ApiResponse;
+import com.dokdok.global.response.CursorResponse;
+import com.dokdok.meeting.api.MyMeetingListApi;
+import com.dokdok.meeting.dto.MeetingListCursor;
+import com.dokdok.meeting.dto.MeetingListCursorRequest;
+import com.dokdok.meeting.dto.MyMeetingListFilter;
+import com.dokdok.meeting.dto.MyMeetingListItemResponse;
+import com.dokdok.meeting.dto.MyMeetingTabCountsResponse;
+import com.dokdok.meeting.service.MeetingService;
+import lombok.RequiredArgsConstructor;
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/meetings")
+public class MyMeetingListController implements MyMeetingListApi {
+
+    private final MeetingService meetingService;
+
+    @Override
+    @GetMapping(value = "/me", produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<ApiResponse<CursorResponse<MyMeetingListItemResponse, MeetingListCursor>>> getMyMeetingList(
+            @RequestParam MyMeetingListFilter filter,
+            @ParameterObject MeetingListCursorRequest cursor,
+            @RequestParam(defaultValue = "4") int size
+    ) {
+        MeetingListCursor cursorValue = cursor == null ? null : cursor.toCursorOrNull();
+        CursorResponse<MyMeetingListItemResponse, MeetingListCursor> response =
+                meetingService.getMyMeetingList(filter, size, cursorValue);
+        return ApiResponse.success(response, "내 약속 리스트 조회에 성공했습니다.");
+    }
+
+    @Override
+    @GetMapping(value = "/me/tab-counts", produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<ApiResponse<MyMeetingTabCountsResponse>> getMyMeetingTabCounts() {
+        MyMeetingTabCountsResponse response = meetingService.getMyMeetingTabCounts();
+        return ApiResponse.success(response, "내 약속 탭 카운트 조회에 성공했습니다.");
+    }
+}

--- a/src/main/java/com/dokdok/meeting/dto/MeetingMyRole.java
+++ b/src/main/java/com/dokdok/meeting/dto/MeetingMyRole.java
@@ -3,9 +3,9 @@ package com.dokdok.meeting.dto;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(
-        description = "내 역할 (LEADER: 약속장, MEMBER: 참여자, NONE: 미참여)",
-        allowableValues = {"LEADER", "MEMBER", "NONE"}
+        description = "내 역할 (LEADER: 약속장, GATHERING_LEADER: 모임장, MEMBER: 참여자, NONE: 미참여)",
+        allowableValues = {"LEADER", "GATHERING_LEADER", "MEMBER", "NONE"}
 )
 public enum MeetingMyRole {
-    LEADER, MEMBER, NONE
+    LEADER, GATHERING_LEADER, MEMBER, NONE
 }

--- a/src/main/java/com/dokdok/meeting/dto/MeetingProgressStatus.java
+++ b/src/main/java/com/dokdok/meeting/dto/MeetingProgressStatus.java
@@ -1,0 +1,11 @@
+package com.dokdok.meeting.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "약속 진행 상태 (시간 기준)")
+public enum MeetingProgressStatus {
+    UPCOMING,
+    ONGOING,
+    DONE,
+    UNKNOWN
+}

--- a/src/main/java/com/dokdok/meeting/dto/MyMeetingListFilter.java
+++ b/src/main/java/com/dokdok/meeting/dto/MyMeetingListFilter.java
@@ -1,0 +1,7 @@
+package com.dokdok.meeting.dto;
+
+public enum MyMeetingListFilter {
+    ALL,
+    UPCOMING,
+    DONE
+}

--- a/src/main/java/com/dokdok/meeting/dto/MyMeetingListItemCursorResponse.java
+++ b/src/main/java/com/dokdok/meeting/dto/MyMeetingListItemCursorResponse.java
@@ -1,0 +1,21 @@
+package com.dokdok.meeting.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+@Schema(description = "메인페이지 내 약속 커서 응답(문서용)")
+public record MyMeetingListItemCursorResponse(
+        @Schema(description = "아이템 목록")
+        List<MyMeetingListItemResponse> items,
+
+        @Schema(description = "페이지 크기", example = "4")
+        int pageSize,
+
+        @Schema(description = "다음 페이지 존재 여부", example = "true")
+        boolean hasNext,
+
+        @Schema(description = "다음 커서")
+        MeetingListCursor nextCursor
+) {
+}

--- a/src/main/java/com/dokdok/meeting/dto/MyMeetingListItemResponse.java
+++ b/src/main/java/com/dokdok/meeting/dto/MyMeetingListItemResponse.java
@@ -1,21 +1,23 @@
 package com.dokdok.meeting.dto;
 
 import com.dokdok.meeting.entity.MeetingStatus;
-import com.dokdok.topic.entity.TopicType;
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.Builder;
 
 import java.time.LocalDateTime;
-import java.util.List;
 
-@Schema(description = "약속 목록 아이템 응답")
-@Builder
-public record MeetingListItemResponse(
+@Schema(description = "메인페이지 내 약속 목록 아이템 응답")
+public record MyMeetingListItemResponse(
         @Schema(description = "약속 ID", example = "1")
         Long meetingId,
 
         @Schema(description = "약속 이름", example = "1월 독서 모임")
         String meetingName,
+
+        @Schema(description = "모임 ID", example = "10")
+        Long gatheringId,
+
+        @Schema(description = "모임 이름", example = "독서 모임")
+        String gatheringName,
 
         @Schema(description = "약속장 이름", example = "독서왕")
         String meetingLeaderName,
@@ -29,16 +31,13 @@ public record MeetingListItemResponse(
         @Schema(description = "종료 일시", example = "2025-02-01T16:00:00")
         LocalDateTime endDateTime,
 
-        @Schema(description = "주제 타입 목록", example = "[\"FREE\", \"CHAPTER\"]")
-        List<TopicType> topicTypes,
-
-        @Schema(description = "참가 여부", example = "true")
-        boolean joined,
+        @Schema(description = "약속 상태", example = "CONFIRMED")
+        MeetingStatus meetingStatus,
 
         @Schema(description = "내 역할 (LEADER: 약속장, GATHERING_LEADER: 모임장, MEMBER: 참여자, NONE: 미참여)", example = "LEADER")
         MeetingMyRole myRole,
 
-        @Schema(description = "약속 상태", example = "CONFIRMED")
-        MeetingStatus meetingStatus
+        @Schema(description = "약속 진행 상태(시간 기준)", example = "UPCOMING")
+        MeetingProgressStatus progressStatus
 ) {
 }

--- a/src/main/java/com/dokdok/meeting/dto/MyMeetingTabCountsResponse.java
+++ b/src/main/java/com/dokdok/meeting/dto/MyMeetingTabCountsResponse.java
@@ -1,0 +1,18 @@
+package com.dokdok.meeting.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+@Schema(description = "메인페이지 내 약속 탭별 카운트 응답")
+@Builder
+public record MyMeetingTabCountsResponse(
+        @Schema(description = "전체 약속 수", example = "10")
+        int all,
+
+        @Schema(description = "다가오는 약속 수 (3일 이내)", example = "2")
+        int upcoming,
+
+        @Schema(description = "완료된 약속 수", example = "5")
+        int done
+) {
+}

--- a/src/main/java/com/dokdok/meeting/repository/MeetingMemberRepository.java
+++ b/src/main/java/com/dokdok/meeting/repository/MeetingMemberRepository.java
@@ -81,6 +81,45 @@ public interface MeetingMemberRepository extends JpaRepository<MeetingMember, Lo
             @Param("meetingStatus") MeetingStatus meetingStatus
     );
 
+    @Query("""
+            SELECT count(mm) FROM MeetingMember mm
+            JOIN mm.meeting m
+            WHERE mm.user.id = :userId
+            AND mm.canceledAt IS NULL
+            AND m.meetingStatus IN :meetingStatuses
+            """)
+    int countMyMeetingsByStatuses(
+            @Param("userId") Long userId,
+            @Param("meetingStatuses") List<MeetingStatus> meetingStatuses
+    );
+
+    @Query("""
+            SELECT count(mm) FROM MeetingMember mm
+            JOIN mm.meeting m
+            WHERE mm.user.id = :userId
+            AND mm.canceledAt IS NULL
+            AND m.meetingStatus = :meetingStatus
+            """)
+    int countMyMeetingsByStatus(
+            @Param("userId") Long userId,
+            @Param("meetingStatus") MeetingStatus meetingStatus
+    );
+
+    @Query("""
+            SELECT count(mm) FROM MeetingMember mm
+            JOIN mm.meeting m
+            WHERE mm.user.id = :userId
+            AND mm.canceledAt IS NULL
+            AND m.meetingStatus = :meetingStatus
+            AND m.meetingStartDate BETWEEN :startDate AND :endDate
+            """)
+    int countMyUpcomingMeetings(
+            @Param("userId") Long userId,
+            @Param("meetingStatus") MeetingStatus meetingStatus,
+            @Param("startDate") LocalDateTime startDate,
+            @Param("endDate") LocalDateTime endDate
+    );
+
     @Query(
             value = """
                     SELECT m FROM MeetingMember mm
@@ -126,6 +165,78 @@ public interface MeetingMemberRepository extends JpaRepository<MeetingMember, Lo
             @Param("userId") Long userId,
             @Param("gatheringId") Long gatheringId,
             @Param("meetingStatus") MeetingStatus meetingStatus,
+            @Param("cursorStartDateTime") LocalDateTime cursorStartDateTime,
+            @Param("cursorMeetingId") Long cursorMeetingId,
+            Pageable pageable
+    );
+
+    @Query(
+            value = """
+                    SELECT m FROM MeetingMember mm
+                    JOIN mm.meeting m
+                    JOIN FETCH m.book
+                    JOIN FETCH m.gathering
+                    WHERE mm.user.id = :userId
+                    AND mm.canceledAt IS NULL
+                    AND m.meetingStatus IN :meetingStatuses
+                    AND (CAST(:cursorStartDateTime AS timestamp) IS NULL
+                        OR m.meetingStartDate > :cursorStartDateTime
+                        OR (m.meetingStartDate = :cursorStartDateTime AND m.id > :cursorMeetingId))
+                    ORDER BY m.meetingStartDate ASC, m.id ASC
+                    """
+    )
+    List<Meeting> findMyMeetingsByStatusesAfterCursor(
+            @Param("userId") Long userId,
+            @Param("meetingStatuses") List<MeetingStatus> meetingStatuses,
+            @Param("cursorStartDateTime") LocalDateTime cursorStartDateTime,
+            @Param("cursorMeetingId") Long cursorMeetingId,
+            Pageable pageable
+    );
+
+    @Query(
+            value = """
+                    SELECT m FROM MeetingMember mm
+                    JOIN mm.meeting m
+                    JOIN FETCH m.book
+                    JOIN FETCH m.gathering
+                    WHERE mm.user.id = :userId
+                    AND mm.canceledAt IS NULL
+                    AND m.meetingStatus = :meetingStatus
+                    AND (CAST(:cursorStartDateTime AS timestamp) IS NULL
+                        OR m.meetingStartDate > :cursorStartDateTime
+                        OR (m.meetingStartDate = :cursorStartDateTime AND m.id > :cursorMeetingId))
+                    ORDER BY m.meetingStartDate ASC, m.id ASC
+                    """
+    )
+    List<Meeting> findMyMeetingsByStatusAfterCursor(
+            @Param("userId") Long userId,
+            @Param("meetingStatus") MeetingStatus meetingStatus,
+            @Param("cursorStartDateTime") LocalDateTime cursorStartDateTime,
+            @Param("cursorMeetingId") Long cursorMeetingId,
+            Pageable pageable
+    );
+
+    @Query(
+            value = """
+                    SELECT m FROM MeetingMember mm
+                    JOIN mm.meeting m
+                    JOIN FETCH m.book
+                    JOIN FETCH m.gathering
+                    WHERE mm.user.id = :userId
+                    AND mm.canceledAt IS NULL
+                    AND m.meetingStatus = :meetingStatus
+                    AND m.meetingStartDate BETWEEN :startDate AND :endDate
+                    AND (CAST(:cursorStartDateTime AS timestamp) IS NULL
+                        OR m.meetingStartDate > :cursorStartDateTime
+                        OR (m.meetingStartDate = :cursorStartDateTime AND m.id > :cursorMeetingId))
+                    ORDER BY m.meetingStartDate ASC, m.id ASC
+                    """
+    )
+    List<Meeting> findMyUpcomingMeetingsAfterCursor(
+            @Param("userId") Long userId,
+            @Param("meetingStatus") MeetingStatus meetingStatus,
+            @Param("startDate") LocalDateTime startDate,
+            @Param("endDate") LocalDateTime endDate,
             @Param("cursorStartDateTime") LocalDateTime cursorStartDateTime,
             @Param("cursorMeetingId") Long cursorMeetingId,
             Pageable pageable

--- a/src/main/java/com/dokdok/meeting/service/MeetingService.java
+++ b/src/main/java/com/dokdok/meeting/service/MeetingService.java
@@ -340,6 +340,9 @@ public class MeetingService {
         meetingRepository.delete(meeting);
     }
 
+    /**
+     * 약속 삭제 가능 상태인지 확인한다.
+     */
     private void validateDeletableStatus(Meeting meeting) {
         if (meeting.getMeetingStatus() == MeetingStatus.DONE) {
             throw new MeetingException(
@@ -349,6 +352,9 @@ public class MeetingService {
         }
     }
 
+    /**
+     * 약속 삭제 가능 시간이 지났는지 확인한다.
+     */
     private void validateDeletableMeetingStartDate(Meeting meeting) {
         LocalDateTime meetingStartDate = meeting.getMeetingStartDate();
         if (meetingStartDate != null
@@ -532,6 +538,84 @@ public class MeetingService {
     }
 
     /**
+     * 메인페이지 내 약속 리스트를 조회한다.
+     * @param filter 필터(ALL, UPCOMING, DONE)
+     * @param size 페이지 크기
+     * @param cursor 커서
+     * @return 약속 리스트
+     */
+    @Transactional(readOnly = true)
+    public CursorResponse<MyMeetingListItemResponse, MeetingListCursor> getMyMeetingList(
+            MyMeetingListFilter filter,
+            int size,
+            MeetingListCursor cursor
+    ) {
+        Long userId = SecurityUtil.getCurrentUserId();
+        Pageable pageable = cursorPageable(size);
+        LocalDateTime now = LocalDateTime.now();
+
+        MyMeetingListFilter safeFilter = filter == null ? MyMeetingListFilter.ALL : filter;
+        List<Meeting> meetings = switch (safeFilter) {
+            case UPCOMING -> meetingMemberRepository.findMyUpcomingMeetingsAfterCursor(
+                    userId,
+                    MeetingStatus.CONFIRMED,
+                    now,
+                    now.plusDays(3),
+                    cursorStartDateTime(cursor),
+                    cursorMeetingId(cursor),
+                    pageable
+            );
+            case DONE -> meetingMemberRepository.findMyMeetingsByStatusAfterCursor(
+                    userId,
+                    MeetingStatus.DONE,
+                    cursorStartDateTime(cursor),
+                    cursorMeetingId(cursor),
+                    pageable
+            );
+            case ALL -> meetingMemberRepository.findMyMeetingsByStatusesAfterCursor(
+                    userId,
+                    List.of(MeetingStatus.CONFIRMED, MeetingStatus.DONE),
+                    cursorStartDateTime(cursor),
+                    cursorMeetingId(cursor),
+                    pageable
+            );
+        };
+
+        return buildMyMeetingListResponse(meetings, size, userId);
+    }
+
+    /**
+     * 메인페이지 내 약속 탭 카운트를 조회한다.
+     * @return 탭별 카운트 응답
+     */
+    @Transactional(readOnly = true)
+    public MyMeetingTabCountsResponse getMyMeetingTabCounts() {
+        Long userId = SecurityUtil.getCurrentUserId();
+        LocalDateTime now = LocalDateTime.now();
+
+        int allCount = meetingMemberRepository.countMyMeetingsByStatuses(
+                userId,
+                List.of(MeetingStatus.CONFIRMED, MeetingStatus.DONE)
+        );
+        int upcomingCount = meetingMemberRepository.countMyUpcomingMeetings(
+                userId,
+                MeetingStatus.CONFIRMED,
+                now,
+                now.plusDays(3)
+        );
+        int doneCount = meetingMemberRepository.countMyMeetingsByStatus(
+                userId,
+                MeetingStatus.DONE
+        );
+
+        return MyMeetingTabCountsResponse.builder()
+                .all(allCount)
+                .upcoming(upcomingCount)
+                .done(doneCount)
+                .build();
+    }
+
+    /**
      * 모임의 약속 중 확정된 리스트를 전부 반환한다.
      */
     private CursorResponse<MeetingListItemResponse, MeetingListCursor> getAllMeetings(
@@ -618,6 +702,9 @@ public class MeetingService {
         return buildMeetingListResponse(meetings, size, userId, gatheringId);
     }
 
+    /**
+     * 약속 리스트 커서 응답을 구성한다.
+     */
     private CursorResponse<MeetingListItemResponse, MeetingListCursor> buildMeetingListResponse(
             List<Meeting> meetingCandidates,
             int size,
@@ -641,6 +728,34 @@ public class MeetingService {
         return CursorResponse.of(items, size, hasNext, nextCursor);
     }
 
+    /**
+     * 내 약속 리스트 커서 응답을 구성한다.
+     */
+    private CursorResponse<MyMeetingListItemResponse, MeetingListCursor> buildMyMeetingListResponse(
+            List<Meeting> meetingCandidates,
+            int size,
+            Long userId
+    ) {
+        boolean hasNext = meetingCandidates.size() > size;
+        List<Meeting> meetings = hasNext ? meetingCandidates.subList(0, size) : meetingCandidates;
+        if (meetings.isEmpty()) {
+            return CursorResponse.of(List.of(), size, false, null);
+        }
+
+        List<MyMeetingListItemResponse> items = buildMyMeetingItems(meetings, userId);
+
+        MeetingListCursor nextCursor = null;
+        if (hasNext) {
+            Meeting last = meetings.get(meetings.size() - 1);
+            nextCursor = new MeetingListCursor(last.getMeetingStartDate(), last.getId());
+        }
+
+        return CursorResponse.of(items, size, hasNext, nextCursor);
+    }
+
+    /**
+     * 약속 리스트 아이템을 생성한다.
+     */
     private List<MeetingListItemResponse> buildMeetingItems(
             List<Meeting> meetings,
             Long userId,
@@ -683,10 +798,84 @@ public class MeetingService {
         return items;
     }
 
+    /**
+     * 내 약속 리스트 아이템을 생성한다.
+     */
+    private List<MyMeetingListItemResponse> buildMyMeetingItems(List<Meeting> meetings, Long userId) {
+        LocalDateTime now = LocalDateTime.now();
+        List<MyMeetingListItemResponse> items = new ArrayList<>();
+
+        for (Meeting meeting : meetings) {
+            MeetingProgressStatus progressStatus = resolveProgressStatus(
+                    meeting.getMeetingStartDate(),
+                    meeting.getMeetingEndDate(),
+                    now
+            );
+            MeetingMyRole myRole = resolveMyMeetingRole(meeting, userId);
+
+            items.add(new MyMeetingListItemResponse(
+                    meeting.getId(),
+                    meeting.getMeetingName(),
+                    meeting.getGathering().getId(),
+                    meeting.getGathering().getGatheringName(),
+                    meeting.getMeetingLeader() != null ? meeting.getMeetingLeader().getNickname() : null,
+                    meeting.getBook().getBookName(),
+                    meeting.getMeetingStartDate(),
+                    meeting.getMeetingEndDate(),
+                    meeting.getMeetingStatus(),
+                    myRole,
+                    progressStatus
+            ));
+        }
+        return items;
+    }
+
+    /**
+     * 내 역할을 계산한다.
+     */
+    private MeetingMyRole resolveMyMeetingRole(Meeting meeting, Long userId) {
+        User leader = meeting.getMeetingLeader();
+        if (leader != null && leader.getId().equals(userId)) {
+            return MeetingMyRole.LEADER;
+        }
+        User gatheringLeader = meeting.getGathering().getGatheringLeader();
+        if (gatheringLeader != null && gatheringLeader.getId().equals(userId)) {
+            return MeetingMyRole.GATHERING_LEADER;
+        }
+        return MeetingMyRole.MEMBER;
+    }
+
+    /**
+     * 약속 진행 상태를 계산한다.
+     */
+    private MeetingProgressStatus resolveProgressStatus(
+            LocalDateTime meetingStartDate,
+            LocalDateTime meetingEndDate,
+            LocalDateTime now
+    ) {
+        if (meetingStartDate == null || meetingEndDate == null) {
+            return MeetingProgressStatus.UNKNOWN;
+        }
+        if (now.isBefore(meetingStartDate)) {
+            return MeetingProgressStatus.UPCOMING;
+        }
+        if (!now.isAfter(meetingEndDate)) {
+            return MeetingProgressStatus.ONGOING;
+        }
+        return MeetingProgressStatus.DONE;
+    }
+
+    /**
+     * 리스트에서 내 역할을 계산한다.
+     */
     private MeetingMyRole resolveMyRole(Meeting meeting, Long userId, boolean joined) {
         User leader = meeting.getMeetingLeader();
         if (leader != null && leader.getId().equals(userId)) {
             return MeetingMyRole.LEADER;
+        }
+        User gatheringLeader = meeting.getGathering().getGatheringLeader();
+        if (gatheringLeader != null && gatheringLeader.getId().equals(userId)) {
+            return MeetingMyRole.GATHERING_LEADER;
         }
         if (joined) {
             return MeetingMyRole.MEMBER;
@@ -694,14 +883,23 @@ public class MeetingService {
         return MeetingMyRole.NONE;
     }
 
+    /**
+     * 커서 페이지네이션을 위한 Pageable을 생성한다.
+     */
     private Pageable cursorPageable(int size) {
         return PageRequest.of(0, size + 1);
     }
 
+    /**
+     * 커서의 시작 시간을 반환한다.
+     */
     private LocalDateTime cursorStartDateTime(MeetingListCursor cursor) {
         return cursor == null ? null : cursor.startDateTime();
     }
 
+    /**
+     * 커서의 약속 ID를 반환한다.
+     */
     private Long cursorMeetingId(MeetingListCursor cursor) {
         return cursor == null ? null : cursor.meetingId();
     }

--- a/src/test/java/com/dokdok/meeting/service/MeetingServiceTest.java
+++ b/src/test/java/com/dokdok/meeting/service/MeetingServiceTest.java
@@ -1131,4 +1131,119 @@ class MeetingServiceTest {
         }
     }
 
+    @DisplayName("내 약속 리스트 조회 시 필터가 null이면 전체 기준으로 조회한다.")
+    @Test
+    void givenNullFilter_whenGetMyMeetingList_thenReturnItems() {
+        // given
+        Long userId = leader.getId();
+        int size = 4;
+        User meetingLeader = User.builder().id(99L).nickname("meetingLeader").build();
+        Meeting myMeeting = Meeting.builder()
+                .id(1L)
+                .meetingName("myMeeting")
+                .meetingStatus(MeetingStatus.CONFIRMED)
+                .meetingStartDate(null)
+                .meetingEndDate(null)
+                .meetingLeader(meetingLeader)
+                .gathering(gathering)
+                .book(Book.builder().id(1L).bookName("book").build())
+                .build();
+
+        given(meetingMemberRepository.findMyMeetingsByStatusesAfterCursor(
+                eq(userId),
+                eq(List.of(MeetingStatus.CONFIRMED, MeetingStatus.DONE)),
+                any(),
+                any(),
+                any()
+        )).willReturn(List.of(myMeeting));
+
+        try (MockedStatic<SecurityUtil> mock = mockStatic(SecurityUtil.class)) {
+            mock.when(SecurityUtil::getCurrentUserId).thenReturn(userId);
+
+            // when
+            CursorResponse<MyMeetingListItemResponse, MeetingListCursor> response =
+                    meetingService.getMyMeetingList(null, size, null);
+
+            // then
+            assertThat(response.items()).hasSize(1);
+            MyMeetingListItemResponse item = response.items().get(0);
+            assertThat(item.myRole()).isEqualTo(MeetingMyRole.GATHERING_LEADER);
+            assertThat(item.progressStatus()).isEqualTo(MeetingProgressStatus.UNKNOWN);
+        }
+    }
+
+    @DisplayName("다가오는 내 약속 리스트를 조회하면 UPCOMING 상태를 반환한다.")
+    @Test
+    void givenUpcomingFilter_whenGetMyMeetingList_thenReturnUpcomingItems() {
+        // given
+        Long userId = 55L;
+        int size = 4;
+        LocalDateTime start = LocalDateTime.now().plusHours(1);
+        LocalDateTime end = start.plusHours(2);
+        Meeting upcomingMeeting = Meeting.builder()
+                .id(2L)
+                .meetingName("upcoming")
+                .meetingStatus(MeetingStatus.CONFIRMED)
+                .meetingStartDate(start)
+                .meetingEndDate(end)
+                .meetingLeader(leader)
+                .gathering(gathering)
+                .book(Book.builder().id(2L).bookName("book2").build())
+                .build();
+
+        given(meetingMemberRepository.findMyUpcomingMeetingsAfterCursor(
+                eq(userId),
+                eq(MeetingStatus.CONFIRMED),
+                any(),
+                any(),
+                any(),
+                any(),
+                any()
+        )).willReturn(List.of(upcomingMeeting));
+
+        try (MockedStatic<SecurityUtil> mock = mockStatic(SecurityUtil.class)) {
+            mock.when(SecurityUtil::getCurrentUserId).thenReturn(userId);
+
+            // when
+            CursorResponse<MyMeetingListItemResponse, MeetingListCursor> response =
+                    meetingService.getMyMeetingList(MyMeetingListFilter.UPCOMING, size, null);
+
+            // then
+            assertThat(response.items()).hasSize(1);
+            MyMeetingListItemResponse item = response.items().get(0);
+            assertThat(item.progressStatus()).isEqualTo(MeetingProgressStatus.UPCOMING);
+        }
+    }
+
+    @DisplayName("내 약속 탭 카운트를 조회하면 전체/다가오는/완료 카운트를 반환한다.")
+    @Test
+    void givenUser_whenGetMyMeetingTabCounts_thenReturnCounts() {
+        // given
+        Long userId = 55L;
+        given(meetingMemberRepository.countMyMeetingsByStatuses(
+                userId,
+                List.of(MeetingStatus.CONFIRMED, MeetingStatus.DONE)
+        )).willReturn(5);
+        given(meetingMemberRepository.countMyUpcomingMeetings(
+                eq(userId),
+                eq(MeetingStatus.CONFIRMED),
+                any(),
+                any()
+        )).willReturn(2);
+        given(meetingMemberRepository.countMyMeetingsByStatus(userId, MeetingStatus.DONE))
+                .willReturn(3);
+
+        try (MockedStatic<SecurityUtil> mock = mockStatic(SecurityUtil.class)) {
+            mock.when(SecurityUtil::getCurrentUserId).thenReturn(userId);
+
+            // when
+            MyMeetingTabCountsResponse response = meetingService.getMyMeetingTabCounts();
+
+            // then
+            assertThat(response.all()).isEqualTo(5);
+            assertThat(response.upcoming()).isEqualTo(2);
+            assertThat(response.done()).isEqualTo(3);
+        }
+    }
+
 }


### PR DESCRIPTION
## PR 요약
> 이 PR이 어떤 변경을 하는지 간단히 설명하고, 체크 표시는 괄호 사이에 소문자 'x'를 삽입하세요.

- [x] 기능 추가
- [ ] 버그 수정
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 기타 (설명)

---

## 이슈 번호
- #246

---

## 주요 변경 사항
 - src/main/java/com/dokdok/meeting/service/MeetingService.java — 내 약속 리스트/탭 카운트 로직 추가, 역할/진행상태 계산 보강
  - src/main/java/com/dokdok/meeting/repository/MeetingMemberRepository.java — 내 약속 조회/카운트 전용 쿼리 추가
  - src/main/java/com/dokdok/meeting/api/MyMeetingListApi.java — 내 약속 리스트/탭 카운트 API 문서화 추가
  - src/main/java/com/dokdok/meeting/controller/MyMeetingListController.java — /api/meetings/me, /api/meetings/me/tab-counts 엔드포인트 추가
  - src/main/java/com/dokdok/meeting/dto/* — 메인페이지 전용 DTO, 진행상태/필터 enum, 문서용 응답 DTO 추가 및 역할 enum 확장
  - src/main/java/com/dokdok/meeting/api/MeetingListApi.java — 문서용 응답 스키마 적용(기존 리스트)
  - src/test/java/com/dokdok/meeting/service/MeetingServiceTest.java — 내 약속 리스트/탭 카운트 더티 케이스 테스트 추가

  - 메인페이지 내 약속 리스트 커서 조회 지원
      - 필터: ALL/UPCOMING/DONE, 기준은 기존 리스트와 동일(다가오는: 3일 이내 시작하는 CONFIRMED, 완료: DONE)
      - 응답에 모임 정보, 약속장 이름, 내 역할(LEADER/GATHERING_LEADER/MEMBER), 진행상태(UPCOMING/ONGOING/DONE/UNKNOWN) 포함
  - 메인페이지 내 약속 탭 카운트 조회 추가
      - all / upcoming / done 카운트 반환
  - 스웨거 응답 스키마가 items 내부 구조까지 잘 보이도록 문서용 DTO 적용


---

## 참고 사항
> 리뷰어가 알아야 할 추가 정보, 테스트 방법 등을 작성해주세요.

예:
- 테스트 계정 정보
- 관련 API 엔드포인트
- 로컬 테스트 방법

---
