### PR TITLE
[#19][REFACTOR] 사전의견 조회 응답값 추가

### DIFF
--- a/src/main/java/com/dokdok/book/api/PersonalBookRecordApi.java
+++ b/src/main/java/com/dokdok/book/api/PersonalBookRecordApi.java
@@ -566,6 +566,7 @@ public interface PersonalBookRecordApi {
                                           {
                                             "topicTitle": "가짜 욕망, 유사 욕망",
                                             "topicDescription": "가짜 욕망, 유사 욕망에 대해 이야기해봅시다.",
+                                            "confirmOrder": 1,
                                             "answer": "가짜 욕망과 유사 욕망은 비슷해 보이지만 결이 다르다고 느꼈다."
                                           }
                                         ]

--- a/src/main/java/com/dokdok/book/dto/response/PersonalReadingTopicAnswerResponse.java
+++ b/src/main/java/com/dokdok/book/dto/response/PersonalReadingTopicAnswerResponse.java
@@ -22,6 +22,8 @@ public record PersonalReadingTopicAnswerResponse(
             String topicTitle,
             @Schema(description = "주제 설명", example = "가짜 욕망, 유사 욕망에 대해 이야기해봅시다.")
             String topicDescription,
+            @Schema(description = "확정 순서", example = "1")
+            Integer confirmOrder,
             @Schema(description = "주제 답변", example = "가짜 욕망과 유사 욕망은 비슷해 보이지만 결이 다르다고 느꼈다.")
             String answer
     ) {

--- a/src/main/java/com/dokdok/book/service/PersonalReadingRecordService.java
+++ b/src/main/java/com/dokdok/book/service/PersonalReadingRecordService.java
@@ -192,6 +192,7 @@ public class PersonalReadingRecordService {
                 .map(topic -> new PersonalReadingTopicAnswerResponse.TopicAnswerInfo(
                         topic.getTitle(),
                         topic.getDescription(),
+                        topic.getConfirmOrder(),
                         topicAnswerMap.containsKey(topic.getId())
                                 ? topicAnswerMap.get(topic.getId()).getContent()
                                 : null

--- a/src/main/java/com/dokdok/topic/api/TopicApi.java
+++ b/src/main/java/com/dokdok/topic/api/TopicApi.java
@@ -260,7 +260,7 @@ public interface TopicApi {
                     content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
                             schema = @Schema(implementation = ConfirmTopicsResponse.class),
                             examples = @ExampleObject(value = """
-                                    {"code":"SUCCESS","message":"주제가 확정되었습니다.","data":{"confirmedTopicIds":[1,2,3]}}
+                                    {"code":"SUCCESS","message":"주제가 확정되었습니다.","data":{"meetingId":1,"topicStatus":"CONFIRMED","topics":[{"topicId":1,"confirmOrder":1},{"topicId":2,"confirmOrder":2},{"topicId":3,"confirmOrder":3}]}}
                                     """))
             ),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(

--- a/src/main/java/com/dokdok/topic/dto/response/ConfirmTopicsResponse.java
+++ b/src/main/java/com/dokdok/topic/dto/response/ConfirmTopicsResponse.java
@@ -3,6 +3,8 @@ package com.dokdok.topic.dto.response;
 import com.dokdok.topic.entity.TopicStatus;
 import io.swagger.v3.oas.annotations.media.Schema;
 
+import java.util.List;
+
 @Schema(description = "주제 확정 응답")
 public record ConfirmTopicsResponse(
         @Schema(description = "약속 ID", example = "1")
@@ -10,9 +12,27 @@ public record ConfirmTopicsResponse(
 
         @Schema(description = "주제 상태 (PROPOSED: 제안됨, CONFIRMED: 확정됨)", example = "CONFIRMED",
                 allowableValues = {"PROPOSED", "CONFIRMED"})
-        TopicStatus topicStatus
+        TopicStatus topicStatus,
+
+        @Schema(description = "확정된 주제 목록")
+        List<ConfirmedTopicOrder> topics
 ) {
-    public static ConfirmTopicsResponse from(Long meetingId) {
-        return new ConfirmTopicsResponse(meetingId, TopicStatus.CONFIRMED);
+    @Schema(description = "확정된 주제 정보")
+    public record ConfirmedTopicOrder(
+            @Schema(description = "주제 ID", example = "10")
+            Long topicId,
+            @Schema(description = "확정 순서", example = "1")
+            Integer confirmOrder
+    ) {
+        public static ConfirmedTopicOrder of(Long topicId, Integer confirmOrder) {
+            return new ConfirmedTopicOrder(topicId, confirmOrder);
+        }
+    }
+
+    public static ConfirmTopicsResponse from(
+            Long meetingId,
+            List<ConfirmedTopicOrder> topics
+    ) {
+        return new ConfirmTopicsResponse(meetingId, TopicStatus.CONFIRMED, topics);
     }
 }

--- a/src/main/java/com/dokdok/topic/service/TopicService.java
+++ b/src/main/java/com/dokdok/topic/service/TopicService.java
@@ -4,7 +4,6 @@ import com.dokdok.gathering.service.GatheringValidator;
 import com.dokdok.global.util.SecurityUtil;
 import com.dokdok.meeting.entity.Meeting;
 import com.dokdok.meeting.entity.MeetingMember;
-import com.dokdok.meeting.repository.MeetingRepository;
 import com.dokdok.meeting.service.MeetingValidator;
 import com.dokdok.topic.dto.request.ConfirmTopicsRequest;
 import com.dokdok.topic.dto.request.SuggestTopicRequest;
@@ -28,7 +27,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.RequestMapping;
 
-import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -146,6 +145,7 @@ public class TopicService {
                 topics.stream()
                         .collect(Collectors.toMap(Topic::getId, Function.identity()));
 
+        List<ConfirmTopicsResponse.ConfirmedTopicOrder> confirmedTopics = new ArrayList<>(topicIds.size());
         for (int i = 0; i < topicIds.size(); i++) {
             Long topicId = topicIds.get(i);
             Topic topic = topicMap.get(topicId);
@@ -154,9 +154,10 @@ public class TopicService {
             }
             topic.updateStatus(TopicStatus.CONFIRMED);
             topic.updateConfirmOrder(i + 1);
+            confirmedTopics.add(ConfirmTopicsResponse.ConfirmedTopicOrder.of(topicId, i + 1));
         }
 
-        return ConfirmTopicsResponse.from(meetingId);
+        return ConfirmTopicsResponse.from(meetingId, confirmedTopics);
     }
 
     @Transactional(readOnly = true)

--- a/src/test/java/com/dokdok/topic/service/TopicServiceTest.java
+++ b/src/test/java/com/dokdok/topic/service/TopicServiceTest.java
@@ -152,6 +152,11 @@ class TopicServiceTest {
 
             assertThat(response.meetingId()).isEqualTo(meetingId);
             assertThat(response.topicStatus()).isEqualTo(TopicStatus.CONFIRMED);
+            assertThat(response.topics()).hasSize(2);
+            assertThat(response.topics().get(0).topicId()).isEqualTo(12L);
+            assertThat(response.topics().get(0).confirmOrder()).isEqualTo(1);
+            assertThat(response.topics().get(1).topicId()).isEqualTo(13L);
+            assertThat(response.topics().get(1).confirmOrder()).isEqualTo(2);
             assertThat(topic1.getTopicStatus()).isEqualTo(TopicStatus.CONFIRMED);
             assertThat(topic2.getTopicStatus()).isEqualTo(TopicStatus.CONFIRMED);
             assertThat(topic1.getConfirmOrder()).isEqualTo(1);


### PR DESCRIPTION
 ## PR 요약

  - [ ] 기능 추가
  - [ ] 버그 수정
  - [x] 코드 리팩토링
  - [x] 문서 수정
  - [ ] 기타 (설명)

  ———

  ## 이슈 번호

  - #19

  ———

  ## 주요 변경 사항

  - src/main/java/com/dokdok/topic/dto/response/ConfirmTopicsResponse.java: 주제 확정 응답에 confirmOrder 포함된 topics 리스트 추가
  - src/main/java/com/dokdok/topic/service/TopicService.java: 확정 시 응답용 순서 정보 구성
  - src/main/java/com/dokdok/topic/api/TopicApi.java: 주제 확정 API 응답 예시 갱신
  - src/test/java/com/dokdok/topic/service/TopicServiceTest.java: 확정 응답 topics 검증 추가
  - src/main/java/com/dokdok/book/dto/response/PersonalReadingTopicAnswerResponse.java: 사전 의견 조회 응답에 confirmOrder 추가
  - src/main/java/com/dokdok/book/service/PersonalReadingRecordService.java: 사전 의견 응답 매핑 시 confirmOrder 세팅
  - src/main/java/com/dokdok/book/api/PersonalBookRecordApi.java: 사전 의견 조회 API 응답 예시 갱신

  ———

  ## 참고 사항