### PR TITLE
[#268][REFACTOR] record page 타입 수정

### DIFF
--- a/src/main/java/com/dokdok/book/api/BookApi.java
+++ b/src/main/java/com/dokdok/book/api/BookApi.java
@@ -60,7 +60,8 @@ public interface BookApi {
                                                 "hasNext": true,
                                                 "nextCursor": {
                                                   "page": 2
-                                                }
+                                                },
+                                                "totalCount": 25
                                               }
                                             }
                                             """
@@ -245,7 +246,8 @@ public interface BookApi {
                                                 "nextCursor": {
                                                   "addedAt": "2026-01-22T10:25:40Z",
                                                   "bookId": 127
-                                                }
+                                                },
+                                                "totalCount": 25
                                               }
                                             }
                                             """

--- a/src/main/java/com/dokdok/book/api/PersonalBookRecordApi.java
+++ b/src/main/java/com/dokdok/book/api/PersonalBookRecordApi.java
@@ -29,6 +29,7 @@ public interface PersonalBookRecordApi {
                     내 책장에 있는 책의 독서 기록을 등록합니다.
                     - 경로의 personalBookId로 책을 지정합니다.
                     - 요청 본문: recordType(ENUM: MEMO/QUOTE/RETROSPECTIVE), recordContent, recordType이 QUOTE일 경우 meta에 page, excerpt 필수.
+                    - recordType이 QUOTE일 경우 meta의 page/excerpt는 문자열로 정규화되어 저장됩니다.
                     - recordType이 MEMO이면 meta는 null로 저장됩니다.
                     - 로그인한 사용자 기준으로 본인 책에만 기록을 남길 수 있습니다.
                     """
@@ -49,7 +50,7 @@ public interface PersonalBookRecordApi {
                                                 "recordType": "QUOTE",
                                                 "recordContent": "오늘 기억하고 싶은 문장을 기록합니다.",
                                                 "meta": {
-                                                  "page": 23,
+                                                  "page": "23 ~ 25",
                                                   "excerpt": "이 문장이 좋았다."
                                                 },
                                                 "bookId": 10
@@ -155,7 +156,7 @@ public interface PersonalBookRecordApi {
                                               "recordType": "QUOTE",
                                               "recordContent": "오늘 기억하고 싶은 문장을 기록합니다.",
                                               "meta": {
-                                                "page": 23,
+                                                "page": "23 ~ 25",
                                                 "excerpt": "이 문장이 좋았다."
                                               }
                                             }
@@ -172,6 +173,7 @@ public interface PersonalBookRecordApi {
                     내 책장에 있는 책의 독서 기록을 수정합니다.
                     - 경로의 personalBookId와 recordId로 대상을 지정합니다.
                     - 요청 본문: recordType (ENUM: MEMO/QUOTE/RETROSPECTIVE), recordContent, recordType이 QUOTE일 경우 meta에 page, excerpt 필수.
+                    - recordType이 QUOTE일 경우 meta의 page/excerpt는 문자열로 정규화되어 저장됩니다.
                     - recordType이 MEMO 이면 meta는 null로 저장됩니다.
                     - 로그인한 사용자 기준으로 본인 기록만 수정할 수 있습니다.
                     """
@@ -192,7 +194,7 @@ public interface PersonalBookRecordApi {
                                                 "recordType": "QUOTE",
                                                 "recordContent": "문장을 다시 손봤습니다.",
                                                 "meta": {
-                                                  "page": 30,
+                                                  "page": "30",
                                                   "excerpt": "수정된 인용문"
                                                 },
                                                 "bookId": 10
@@ -313,7 +315,7 @@ public interface PersonalBookRecordApi {
                                               "recordType": "QUOTE",
                                               "recordContent": "문장을 다시 손봤습니다.",
                                               "meta": {
-                                                "page": 30,
+                                                "page": "30 ~ 31",
                                                 "excerpt": "수정된 인용문"
                                               }
                                             }
@@ -450,7 +452,7 @@ public interface PersonalBookRecordApi {
                                                     "recordType": "QUOTE",
                                                     "recordContent": "오늘 기억하고 싶은 문장을 기록합니다.",
                                                     "meta": {
-                                                      "page": 23,
+                                                      "page": "23 ~ 25",
                                                       "excerpt": "이 문장이 좋았다."
                                                     },
                                                     "createdAt": "2026-01-25T22:39:57.899858",

--- a/src/main/java/com/dokdok/book/api/PersonalBookRecordApi.java
+++ b/src/main/java/com/dokdok/book/api/PersonalBookRecordApi.java
@@ -464,7 +464,8 @@ public interface PersonalBookRecordApi {
                                                 "nextCursor": {
                                                   "createdAt": "2026-01-22T10:25:40Z",
                                                   "recordId": 5
-                                                }
+                                                },
+                                                "totalCount": 25
                                               }
                                             }
                                             """

--- a/src/main/java/com/dokdok/book/dto/response/CursorPageResponse.java
+++ b/src/main/java/com/dokdok/book/dto/response/CursorPageResponse.java
@@ -1,5 +1,6 @@
 package com.dokdok.book.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -8,6 +9,7 @@ import java.util.List;
 
 @Getter
 @AllArgsConstructor
+@JsonPropertyOrder({"items", "pageSize", "hasNext", "nextCursor", "totalCount"})
 public class CursorPageResponse<T, C> {
 
     @Schema(description = "아이템 목록")
@@ -18,8 +20,16 @@ public class CursorPageResponse<T, C> {
     private boolean hasNext;
     @Schema(hidden = true)
     private C nextCursor;
+    @Schema(description = "전체 아이템 수")
+    private long totalCount;
 
-    public static <T, C> CursorPageResponse<T, C> of(List<T> items, int pageSize, boolean hasNext, C nextCursor) {
-        return new CursorPageResponse<>(items, pageSize, hasNext, nextCursor);
+    public static <T, C> CursorPageResponse<T, C> of(
+            List<T> items,
+            int pageSize,
+            boolean hasNext,
+            C nextCursor,
+            long totalCount
+    ) {
+        return new CursorPageResponse<>(items, pageSize, hasNext, nextCursor, totalCount);
     }
 }

--- a/src/main/java/com/dokdok/book/repository/PersonalBookRepository.java
+++ b/src/main/java/com/dokdok/book/repository/PersonalBookRepository.java
@@ -97,4 +97,24 @@ public interface PersonalBookRepository extends JpaRepository<PersonalBook, Long
             Pageable pageable
     );
 
+    @Query(
+            value = """
+                select count(distinct pb.book_id)
+                from personal_book pb
+                left join gathering g
+                    on pb.gathering_id = g.gathering_id
+                    and g.deleted_at is null
+                where pb.user_id = :userId
+                    and pb.deleted_at is null
+                    and (:gatheringId is null or g.gathering_id = :gatheringId)
+                    and (:readingStatus is null or pb.reading_status = :readingStatus)
+                """,
+            nativeQuery = true
+    )
+    long countPersonalBooksByUserIdReadingStatusAndGatheringId(
+            @Param("userId") Long userId,
+            @Param("gatheringId") Long gatheringId,
+            @Param("readingStatus") String readingStatus
+    );
+
 }

--- a/src/main/java/com/dokdok/book/repository/PersonalReadingRecordRepository.java
+++ b/src/main/java/com/dokdok/book/repository/PersonalReadingRecordRepository.java
@@ -14,6 +14,7 @@ import java.util.Optional;
 public interface PersonalReadingRecordRepository extends JpaRepository<PersonalReadingRecord, Long> {
     Optional<PersonalReadingRecord> findByIdAndPersonalBook_IdAndUserId(Long id, Long personalBookId, Long userId);
     Page<PersonalReadingRecord> findAllByPersonalBook_IdAndUserId(Long personalBookId, Long userId, Pageable pageable);
+    long countByPersonalBook_IdAndUserId(Long personalBookId, Long userId);
 
     @Query("""
             select record

--- a/src/main/java/com/dokdok/book/service/BookService.java
+++ b/src/main/java/com/dokdok/book/service/BookService.java
@@ -39,8 +39,9 @@ public class BookService {
                 : List.of();
         boolean hasNext = response != null && response.meta() != null && !response.meta().isEnd();
         BookSearchCursor nextCursor = hasNext ? new BookSearchCursor(page + 1) : null;
+        long totalCount = response != null && response.meta() != null ? response.meta().totalCount() : 0L;
 
-        return CursorPageResponse.of(items, pageSize, hasNext, nextCursor);
+        return CursorPageResponse.of(items, pageSize, hasNext, nextCursor, totalCount);
     }
 
     public BookDetailResponse getBook(String isbn) {

--- a/src/main/java/com/dokdok/book/service/PersonalBookService.java
+++ b/src/main/java/com/dokdok/book/service/PersonalBookService.java
@@ -120,6 +120,11 @@ public class PersonalBookService {
                         cursorBookId,
                         PageRequest.of(0, pageSize + 1)
                 );
+        long totalCount = personalBookRepository.countPersonalBooksByUserIdReadingStatusAndGatheringId(
+                userEntity.getId(),
+                gatheringId,
+                readingStatus
+        );
 
         boolean hasNext = results.size() > pageSize;
         List<PersonalBookListProjection> pageResults = hasNext ? results.subList(0, pageSize) : results;
@@ -133,7 +138,7 @@ public class PersonalBookService {
             nextCursor = BookListCursor.from(last.getAddedAt(), last.getBookId());
         }
 
-        return CursorPageResponse.of(items, pageSize, hasNext, nextCursor);
+        return CursorPageResponse.of(items, pageSize, hasNext, nextCursor, totalCount);
     }
 
     public PersonalBookDetailResponse getPersonalBook(Long bookId) {

--- a/src/main/java/com/dokdok/book/service/PersonalReadingRecordService.java
+++ b/src/main/java/com/dokdok/book/service/PersonalReadingRecordService.java
@@ -143,6 +143,10 @@ public class PersonalReadingRecordService {
                     )
                     .getContent();
         }
+        long totalCount = personalReadingRecordRepository.countByPersonalBook_IdAndUserId(
+                personalBookEntity.getId(),
+                userEntity.getId()
+        );
 
         boolean hasNext = entities.size() > pageSize;
         List<PersonalReadingRecord> pageEntities = hasNext ? entities.subList(0, pageSize) : entities;
@@ -156,7 +160,7 @@ public class PersonalReadingRecordService {
             nextCursor = ReadingRecordCursor.from(last.getCreatedAt(), last.getId());
         }
 
-        return CursorPageResponse.of(items, pageSize, hasNext, nextCursor);
+        return CursorPageResponse.of(items, pageSize, hasNext, nextCursor, totalCount);
     }
 
     public PersonalReadingTopicAnswerResponse getTopicAnswers(Long personalBookId) {

--- a/src/main/java/com/dokdok/book/service/PersonalReadingRecordService.java
+++ b/src/main/java/com/dokdok/book/service/PersonalReadingRecordService.java
@@ -221,7 +221,7 @@ public class PersonalReadingRecordService {
             if (page == null || excerpt == null) {
                 throw new RecordException(RecordErrorCode.INVALID_RECORD_REQUEST);
             }
-            meta.put("page", Integer.parseInt(String.valueOf(page)));
+            meta.put("page", String.valueOf(page));
             meta.put("excerpt", String.valueOf(excerpt));
         }
         return meta;

--- a/src/test/java/com/dokdok/book/service/PersonalReadingRecordServiceTest.java
+++ b/src/test/java/com/dokdok/book/service/PersonalReadingRecordServiceTest.java
@@ -171,7 +171,7 @@ class PersonalReadingRecordServiceTest {
         assertThat(response.recordType()).isEqualTo(RecordType.QUOTE);
         assertThat(response.recordContent()).isEqualTo(request.recordContent());
         assertThat(response.meta()).isNotNull();
-        assertThat(response.meta().get("page")).isEqualTo(12);
+        assertThat(response.meta().get("page")).isEqualTo("12");
         assertThat(response.meta().get("excerpt")).isEqualTo("인용 내용");
         assertThat(response.bookId()).isEqualTo(bookId);
 
@@ -181,7 +181,7 @@ class PersonalReadingRecordServiceTest {
 
         com.dokdok.book.entity.PersonalReadingRecord savedRecord = recordCaptor.getValue();
         assertThat(savedRecord.getMeta()).isNotNull();
-        assertThat(savedRecord.getMeta().get("page")).isEqualTo(12);
+        assertThat(savedRecord.getMeta().get("page")).isEqualTo("12");
         assertThat(savedRecord.getMeta().get("excerpt")).isEqualTo("인용 내용");
 
         securityUtilMock.verify(SecurityUtil::getCurrentUserId, times(1));
@@ -284,12 +284,12 @@ class PersonalReadingRecordServiceTest {
         assertThat(response.recordContent()).isEqualTo(request.recordContent());
         assertThat(response.recordType()).isEqualTo(RecordType.QUOTE);
         assertThat(response.meta()).isNotNull();
-        assertThat(response.meta().get("page")).isEqualTo(30);
+        assertThat(response.meta().get("page")).isEqualTo("30");
         assertThat(response.meta().get("excerpt")).isEqualTo("수정된 인용문");
 
         assertThat(record.getRecordContent()).isEqualTo(request.recordContent());
         assertThat(record.getRecordType()).isEqualTo(RecordType.QUOTE);
-        assertThat(record.getMeta().get("page")).isEqualTo(30);
+        assertThat(record.getMeta().get("page")).isEqualTo("30");
 
         verify(personalReadingRecordRepository, times(1))
                 .findByIdAndPersonalBook_IdAndUserId(recordId, personalBookId, userId);


### PR DESCRIPTION
## PR 요약

  > QUOTE 기록의 meta.page를 정수에서 문자열로 저장/응답하도록 변경해 범위 표현 등을 보존합니다. 관련 API 문서와 테스트를 함께 수정했습니다. 체크 표시는 괄호 사이에 소문자 'x'를 삽입했습니다.                                                                                                                             

  - [ ] 기능 추가
  - [x] 버그 수정
  - [ ] 코드 리팩토링
  - [x] 문서 수정
  - [ ] 기타 (설명)

  ———

  ## 이슈 번호

  - #268

  ———

  ## 주요 변경 사항

  > 주요 파일, 로직, 컴포넌트 등을 구체적으로 적어주세요.                                                                                                                                                                                                                                                                   

  - src/main/java/com/dokdok/book/service/PersonalReadingRecordService.java: QUOTE meta.page를 String으로 저장하도록 변경(범위 문자열 유지)
  - src/main/java/com/dokdok/book/api/PersonalBookRecordApi.java: 요청/응답 예시 및 설명에서 page를 문자열로 명시
  - src/test/java/com/dokdok/book/service/PersonalReadingRecordServiceTest.java: meta.page 문자열 기대값으로 테스트 수정

  ———

  ## 참고 사항

  > 리뷰어가 알아야 할 추가 정보, 테스트 방법 등을 작성해주세요. 