### PR TITLE
[#275][REFACTOR] 키워드 목록 조회

### DIFF
--- a/src/main/java/com/dokdok/keyword/api/KeywordApi.java
+++ b/src/main/java/com/dokdok/keyword/api/KeywordApi.java
@@ -1,0 +1,67 @@
+package com.dokdok.keyword.api;
+
+import com.dokdok.book.entity.KeywordType;
+import com.dokdok.global.response.ApiResponse;
+import com.dokdok.keyword.dto.response.KeywordListResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import java.util.List;
+
+@Tag(name = "키워드", description = "키워드 관련 API")
+public interface KeywordApi {
+
+    @Operation(
+            summary = "키워드 목록 조회 (developer: 양재웅)",
+            description = """
+                    키워드 목록을 조회합니다.
+                    - types 파라미터로 키워드 타입을 필터링할 수 있습니다. (예: BOOK, IMPRESSION)
+                    - types 미전달 시 전체 키워드를 반환합니다.
+                    """
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "키워드 목록 조회 성공",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = KeywordListResponse.class),
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "code": "SUCCESS",
+                                      "message": "키워드 목록 조회 성공",
+                                      "data": {
+                                        "keywords": [
+                                          { "id": 1, "name": "인간관계", "type": "BOOK", "parentId": null, "parentName": null, "level": 1, "sortOrder": 1, "isSelectable": false },
+                                          { "id": 3, "name": "판타지", "type": "BOOK", "parentId": 1, "parentName": "인간관계", "level": 2, "sortOrder": 3, "isSelectable": true },
+                                          { "id": 101, "name": "긍정", "type": "IMPRESSION", "parentId": null, "parentName": null, "level": 1, "sortOrder": 1, "isSelectable": false }
+                                        ]
+                                      }
+                                    }
+                                    """))
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "500",
+                    description = "서버 오류",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(value = """
+                                    {"code": "E000", "message": "서버 에러가 발생했습니다. 담당자에게 문의 바랍니다.", "data": null}
+                                    """)))
+    })
+    @GetMapping(value = "/keywords", produces = MediaType.APPLICATION_JSON_VALUE)
+    ResponseEntity<ApiResponse<KeywordListResponse>> getKeywords(
+            @Parameter(
+                    description = "키워드 타입 필터 (예: BOOK, IMPRESSION)",
+                    example = "BOOK"
+            )
+            @RequestParam(required = false) List<KeywordType> types
+    );
+}

--- a/src/main/java/com/dokdok/keyword/controller/KeywordController.java
+++ b/src/main/java/com/dokdok/keyword/controller/KeywordController.java
@@ -1,0 +1,27 @@
+package com.dokdok.keyword.controller;
+
+import com.dokdok.book.entity.KeywordType;
+import com.dokdok.global.response.ApiResponse;
+import com.dokdok.keyword.api.KeywordApi;
+import com.dokdok.keyword.dto.response.KeywordListResponse;
+import com.dokdok.keyword.service.KeywordService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class KeywordController implements KeywordApi {
+
+    private final KeywordService keywordService;
+
+    @Override
+    public ResponseEntity<ApiResponse<KeywordListResponse>> getKeywords(List<KeywordType> types) {
+        KeywordListResponse response = keywordService.getKeywords(types);
+        return ApiResponse.success(response, "키워드 목록 조회 성공");
+    }
+}

--- a/src/main/java/com/dokdok/keyword/dto/response/KeywordListResponse.java
+++ b/src/main/java/com/dokdok/keyword/dto/response/KeywordListResponse.java
@@ -1,0 +1,54 @@
+package com.dokdok.keyword.dto.response;
+
+import com.dokdok.book.entity.KeywordType;
+import com.dokdok.keyword.entity.Keyword;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+@Schema(description = "키워드 목록 응답")
+public record KeywordListResponse(
+        @Schema(description = "키워드 목록")
+        List<KeywordInfo> keywords
+) {
+    public static KeywordListResponse from(List<Keyword> keywords) {
+        return new KeywordListResponse(
+                keywords.stream()
+                        .map(KeywordInfo::from)
+                        .toList()
+        );
+    }
+
+    @Schema(description = "키워드 정보")
+    public record KeywordInfo(
+            @Schema(description = "키워드 ID", example = "3")
+            Long id,
+            @Schema(description = "키워드 이름", example = "판타지")
+            String name,
+            @Schema(description = "키워드 타입", example = "BOOK")
+            KeywordType type,
+            @Schema(description = "부모 키워드 ID", example = "1")
+            Long parentId,
+            @Schema(description = "부모 키워드 이름", example = "기타")
+            String parentName,
+            @Schema(description = "키워드 레벨", example = "2")
+            Integer level,
+            @Schema(description = "정렬 순서", example = "3")
+            Integer sortOrder,
+            @Schema(description = "선택 가능 여부", example = "true")
+            Boolean isSelectable
+    ) {
+        public static KeywordInfo from(Keyword keyword) {
+            return new KeywordInfo(
+                    keyword.getId(),
+                    keyword.getKeywordName(),
+                    keyword.getKeywordType(),
+                    keyword.getParent() != null ? keyword.getParent().getId() : null,
+                    keyword.getParent() != null ? keyword.getParent().getKeywordName() : null,
+                    keyword.getLevel(),
+                    keyword.getSortOrder(),
+                    keyword.getIsSelectable()
+            );
+        }
+    }
+}

--- a/src/main/java/com/dokdok/keyword/repository/KeywordRepository.java
+++ b/src/main/java/com/dokdok/keyword/repository/KeywordRepository.java
@@ -1,7 +1,27 @@
 package com.dokdok.keyword.repository;
 
+import com.dokdok.book.entity.KeywordType;
 import com.dokdok.keyword.entity.Keyword;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
 
 public interface KeywordRepository extends JpaRepository<Keyword, Long> {
+    @Query("""
+            SELECT k
+            FROM Keyword k
+            LEFT JOIN FETCH k.parent p
+            ORDER BY k.keywordType, k.level, k.sortOrder, k.id
+            """)
+    List<Keyword> findAllWithParent();
+
+    @Query("""
+            SELECT k
+            FROM Keyword k
+            LEFT JOIN FETCH k.parent p
+            WHERE k.keywordType IN :keywordTypes
+            ORDER BY k.keywordType, k.level, k.sortOrder, k.id
+            """)
+    List<Keyword> findByKeywordTypeInWithParent(List<KeywordType> keywordTypes);
 }

--- a/src/main/java/com/dokdok/keyword/service/KeywordService.java
+++ b/src/main/java/com/dokdok/keyword/service/KeywordService.java
@@ -1,0 +1,29 @@
+package com.dokdok.keyword.service;
+
+import com.dokdok.book.entity.KeywordType;
+import com.dokdok.keyword.dto.response.KeywordListResponse;
+import com.dokdok.keyword.entity.Keyword;
+import com.dokdok.keyword.repository.KeywordRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class KeywordService {
+
+    private final KeywordRepository keywordRepository;
+
+    @Transactional(readOnly = true)
+    public KeywordListResponse getKeywords(List<KeywordType> types) {
+        List<Keyword> keywords;
+        if (types == null || types.isEmpty()) {
+            keywords = keywordRepository.findAllWithParent();
+        } else {
+            keywords = keywordRepository.findByKeywordTypeInWithParent(types);
+        }
+        return KeywordListResponse.from(keywords);
+    }
+}


### PR DESCRIPTION
 ## PR 요약

  - [x] 기능 추가
  - [ ] 버그 수정
  - [ ] 코드 리팩토링
  - [x] 문서 수정
  - [ ] 기타 (설명)

  ———

  ## 이슈 번호

  - #275 

  ———

  ## 주요 변경 사항

  - src/main/java/com/dokdok/keyword/api/KeywordApi.java: 키워드 목록 조회 API 신규 추가
  - src/main/java/com/dokdok/keyword/controller/KeywordController.java: 키워드 목록 조회 컨트롤러 구현
  - src/main/java/com/dokdok/keyword/service/KeywordService.java: 키워드 목록 조회 서비스 로직 추가
  - src/main/java/com/dokdok/keyword/dto/response/KeywordListResponse.java: 키워드 목록 응답 DTO 추가
  - src/main/java/com/dokdok/keyword/repository/KeywordRepository.java: 키워드 목록 조회 쿼리(부모 포함, 정렬) 추가

  ———

  ## 참고 사항

  - 관련 API: GET /api/keywords (예: types=BOOK,IMPRESSION)