### PR TITLE
[#277][REFACTOR] Meeting 관련 커서 리스폰스 변경

### DIFF
--- a/src/main/java/com/dokdok/global/response/CursorResponse.java
+++ b/src/main/java/com/dokdok/global/response/CursorResponse.java
@@ -1,5 +1,6 @@
 package com.dokdok.global.response;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
@@ -18,14 +19,28 @@ public record CursorResponse<T, C>(
         boolean hasNext,
 
         @Schema(description = "다음 페이지 커서 (hasNext가 false면 null)")
-        C nextCursor
+        C nextCursor,
+
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        @Schema(description = "전체 아이템 수 (첫 페이지 요청 시에만 제공)", example = "100")
+        Integer totalCount
 ) {
     public static <T, C> CursorResponse<T, C> of(List<T> items, int pageSize, boolean hasNext, C nextCursor) {
-        return new CursorResponse<>(items, pageSize, hasNext, hasNext ? nextCursor : null);
+        return new CursorResponse<>(items, pageSize, hasNext, hasNext ? nextCursor : null, null);
     }
 
     public static <T, C> CursorResponse<T, C> of(List<T> items, int pageSize, C nextCursor) {
         boolean hasNext = nextCursor != null;
-        return new CursorResponse<>(items, pageSize, hasNext, nextCursor);
+        return new CursorResponse<>(items, pageSize, hasNext, nextCursor, null);
+    }
+
+    public static <T, C> CursorResponse<T, C> of(
+            List<T> items,
+            int pageSize,
+            boolean hasNext,
+            C nextCursor,
+            Integer totalCount
+    ) {
+        return new CursorResponse<>(items, pageSize, hasNext, hasNext ? nextCursor : null, totalCount);
     }
 }

--- a/src/main/java/com/dokdok/meeting/api/MeetingListApi.java
+++ b/src/main/java/com/dokdok/meeting/api/MeetingListApi.java
@@ -68,6 +68,7 @@ public interface MeetingListApi {
                                             "meetingStatus": "CONFIRMED"
                                           }
                                         ],
+                                        "totalCount": 12,
                                         "pageSize": 4,
                                         "hasNext": true,
                                         "nextCursor": {

--- a/src/main/java/com/dokdok/meeting/api/MyMeetingListApi.java
+++ b/src/main/java/com/dokdok/meeting/api/MyMeetingListApi.java
@@ -65,6 +65,7 @@ public interface MyMeetingListApi {
                                             "progressStatus": "UPCOMING"
                                           }
                                         ],
+                                        "totalCount": 8,
                                         "pageSize": 4,
                                         "hasNext": true,
                                         "nextCursor": {

--- a/src/main/java/com/dokdok/meeting/dto/MeetingListItemCursorResponse.java
+++ b/src/main/java/com/dokdok/meeting/dto/MeetingListItemCursorResponse.java
@@ -10,6 +10,9 @@ public record MeetingListItemCursorResponse(
         @Schema(description = "아이템 목록")
         List<MeetingListItemResponse> items,
 
+        @Schema(description = "전체 아이템 수 (첫 페이지 요청 시에만 제공)", example = "100")
+        Integer totalCount,
+
         @Schema(description = "페이지 크기", example = "4")
         int pageSize,
 
@@ -22,6 +25,7 @@ public record MeetingListItemCursorResponse(
     public static MeetingListItemCursorResponse from(CursorResponse<MeetingListItemResponse, MeetingListCursor> response) {
         return new MeetingListItemCursorResponse(
                 response.items(),
+                response.totalCount(),
                 response.pageSize(),
                 response.hasNext(),
                 response.nextCursor()

--- a/src/main/java/com/dokdok/meeting/dto/MyMeetingListItemCursorResponse.java
+++ b/src/main/java/com/dokdok/meeting/dto/MyMeetingListItemCursorResponse.java
@@ -9,6 +9,9 @@ public record MyMeetingListItemCursorResponse(
         @Schema(description = "아이템 목록")
         List<MyMeetingListItemResponse> items,
 
+        @Schema(description = "전체 아이템 수 (첫 페이지 요청 시에만 제공)", example = "100")
+        Integer totalCount,
+
         @Schema(description = "페이지 크기", example = "4")
         int pageSize,
 

--- a/src/main/java/com/dokdok/meeting/service/MeetingService.java
+++ b/src/main/java/com/dokdok/meeting/service/MeetingService.java
@@ -581,7 +581,27 @@ public class MeetingService {
             );
         };
 
-        return buildMyMeetingListResponse(meetings, size, userId);
+        Integer totalCount = null;
+        if (cursor == null) {
+            totalCount = switch (safeFilter) {
+                case UPCOMING -> meetingMemberRepository.countMyUpcomingMeetings(
+                        userId,
+                        MeetingStatus.CONFIRMED,
+                        now,
+                        now.plusDays(3)
+                );
+                case DONE -> meetingMemberRepository.countMyMeetingsByStatus(
+                        userId,
+                        MeetingStatus.DONE
+                );
+                case ALL -> meetingMemberRepository.countMyMeetingsByStatuses(
+                        userId,
+                        List.of(MeetingStatus.CONFIRMED, MeetingStatus.DONE)
+                );
+            };
+        }
+
+        return buildMyMeetingListResponse(meetings, size, userId, totalCount);
     }
 
     /**
@@ -632,7 +652,10 @@ public class MeetingService {
                 cursorMeetingId(cursor),
                 pageable
         );
-        return buildMeetingListResponse(meetings, size, userId, gatheringId);
+        Integer totalCount = cursor == null
+                ? meetingRepository.countByGatheringIdAndMeetingStatus(gatheringId, MeetingStatus.CONFIRMED)
+                : null;
+        return buildMeetingListResponse(meetings, size, userId, gatheringId, totalCount);
     }
 
     /**
@@ -658,7 +681,15 @@ public class MeetingService {
                         pageable
                 );
 
-        return buildMeetingListResponse(meetings, size, userId, gatheringId);
+        Integer totalCount = cursor == null
+                ? meetingRepository.countUpcomingMeetings(
+                        gatheringId,
+                        MeetingStatus.CONFIRMED,
+                        now,
+                        now.plusDays(3)
+                )
+                : null;
+        return buildMeetingListResponse(meetings, size, userId, gatheringId, totalCount);
     }
 
     /**
@@ -678,7 +709,10 @@ public class MeetingService {
                 cursorMeetingId(cursor),
                 pageable
         );
-        return buildMeetingListResponse(meetings, size, userId, gatheringId);
+        Integer totalCount = cursor == null
+                ? meetingRepository.countByGatheringIdAndMeetingStatus(gatheringId, MeetingStatus.DONE)
+                : null;
+        return buildMeetingListResponse(meetings, size, userId, gatheringId, totalCount);
     }
 
     /**
@@ -699,7 +733,14 @@ public class MeetingService {
                 cursorMeetingId(cursor),
                 pageable
         );
-        return buildMeetingListResponse(meetings, size, userId, gatheringId);
+        Integer totalCount = cursor == null
+                ? meetingMemberRepository.countMeetingsByUserIdAndStatus(
+                        userId,
+                        gatheringId,
+                        MeetingStatus.DONE
+                )
+                : null;
+        return buildMeetingListResponse(meetings, size, userId, gatheringId, totalCount);
     }
 
     /**
@@ -709,12 +750,13 @@ public class MeetingService {
             List<Meeting> meetingCandidates,
             int size,
             Long userId,
-            Long gatheringId
+            Long gatheringId,
+            Integer totalCount
     ) {
         boolean hasNext = meetingCandidates.size() > size;
         List<Meeting> meetings = hasNext ? meetingCandidates.subList(0, size) : meetingCandidates;
         if (meetings.isEmpty()) {
-            return CursorResponse.of(List.of(), size, false, null);
+            return CursorResponse.of(List.of(), size, false, null, totalCount);
         }
 
         List<MeetingListItemResponse> items = buildMeetingItems(meetings, userId, gatheringId);
@@ -725,7 +767,7 @@ public class MeetingService {
             nextCursor = new MeetingListCursor(last.getMeetingStartDate(), last.getId());
         }
 
-        return CursorResponse.of(items, size, hasNext, nextCursor);
+        return CursorResponse.of(items, size, hasNext, nextCursor, totalCount);
     }
 
     /**
@@ -734,12 +776,13 @@ public class MeetingService {
     private CursorResponse<MyMeetingListItemResponse, MeetingListCursor> buildMyMeetingListResponse(
             List<Meeting> meetingCandidates,
             int size,
-            Long userId
+            Long userId,
+            Integer totalCount
     ) {
         boolean hasNext = meetingCandidates.size() > size;
         List<Meeting> meetings = hasNext ? meetingCandidates.subList(0, size) : meetingCandidates;
         if (meetings.isEmpty()) {
-            return CursorResponse.of(List.of(), size, false, null);
+            return CursorResponse.of(List.of(), size, false, null, totalCount);
         }
 
         List<MyMeetingListItemResponse> items = buildMyMeetingItems(meetings, userId);
@@ -750,7 +793,7 @@ public class MeetingService {
             nextCursor = new MeetingListCursor(last.getMeetingStartDate(), last.getId());
         }
 
-        return CursorResponse.of(items, size, hasNext, nextCursor);
+        return CursorResponse.of(items, size, hasNext, nextCursor, totalCount);
     }
 
     /**


### PR DESCRIPTION
## PR 요약
> 이 PR이 어떤 변경을 하는지 간단히 설명하고, 체크 표시는 괄호 사이에 소문자 'x'를 삽입하세요.

- [ ] 기능 추가
- [ ] 버그 수정
- [x] 코드 리팩토링
- [ ] 문서 수정
- [ ] 기타 (설명)

---

## 이슈 번호
- #277

---

## 주요 변경 사항
> 주요 파일, 로직, 컴포넌트 등을 구체적으로 적어주세요.
  - src/main/java/com/dokdok/global/response/CursorResponse.java — 커서 응답에 totalCount(nullable) 추가, 첫 페이지에만 내려주기 위한 팩토리 메서드 확장 및 null 숨김 처
    리 적용
  - src/main/java/com/dokdok/meeting/service/MeetingService.java — 미팅 리스트/내 약속 리스트에서 첫 페이지(cursor 없음)일 때만 totalCount 계산하도록 로직 추가
  - src/main/java/com/dokdok/meeting/dto/MeetingListItemCursorResponse.java — 문서용 DTO에 totalCount 필드 추가 및 매핑 반영
  - src/main/java/com/dokdok/meeting/dto/MyMeetingListItemCursorResponse.java — 문서용 DTO에 totalCount 필드 추가
  - src/main/java/com/dokdok/meeting/api/MeetingListApi.java / src/main/java/com/dokdok/meeting/api/MyMeetingListApi.java — 응답 예시에 totalCount 추가


---

## 참고 사항
> 리뷰어가 알아야 할 추가 정보, 테스트 방법 등을 작성해주세요.

예:
- 테스트 계정 정보
- 관련 API 엔드포인트
- 로컬 테스트 방법

---
