### PR TITLE
[#266][FIX] 개인 회고 목록 조회 API 누락된 topicTitle 추가 및 기록 타입 enum으로 수정

### DIFF
--- a/src/main/java/com/dokdok/book/api/BookRecordApi.java
+++ b/src/main/java/com/dokdok/book/api/BookRecordApi.java
@@ -58,7 +58,7 @@ public interface BookRecordApi {
                     content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
                             schema = @Schema(implementation = CursorResponse.class),
                             examples = @ExampleObject(value = """
-                                    {"code":"SUCCESS","message":"해당 책의 개인 회고 목록 조회를 성공했습니다.","data":{"items":[{"retrospectiveId":1,"gatheringName":"독서 모임","recordType":"개인 회고","createdAt":"2025-02-01T16:30:00","topicGroups":[{"topicId":1,"confirmOrder":1,"changedThoughts":[{"keyIssue":"요약된 핵심 쟁점","postOpinion":"토론 후 바뀐 생각"}],"othersPerspectives":[{"meetingMemberId":10,"memberNickname":"독서왕","opinionContent":"상대 의견이 인상적이었습니다.","impressiveReason":"새로운 관점을 제공했기 때문입니다."}]}],"freeTexts":[{"title":"오늘의 한 줄","content":"회고 내용을 작성합니다."}]}],"pageSize":10,"hasNext":false,"nextCursor":null}}
+                                    {"code":"SUCCESS","message":"해당 책의 개인 회고 목록 조회를 성공했습니다.","data":{"items":[{"retrospectiveId":1,"gatheringName":"독서 모임","recordType":"개인 회고","createdAt":"2025-02-01T16:30:00","topicGroups":[{"topicId":1,"topicTitle":"이 책의 핵심 메시지는 무엇인가?","confirmOrder":1,"changedThoughts":{"keyIssue":"요약된 핵심 쟁점","postOpinion":"토론 후 바뀐 생각"},"othersPerspectives":[{"meetingMemberId":10,"memberNickname":"독서왕","opinionContent":"상대 의견이 인상적이었습니다.","impressiveReason":"새로운 관점을 제공했기 때문입니다."}]}],"freeTexts":[{"title":"오늘의 한 줄","content":"회고 내용을 작성합니다."}]}],"pageSize":10,"hasNext":false,"nextCursor":null}}
                                     """))
             ),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(

--- a/src/main/java/com/dokdok/book/entity/ReflectionRecordType.java
+++ b/src/main/java/com/dokdok/book/entity/ReflectionRecordType.java
@@ -1,0 +1,7 @@
+package com.dokdok.book.entity;
+
+public enum ReflectionRecordType {
+    MEETING_RETROSPECTIVE,
+    PERSONAL_RETROSPECTIVE,
+    PRE_OPINION
+}

--- a/src/main/java/com/dokdok/retrospective/dto/projection/ChangedThoughtProjection.java
+++ b/src/main/java/com/dokdok/retrospective/dto/projection/ChangedThoughtProjection.java
@@ -3,6 +3,7 @@ package com.dokdok.retrospective.dto.projection;
 public record ChangedThoughtProjection(
         Long retrospectiveId,
         Long topicId,
+        String topicTitle,
         Integer confirmOrder,
         String keyIssue,
         String postOpinion

--- a/src/main/java/com/dokdok/retrospective/dto/projection/OtherPerspectiveProjection.java
+++ b/src/main/java/com/dokdok/retrospective/dto/projection/OtherPerspectiveProjection.java
@@ -3,6 +3,7 @@ package com.dokdok.retrospective.dto.projection;
 public record OtherPerspectiveProjection(
         Long retrospectiveId,
         Long topicId,
+        String topicTitle,
         Integer confirmOrder,
         Long meetingMemberId,
         String memberNickname,

--- a/src/main/java/com/dokdok/retrospective/dto/response/RetrospectiveRecordResponse.java
+++ b/src/main/java/com/dokdok/retrospective/dto/response/RetrospectiveRecordResponse.java
@@ -1,5 +1,6 @@
 package com.dokdok.retrospective.dto.response;
 
+import com.dokdok.book.entity.ReflectionRecordType;
 import com.dokdok.retrospective.dto.projection.ChangedThoughtProjection;
 import com.dokdok.retrospective.dto.projection.FreeTextProjection;
 import com.dokdok.retrospective.dto.projection.OtherPerspectiveProjection;
@@ -15,7 +16,7 @@ public record RetrospectiveRecordResponse(
         @Schema(description = "모임 이름", example = "독서 모임")
         String gatheringName,
         @Schema(description = "기록 유형", example = "개인 회고")
-        String recordType,
+        ReflectionRecordType recordType,
         @Schema(description = "작성 일시", example = "2025-02-01T16:30:00")
         LocalDateTime createdAt,
         @Schema(description = "주제별 그룹 목록")
@@ -27,10 +28,12 @@ public record RetrospectiveRecordResponse(
     public record TopicGroup(
             @Schema(description = "주제 ID", example = "1")
             Long topicId,
+            @Schema(description = "주제명", example = "1")
+            String topicTitle,
             @Schema(description = "주제 확정 순서", example = "1")
             Integer confirmOrder,
             @Schema(description = "생각 변화 목록")
-            List<ChangedThought> changedThoughts,
+            ChangedThought changedThought,
             @Schema(description = "타인의 관점 목록")
             List<OthersPerspective> othersPerspectives
     ) {}
@@ -89,7 +92,7 @@ public record RetrospectiveRecordResponse(
     public static RetrospectiveRecordResponse of(
             Long retrospectiveId,
             String gatheringName,
-            String recordType,
+            ReflectionRecordType recordType,
             LocalDateTime createdAt,
             List<TopicGroup> topicGroups,
             List<FreeText> freeTexts

--- a/src/main/java/com/dokdok/retrospective/repository/ChangedThoughtRepository.java
+++ b/src/main/java/com/dokdok/retrospective/repository/ChangedThoughtRepository.java
@@ -24,6 +24,7 @@ public interface ChangedThoughtRepository extends JpaRepository<RetrospectiveCha
             SELECT new com.dokdok.retrospective.dto.projection.ChangedThoughtProjection(
                         pmr.id,
                         t.id,
+                        t.title,
                         t.confirmOrder,
                         ct.keyIssue,
                         ct.postOpinion

--- a/src/main/java/com/dokdok/retrospective/repository/OthersPerspectiveRepository.java
+++ b/src/main/java/com/dokdok/retrospective/repository/OthersPerspectiveRepository.java
@@ -26,6 +26,7 @@ public interface OthersPerspectiveRepository extends JpaRepository<Retrospective
             SELECT new com.dokdok.retrospective.dto.projection.OtherPerspectiveProjection(
                         op.personalMeetingRetrospective.id,
                         t.id,
+                        t.title,
                         t.confirmOrder,
                         mm.id,
                         u.nickname,

--- a/src/main/java/com/dokdok/retrospective/service/PersonalRetrospectiveAssembler.java
+++ b/src/main/java/com/dokdok/retrospective/service/PersonalRetrospectiveAssembler.java
@@ -19,6 +19,7 @@ import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import static com.dokdok.book.entity.ReflectionRecordType.PERSONAL_RETROSPECTIVE;
 import static java.util.stream.Collectors.groupingBy;
 
 @Component
@@ -160,7 +161,7 @@ public class PersonalRetrospectiveAssembler {
                     return RetrospectiveRecordResponse.of(
                             retroId,
                             retrospective.getMeeting().getGathering().getGatheringName(),
-                            "개인 회고",
+                            PERSONAL_RETROSPECTIVE,
                             retrospective.getCreatedAt(),
                             topicGroups,
                             freeTexts
@@ -213,17 +214,20 @@ public class PersonalRetrospectiveAssembler {
             List<ChangedThoughtProjection> changedThoughts,
             List<OtherPerspectiveProjection> othersPerspectives
     ) {
-        Map<Long, Integer> topicIdToConfirmOrder = new LinkedHashMap<>();
+        // topicId -> (title, confirmOrder)
+        Map<Long, TopicInfoHolder> topicIdToInfo = new LinkedHashMap<>();
 
         changedThoughts.forEach(ct -> {
             if (ct.topicId() != null) {
-                topicIdToConfirmOrder.putIfAbsent(ct.topicId(), ct.confirmOrder());
+                topicIdToInfo.putIfAbsent(ct.topicId(),
+                        new TopicInfoHolder(ct.topicTitle(), ct.confirmOrder()));
             }
         });
 
         othersPerspectives.forEach(op -> {
             if (op.topicId() != null) {
-                topicIdToConfirmOrder.putIfAbsent(op.topicId(), op.confirmOrder());
+                topicIdToInfo.putIfAbsent(op.topicId(),
+                        new TopicInfoHolder(op.topicTitle(), op.confirmOrder()));
             }
         });
 
@@ -238,19 +242,20 @@ public class PersonalRetrospectiveAssembler {
                 .filter(op -> op.topicId() != null)
                 .collect(groupingBy(OtherPerspectiveProjection::topicId));
 
-        List<RetrospectiveRecordResponse.TopicGroup> topicGroups = topicIdToConfirmOrder.entrySet().stream()
+        List<RetrospectiveRecordResponse.TopicGroup> topicGroups = topicIdToInfo.entrySet().stream()
                 .sorted(Comparator.comparing(
-                        Map.Entry::getValue,
+                        e -> e.getValue().confirmOrder(),
                         Comparator.nullsLast(Comparator.naturalOrder())
                 ))
                 .map(entry -> {
                     Long topicId = entry.getKey();
-                    Integer confirmOrder = entry.getValue();
+                    TopicInfoHolder info = entry.getValue();
 
-                    List<RetrospectiveRecordResponse.ChangedThought> thoughts =
+                    RetrospectiveRecordResponse.ChangedThought thought =
                             changedThoughtsByTopic.getOrDefault(topicId, List.of()).stream()
+                                    .findFirst()
                                     .map(RetrospectiveRecordResponse.ChangedThought::from)
-                                    .toList();
+                                    .orElse(null);
 
                     List<RetrospectiveRecordResponse.OthersPerspective> perspectives =
                             othersPerspectivesByTopic.getOrDefault(topicId, List.of()).stream()
@@ -259,8 +264,9 @@ public class PersonalRetrospectiveAssembler {
 
                     return new RetrospectiveRecordResponse.TopicGroup(
                             topicId,
-                            confirmOrder,
-                            thoughts,
+                            info.title(),
+                            info.confirmOrder(),
+                            thought,
                             perspectives
                     );
                 })
@@ -276,11 +282,14 @@ public class PersonalRetrospectiveAssembler {
             topicGroups.add(new RetrospectiveRecordResponse.TopicGroup(
                     null,
                     null,
-                    List.of(),
+                    null,
+                    null,
                     nullTopicPerspectives
             ));
         }
 
         return topicGroups;
     }
+
+    private record TopicInfoHolder(String title, Integer confirmOrder) {}
 }

--- a/src/main/java/com/dokdok/topic/api/TopicApi.java
+++ b/src/main/java/com/dokdok/topic/api/TopicApi.java
@@ -186,7 +186,7 @@ public interface TopicApi {
                             mediaType = MediaType.APPLICATION_JSON_VALUE,
                             schema = @Schema(implementation = CursorResponse.class),
                             examples = @ExampleObject(value = """
-                                    {"code":"SUCCESS","message":"제안된 주제 조회를 성공했습니다.","data":{"page":{"items":[],"pageSize":10,"hasNext":false,"nextCursor":null},"actions":{"canConfirm":false,"canSuggest":true}}}
+                                    {"code":"SUCCESS","message":"제안된 주제 조회를 성공했습니다.","data":{"page":{"items":[{"topicId":1,"meetingId":10,"title":"이 책의 핵심 메시지는 무엇인가?","description":"저자가 전달하고자 하는 핵심 메시지에 대해 토론합니다.","topicType":"DISCUSSION","topicTypeLabel":"토론형","topicStatus":"PROPOSED","likeCount":5,"canDelete":true,"createdByInfo":{"userId":1,"nickname":"독서왕"}}],"pageSize":10,"hasNext":false,"nextCursor":null},"actions":{"canConfirm":false,"canSuggest":true}}}
                                     """)
                     )
             ),

--- a/src/test/java/com/dokdok/retrospective/service/PersonalRetrospectiveServiceTest.java
+++ b/src/test/java/com/dokdok/retrospective/service/PersonalRetrospectiveServiceTest.java
@@ -1,5 +1,6 @@
 package com.dokdok.retrospective.service;
 
+import com.dokdok.book.entity.ReflectionRecordType;
 import com.dokdok.gathering.entity.Gathering;
 import com.dokdok.global.exception.GlobalErrorCode;
 import com.dokdok.global.exception.GlobalException;
@@ -1320,7 +1321,7 @@ class PersonalRetrospectiveServiceTest {
                     .thenReturn(List.of());
 
             RetrospectiveRecordResponse recordResponse = RetrospectiveRecordResponse.of(
-                    retrospectiveId, "테스트 모임", "개인 회고", null, List.of(), List.of()
+                    retrospectiveId, "테스트 모임", ReflectionRecordType.PERSONAL_RETROSPECTIVE, null, List.of(), List.of()
             );
             when(assembler.assembleRecords(any(), any(), any(), any()))
                     .thenReturn(List.of(recordResponse));


### PR DESCRIPTION
## PR 요약
> 이 PR이 어떤 변경을 하는지 간단히 설명하고, 체크 표시는 괄호 사이에 소문자 'x'를 삽입하세요.

- [ ] 기능 추가
- [x] 버그 수정
- [ ] 코드 리팩토링
- [x] 문서 수정
- [ ] 기타 (설명)

---

## 이슈 번호
- #266

---

## 주요 변경 사항
> 주요 파일, 로직, 컴포넌트 등을 구체적으로 적어주세요.

- `src/main/java/com/dokdok/book`: +8/-1 (2 files) — 요구사항 반영
- `src/main/java/com/dokdok/retrospective`: +31/-15 (6 files) — 요구사항 반영
- `src/main/java/com/dokdok/topic`: +1/-1 (1 files) — 요구사항 반영
- `src/test/java/com/dokdok/retrospective`: +2/-1 (1 files) — 요구사항 반영

---

## 참고 사항
> 리뷰어가 알아야 할 추가 정보, 테스트 방법 등을 작성해주세요.

예:
- 테스트 계정 정보
- 관련 API 엔드포인트
- 로컬 테스트 방법

---
