### PR TITLE
[#280][REFACTOR] 약속 ActioncState 값 추가

### DIFF
--- a/docs/ErrorCode.md
+++ b/docs/ErrorCode.md
@@ -126,6 +126,9 @@
 | M013 | INVALID_MAX_PARTICIPANTS | 최대 참가 인원은 1명 이상이어야 하며, 모임 전체 인원을 초과할 수 없습니다. | 400 |
 | M014 | MAX_PARTICIPANTS_LESS_THAN_CURRENT | 현재 참가 확정된 인원 수보다 적게 수정할 수 없습니다. | 400 |
 | M015 | MEETING_DELETE_NOT_ALLOWED | 약속 시작 24시간 이내에는 삭제할 수 없습니다. | 400 |
+| M016 | MEETING_JOIN_NOT_ALLOWED | 약속 시작 24시간 이내에는 참가 신청할 수 없습니다. | 400 |
+| M017 | MEETING_UPDATE_NOT_ALLOWED | 약속 시작 24시간 이내에는 수정할 수 없습니다. | 400 |
+| M018 | MEETING_NOT_CONFIRMED | 약속이 확정된 경우에만 주제를 제안할 수 있습니다. | 400 |
 
 ---
 

--- a/src/main/java/com/dokdok/meeting/api/MeetingApi.java
+++ b/src/main/java/com/dokdok/meeting/api/MeetingApi.java
@@ -302,6 +302,7 @@ public interface MeetingApi {
             약속에 참가 신청합니다.
             - 권한: 모임원 전원
             - 제약: 모집 정원 마감 전
+            - 제약: 약속 시작 24시간 이내 참가 신청 불가
             """,
             parameters = {
                     @Parameter(name = "meetingId", description = "약속 식별자", in = ParameterIn.PATH, required = true)
@@ -329,6 +330,9 @@ public interface MeetingApi {
                                             """),
                                     @ExampleObject(name = "이미 참가", value = """
                                             {"code": "M010", "message": "이미 참가한 약속입니다.", "data": null}
+                                            """),
+                                    @ExampleObject(name = "24시간 이내 참가 불가", value = """
+                                            {"code": "M016", "message": "약속 시작 24시간 이내에는 참가 신청할 수 없습니다.", "data": null}
                                             """)
                             })),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "모임 멤버가 아님",
@@ -413,6 +417,7 @@ public interface MeetingApi {
             약속 정보를 수정합니다.
             - 권한: 약속장
             - 제약: 종료된 약속은 수정 불가
+            - 제약: 약속 시작 24시간 이내 수정 불가
             - 제약: 종료 일시는 시작 일시보다 이전일 수 없음
             - 제약: 최대 참여 인원은 현재 참여 인원보다 작을 수 없음
             """
@@ -451,6 +456,9 @@ public interface MeetingApi {
                                             """),
                                     @ExampleObject(name = "잘못된 최대 인원", value = """
                                             {"code": "M013", "message": "최대 참가 인원은 1명 이상이어야 하며, 모임 전체 인원을 초과할 수 없습니다.", "data": null}
+                                            """),
+                                    @ExampleObject(name = "24시간 이내 수정 불가", value = """
+                                            {"code": "M017", "message": "약속 시작 24시간 이내에는 수정할 수 없습니다.", "data": null}
                                             """)
                             })),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "약속장 아님",

--- a/src/main/java/com/dokdok/meeting/dto/MeetingActionType.java
+++ b/src/main/java/com/dokdok/meeting/dto/MeetingActionType.java
@@ -9,7 +9,9 @@ public enum MeetingActionType {
     CAN_EDIT("수정하기", true),
     EDIT_TIME_EXPIRED("수정 가능 시간이 지났어요", false),
     CAN_JOIN("참가 신청하기", true),
+    JOIN_TIME_EXPIRED("참가 신청하기", false),
     CAN_CANCEL("참가 신청 취소하기", true),
+    CANCEL_TIME_EXPIRED("참가 신청 취소하기", false),
     RECRUITMENT_CLOSED("모집인원이 마감되었어요", false),
     DONE("약속이 끝났어요", false),
     REJECTED("약속 신청이 거절됐어요", false);

--- a/src/main/java/com/dokdok/meeting/dto/MeetingDetailResponse.java
+++ b/src/main/java/com/dokdok/meeting/dto/MeetingDetailResponse.java
@@ -95,7 +95,7 @@ public record MeetingDetailResponse(
 
         User meetingLeader = meeting.getMeetingLeader();
         if (meetingLeader != null && meetingLeader.getId().equals(requestUserId)) {
-            if (isEditTimeExpired(meeting.getMeetingStartDate())) {
+            if (isActionTimeExpired(meeting.getMeetingStartDate())) {
                 return ActionState.editTimeExpired();
             }
             return ActionState.canEdit();
@@ -104,7 +104,14 @@ public record MeetingDetailResponse(
         boolean isParticipant = activeMembers.stream()
                 .anyMatch(member -> member.getUser().getId().equals(requestUserId));
         if (isParticipant) {
+            if (isActionTimeExpired(meeting.getMeetingStartDate())) {
+                return ActionState.cancelTimeExpired();
+            }
             return ActionState.canCancel();
+        }
+
+        if (isActionTimeExpired(meeting.getMeetingStartDate())) {
+            return ActionState.joinTimeExpired();
         }
 
         if (isRecruitmentClosed(currentCount, maxCount)) {
@@ -118,7 +125,7 @@ public record MeetingDetailResponse(
         return maxCount != null && currentCount >= maxCount;
     }
 
-    private static boolean isEditTimeExpired(LocalDateTime meetingStartDate) {
+    private static boolean isActionTimeExpired(LocalDateTime meetingStartDate) {
         return meetingStartDate != null
                 && meetingStartDate.isBefore(LocalDateTime.now().plusHours(24));
     }
@@ -264,7 +271,9 @@ public record MeetingDetailResponse(
                     - 약속장: CAN_EDIT (enabled=true, buttonLabel=수정하기)
                     - 약속장(24시간 전): EDIT_TIME_EXPIRED (enabled=false, buttonLabel=수정 가능 시간이 지났어요)
                     - 모임원 + 미참가: CAN_JOIN (enabled=true, buttonLabel=참가 신청하기)
+                    - 모임원 + 미참가(24시간 전): JOIN_TIME_EXPIRED (enabled=false, buttonLabel=참가 신청하기)
                     - 모임원 + 참가: CAN_CANCEL (enabled=true, buttonLabel=참가 신청 취소하기)
+                    - 모임원 + 참가(24시간 전): CANCEL_TIME_EXPIRED (enabled=false, buttonLabel=참가 신청 취소하기)
                     - 모임원 + 모집 마감: RECRUITMENT_CLOSED (enabled=false, buttonLabel=모집인원이 마감되었어요)
                     - 약속 종료(DONE): DONE (enabled=false, buttonLabel=약속이 끝났어요)
                     - 약속 거절(REJECTED): REJECTED (enabled=false, buttonLabel=약속 신청이 거절됐어요)
@@ -289,8 +298,16 @@ public record MeetingDetailResponse(
             return fromType(MeetingActionType.CAN_JOIN);
         }
 
+        public static ActionState joinTimeExpired() {
+            return fromType(MeetingActionType.JOIN_TIME_EXPIRED);
+        }
+
         public static ActionState canCancel() {
             return fromType(MeetingActionType.CAN_CANCEL);
+        }
+
+        public static ActionState cancelTimeExpired() {
+            return fromType(MeetingActionType.CANCEL_TIME_EXPIRED);
         }
 
         public static ActionState recruitmentClosed() {

--- a/src/main/java/com/dokdok/meeting/exception/MeetingErrorCode.java
+++ b/src/main/java/com/dokdok/meeting/exception/MeetingErrorCode.java
@@ -24,6 +24,9 @@ public enum MeetingErrorCode implements BaseErrorCode {
     MEETING_ALREADY_CANCELED("M011", "이미 취소된 약속입니다.", HttpStatus.BAD_REQUEST),
     MEETING_CANCEL_NOT_ALLOWED("M012", "약속 시작 24시간 이내에는 취소할 수 없습니다.", HttpStatus.BAD_REQUEST),
     MEETING_DELETE_NOT_ALLOWED("M015", "약속 시작 24시간 이내에는 삭제할 수 없습니다.", HttpStatus.BAD_REQUEST),
+    MEETING_JOIN_NOT_ALLOWED("M016", "약속 시작 24시간 이내에는 참가 신청할 수 없습니다.", HttpStatus.BAD_REQUEST),
+    MEETING_UPDATE_NOT_ALLOWED("M017", "약속 시작 24시간 이내에는 수정할 수 없습니다.", HttpStatus.BAD_REQUEST),
+    MEETING_NOT_CONFIRMED("M018", "약속이 확정된 경우에만 주제를 제안할 수 있습니다.", HttpStatus.BAD_REQUEST),
 
     INVALID_MAX_PARTICIPANTS("M013", "최대 참가 인원은 1명 이상이어야 하며, 모임 전체 인원을 초과할 수 없습니다.", HttpStatus.BAD_REQUEST),
     MAX_PARTICIPANTS_LESS_THAN_CURRENT("M014", "현재 참가 확정된 인원 수보다 적게 수정할 수 없습니다.", HttpStatus.BAD_REQUEST);

--- a/src/main/java/com/dokdok/meeting/service/MeetingService.java
+++ b/src/main/java/com/dokdok/meeting/service/MeetingService.java
@@ -220,6 +220,8 @@ public class MeetingService {
 
         Meeting meeting = meetingValidator.findMeetingOrThrow(meetingId);
 
+        validateJoinableMeetingStartDate(meeting);
+
         gatheringValidator.validateMembership(meeting.getGathering().getId(), userId);
 
         if (restoreCanceledMemberIfExists(meetingId, userId, meeting.getMaxParticipants())) {
@@ -382,6 +384,7 @@ public class MeetingService {
         meetingValidator.validateMeetingLeader(meeting, userId);
 
         validateUpdatableStatus(meeting);
+        validateUpdatableMeetingStartDate(meeting);
 
         Long gatheringId = meeting.getGathering().getId();
         validateMaxParticipants(request.maxParticipants(), gatheringId);
@@ -416,6 +419,28 @@ public class MeetingService {
                     MeetingErrorCode.INVALID_MEETING_STATUS_CHANGE,
                     "종료된 약속은 수정할 수 없습니다."
             );
+        }
+    }
+
+    /**
+     * 약속 시작 24시간 이내면 수정 불가
+     */
+    private void validateUpdatableMeetingStartDate(Meeting meeting) {
+        LocalDateTime meetingStartDate = meeting.getMeetingStartDate();
+        if (meetingStartDate != null
+                && meetingStartDate.isBefore(LocalDateTime.now().plusHours(24))) {
+            throw new MeetingException(MeetingErrorCode.MEETING_UPDATE_NOT_ALLOWED);
+        }
+    }
+
+    /**
+     * 약속 시작 24시간 이내면 참가 신청 불가
+     */
+    private void validateJoinableMeetingStartDate(Meeting meeting) {
+        LocalDateTime meetingStartDate = meeting.getMeetingStartDate();
+        if (meetingStartDate != null
+                && meetingStartDate.isBefore(LocalDateTime.now().plusHours(24))) {
+            throw new MeetingException(MeetingErrorCode.MEETING_JOIN_NOT_ALLOWED);
         }
     }
 

--- a/src/main/java/com/dokdok/meeting/service/MeetingValidator.java
+++ b/src/main/java/com/dokdok/meeting/service/MeetingValidator.java
@@ -46,14 +46,14 @@ public class MeetingValidator {
     }
 
     /**
-     * 약속 상태가 PENDING인지 검증한다.
+     * 약속 상태가 CONFIRMED인지 검증한다.
      */
     public void validateMeetingStatus(Long meetingId) {
         Meeting meeting = meetingRepository.findById(meetingId)
                 .orElseThrow(() -> new MeetingException(MeetingErrorCode.MEETING_NOT_FOUND));
 
-        if (meeting.getMeetingStatus() != MeetingStatus.PENDING) {
-            throw new MeetingException(MeetingErrorCode.MEETING_ALREADY_CONFIRMED);
+        if (meeting.getMeetingStatus() != MeetingStatus.CONFIRMED) {
+            throw new MeetingException(MeetingErrorCode.MEETING_NOT_CONFIRMED);
         }
     }
 

--- a/src/test/java/com/dokdok/meeting/service/MeetingServiceTest.java
+++ b/src/test/java/com/dokdok/meeting/service/MeetingServiceTest.java
@@ -701,6 +701,41 @@ class MeetingServiceTest {
         }
     }
 
+    @DisplayName("약속 시작 24시간 이내면 참가 신청에 실패한다.")
+    @Test
+    void givenMeetingWithin24Hours_whenJoinMeeting_thenThrowException() {
+        // given
+        Long meetingId = 3L;
+        Long userId = 7L;
+        Meeting meeting = Meeting.builder()
+                .id(meetingId)
+                .meetingStartDate(LocalDateTime.now().plusHours(1))
+                .gathering(Gathering.builder()
+                        .id(1L)
+                        .gatheringName("gathering")
+                        .invitationLink("link")
+                        .build())
+                .book(sampleBook())
+                .build();
+
+        given(meetingValidator.findMeetingOrThrow(meetingId))
+                .willReturn(meeting);
+
+        try (MockedStatic<SecurityUtil> securityUtilMock = mockStatic(SecurityUtil.class)) {
+            securityUtilMock.when(SecurityUtil::getCurrentUserId).thenReturn(userId);
+
+            // when + then
+            assertThatThrownBy(() -> meetingService.joinMeeting(meetingId))
+                    .isInstanceOf(MeetingException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(MeetingErrorCode.MEETING_JOIN_NOT_ALLOWED);
+            verify(gatheringValidator, never()).validateMembership(any(), any());
+            verify(meetingValidator, never()).validateCapacity(any(), any());
+            verify(userValidator, never()).findUserOrThrow(any());
+            verify(meetingMemberRepository, never()).save(any());
+        }
+    }
+
     @DisplayName("약속 참가 신청을 취소할 수 있다.")
     @Test
     void givenMeetingId_whenMeetingCancel_thenSuccess() {
@@ -922,6 +957,36 @@ class MeetingServiceTest {
                     .isInstanceOf(MeetingException.class)
                     .extracting("errorCode")
                     .isEqualTo(MeetingErrorCode.MAX_PARTICIPANTS_LESS_THAN_CURRENT);
+        }
+    }
+
+    @DisplayName("약속 시작 24시간 이내면 약속을 수정할 수 없다.")
+    @Test
+    void givenMeetingWithin24Hours_whenUpdateMeeting_thenThrowException() {
+        // given
+        Meeting meeting = Meeting.builder()
+                .id(meetingId)
+                .meetingName("Meeting 1")
+                .meetingStatus(MeetingStatus.PENDING)
+                .meetingStartDate(LocalDateTime.now().plusHours(1))
+                .meetingLeader(leader)
+                .gathering(gathering)
+                .build();
+        MeetingUpdateRequest request = MeetingUpdateRequest.builder()
+                .meetingName("약속명 변경")
+                .build();
+
+        given(meetingValidator.findMeetingOrThrow(meetingId)).willReturn(meeting);
+
+        // when + then
+        try (MockedStatic<SecurityUtil> mock = mockStatic(SecurityUtil.class)) {
+            mock.when(SecurityUtil::getCurrentUserId).thenReturn(leader.getId());
+
+            assertThatThrownBy(() -> meetingService.updateMeeting(meetingId, request))
+                    .isInstanceOf(MeetingException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(MeetingErrorCode.MEETING_UPDATE_NOT_ALLOWED);
+            verify(meetingValidator, never()).countActiveMembers(any());
         }
     }
 

--- a/src/test/java/com/dokdok/topic/service/TopicServiceTest.java
+++ b/src/test/java/com/dokdok/topic/service/TopicServiceTest.java
@@ -408,7 +408,7 @@ class TopicServiceTest {
     }
 
     @Test
-    @DisplayName("약속 상태가 PENDING인 경우 예외가 발생한다")
+    @DisplayName("약속 상태가 CONFIRMED가 아니면 예외가 발생한다")
     void createTopic_MeetingStatusPending_ThrowsException() {
         Long gatheringId = 1L;
         Long meetingId = 1L;
@@ -424,7 +424,7 @@ class TopicServiceTest {
             doNothing().when(meetingValidator)
                     .validateMeetingInGathering(meetingId, gatheringId);
 
-            doThrow(new MeetingException(MeetingErrorCode.MEETING_ALREADY_CONFIRMED))
+            doThrow(new MeetingException(MeetingErrorCode.MEETING_NOT_CONFIRMED))
                     .when(meetingValidator)
                     .validateMeetingStatus(meetingId);
 
@@ -432,7 +432,7 @@ class TopicServiceTest {
                     topicService.createTopic(gatheringId, meetingId, testRequest))
                     .isInstanceOf(MeetingException.class)
                     .hasFieldOrPropertyWithValue("errorCode",
-                            MeetingErrorCode.MEETING_ALREADY_CONFIRMED);
+                            MeetingErrorCode.MEETING_NOT_CONFIRMED);
 
             verify(meetingValidator, never()).getMeetingMember(any(), any());
             verify(topicRepository, never()).save(any());


### PR DESCRIPTION
## PR 요약
> 이 PR이 어떤 변경을 하는지 간단히 설명하고, 체크 표시는 괄호 사이에 소문자 'x'를 삽입하세요.

- [ ] 기능 추가
- [ ] 버그 수정
- [x] 코드 리팩토링
- [ ] 문서 수정
- [ ] 기타 (설명)

---

## 이슈 번호
- #280

---

## 주요 변경 사항
> 주요 파일, 로직, 컴포넌트 등을 구체적으로 적어주세요.

  - docs/ErrorCode.md: +3/-0 — M016~M018 에러 코드 추가
  - src/main/java/com/dokdok/meeting: +60/-5 (6 files) — 24시간 제약/ActionState/에러코드/검증 로직 반영
  - src/test/java/com/dokdok/meeting: +65/-0 (1 files) — 참가/수정 24시간 제약 테스트 추가
  - src/test/java/com/dokdok/topic: +3/-3 (1 files) — 토픽 생성 상태 검증 테스트 수정


---

## 참고 사항
> 리뷰어가 알아야 할 추가 정보, 테스트 방법 등을 작성해주세요.

예:
- 테스트 계정 정보
- 관련 API 엔드포인트
- 로컬 테스트 방법

---
