### PR TITLE
[#281][REFACTOR] 약속 상세 조회 응답 값 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,6 @@ scripts/PR_BODY.md
 /logs/**
 /claude.md
 /agent.md
+
+### Private Docs ###
+docs/private/

--- a/src/main/java/com/dokdok/meeting/dto/MeetingDetailProgressStatus.java
+++ b/src/main/java/com/dokdok/meeting/dto/MeetingDetailProgressStatus.java
@@ -1,0 +1,11 @@
+package com.dokdok.meeting.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "약속 상세 진행 상태 (시간 기준) - PRE(약속 전), ONGOING(약속 중), POST(약속 후), UNKNOWN(일정 미정)")
+public enum MeetingDetailProgressStatus {
+    PRE,
+    ONGOING,
+    POST,
+    UNKNOWN
+}

--- a/src/main/java/com/dokdok/meeting/dto/MeetingDetailResponse.java
+++ b/src/main/java/com/dokdok/meeting/dto/MeetingDetailResponse.java
@@ -27,6 +27,15 @@ public record MeetingDetailResponse(
         @Schema(description = "약속 상태", example = "CONFIRMED")
         MeetingStatus meetingStatus,
 
+        @Schema(description = "약속 진행 상태(시간 기준)", example = "PRE")
+        MeetingDetailProgressStatus progressStatus,
+
+        @Schema(description = "주제 확정 여부", example = "true")
+        Boolean confirmedTopic,
+
+        @Schema(description = "주제 확정 날짜", example = "2026-01-30T10:00:00")
+        LocalDateTime confirmedTopicDate,
+
         @Schema(description = "모임 정보")
         GatheringInfo gathering,
 
@@ -49,7 +58,9 @@ public record MeetingDetailResponse(
     public static MeetingDetailResponse from(
             Meeting meeting,
             List<MeetingMember> meetingMembers,
-            Long requestUserId
+            Long requestUserId,
+            Boolean confirmedTopic,
+            LocalDateTime confirmedTopicDate
     ) {
         List<MeetingMember> safeMembers = meetingMembers == null ? Collections.emptyList() : meetingMembers;
         List<MeetingMember> activeMembers = safeMembers.stream()
@@ -66,10 +77,19 @@ public record MeetingDetailResponse(
                 participantsInfo.maxCount()
         );
 
+        MeetingDetailProgressStatus progressStatus = resolveProgressStatus(
+                meeting.getMeetingStartDate(),
+                meeting.getMeetingEndDate(),
+                LocalDateTime.now()
+        );
+
         return new MeetingDetailResponse(
                 meeting.getId(),
                 meeting.getMeetingName(),
                 meeting.getMeetingStatus(),
+                progressStatus,
+                confirmedTopic,
+                confirmedTopicDate,
                 GatheringInfo.from(meeting.getGathering()),
                 BookInfo.from(meeting.getBook()),
                 ScheduleInfo.from(meeting.getMeetingStartDate(), meeting.getMeetingEndDate()),
@@ -77,6 +97,23 @@ public record MeetingDetailResponse(
                 participantsInfo,
                 actionState
         );
+    }
+
+    private static MeetingDetailProgressStatus resolveProgressStatus(
+            LocalDateTime meetingStartDate,
+            LocalDateTime meetingEndDate,
+            LocalDateTime now
+    ) {
+        if (meetingStartDate == null || meetingEndDate == null) {
+            return MeetingDetailProgressStatus.UNKNOWN;
+        }
+        if (now.isBefore(meetingStartDate)) {
+            return MeetingDetailProgressStatus.PRE;
+        }
+        if (!now.isAfter(meetingEndDate)) {
+            return MeetingDetailProgressStatus.ONGOING;
+        }
+        return MeetingDetailProgressStatus.POST;
     }
 
     private static ActionState calculateActionState(

--- a/src/main/java/com/dokdok/meeting/service/MeetingService.java
+++ b/src/main/java/com/dokdok/meeting/service/MeetingService.java
@@ -27,6 +27,7 @@ import com.dokdok.meeting.exception.MeetingException;
 import com.dokdok.meeting.repository.MeetingMemberRepository;
 import com.dokdok.meeting.repository.MeetingRepository;
 import com.dokdok.topic.entity.Topic;
+import com.dokdok.topic.entity.TopicStatus;
 import com.dokdok.topic.entity.TopicType;
 import com.dokdok.topic.repository.TopicAnswerRepository;
 import com.dokdok.topic.repository.TopicRepository;
@@ -75,7 +76,19 @@ public class MeetingService {
 
         List<MeetingMember> meetingMembers = meetingMemberRepository.findAllByMeetingId(meetingId);
 
-        return MeetingDetailResponse.from(meeting, meetingMembers, userId);
+        LocalDateTime confirmedTopicDate = topicRepository.findConfirmedTopicDateByMeetingId(
+                meetingId,
+                TopicStatus.CONFIRMED
+        );
+        boolean confirmedTopic = confirmedTopicDate != null;
+
+        return MeetingDetailResponse.from(
+                meeting,
+                meetingMembers,
+                userId,
+                confirmedTopic,
+                confirmedTopicDate
+        );
     }
 
     /**

--- a/src/main/java/com/dokdok/topic/repository/TopicRepository.java
+++ b/src/main/java/com/dokdok/topic/repository/TopicRepository.java
@@ -183,6 +183,18 @@ public interface TopicRepository extends JpaRepository<Topic, Long> {
             @Param("meetingId") Long meetingId
     );
 
+    @Query("""
+            SELECT MAX(t.updatedAt)
+            FROM Topic t
+            WHERE t.meeting.id = :meetingId
+            AND t.topicStatus = :status
+            AND t.deletedAt IS NULL
+            """)
+    LocalDateTime findConfirmedTopicDateByMeetingId(
+            @Param("meetingId") Long meetingId,
+            @Param("status") TopicStatus status
+    );
+
     /**
      * 확정된 주제가 없고, 약속장 혹은 모임장일 경우 true
      */
@@ -233,6 +245,5 @@ public interface TopicRepository extends JpaRepository<Topic, Long> {
                 THEN true ELSE false END
             """)
     boolean canSuggestTopic(Long meetingId, Long userId);
-
 
 }

--- a/src/test/java/com/dokdok/meeting/service/MeetingServiceTest.java
+++ b/src/test/java/com/dokdok/meeting/service/MeetingServiceTest.java
@@ -24,6 +24,7 @@ import com.dokdok.meeting.exception.MeetingErrorCode;
 import com.dokdok.meeting.exception.MeetingException;
 import com.dokdok.meeting.repository.MeetingMemberRepository;
 import com.dokdok.meeting.repository.MeetingRepository;
+import com.dokdok.topic.entity.TopicStatus;
 import com.dokdok.topic.entity.TopicType;
 import com.dokdok.topic.repository.TopicAnswerRepository;
 import com.dokdok.topic.repository.TopicRepository;
@@ -141,6 +142,8 @@ class MeetingServiceTest {
                 .willReturn(meeting);
         given(meetingMemberRepository.findAllByMeetingId(meetingId))
                 .willReturn(java.util.Collections.emptyList());
+        given(topicRepository.findConfirmedTopicDateByMeetingId(meetingId, TopicStatus.CONFIRMED))
+                .willReturn(null);
         try (MockedStatic<SecurityUtil> securityUtilMock = mockStatic(SecurityUtil.class)) {
             securityUtilMock.when(SecurityUtil::getCurrentUserId).thenReturn(userId);
 
@@ -150,6 +153,90 @@ class MeetingServiceTest {
             // then
             assertThat(findMeeting.meetingName()).isEqualTo(meeting.getMeetingName());
             assertThat(findMeeting.meetingStatus()).isEqualTo(meeting.getMeetingStatus());
+            assertThat(findMeeting.progressStatus()).isEqualTo(MeetingDetailProgressStatus.UNKNOWN);
+            assertThat(findMeeting.confirmedTopic()).isFalse();
+            assertThat(findMeeting.confirmedTopicDate()).isNull();
+        }
+    }
+
+    @DisplayName("약속 상세 응답에 진행 상태가 전/중/후로 내려간다.")
+    @Test
+    void givenMeetingDates_whenFindMeeting_thenProgressStatus() {
+        // given
+        Long userId = 1L;
+        LocalDateTime now = LocalDateTime.now();
+        Meeting upcomingMeeting = Meeting.builder()
+                .id(meetingId)
+                .meetingName("Upcoming")
+                .meetingStatus(MeetingStatus.CONFIRMED)
+                .meetingStartDate(now.plusDays(1))
+                .meetingEndDate(now.plusDays(1).plusHours(1))
+                .meetingLeader(leader)
+                .gathering(gathering)
+                .build();
+        Meeting ongoingMeeting = Meeting.builder()
+                .id(meetingId)
+                .meetingName("Ongoing")
+                .meetingStatus(MeetingStatus.CONFIRMED)
+                .meetingStartDate(now.minusHours(1))
+                .meetingEndDate(now.plusHours(1))
+                .meetingLeader(leader)
+                .gathering(gathering)
+                .build();
+        Meeting finishedMeeting = Meeting.builder()
+                .id(meetingId)
+                .meetingName("Finished")
+                .meetingStatus(MeetingStatus.DONE)
+                .meetingStartDate(now.minusDays(1))
+                .meetingEndDate(now.minusDays(1).plusHours(1))
+                .meetingLeader(leader)
+                .gathering(gathering)
+                .build();
+
+        given(meetingValidator.findMeetingOrThrow(meetingId))
+                .willReturn(upcomingMeeting, ongoingMeeting, finishedMeeting);
+        given(meetingMemberRepository.findAllByMeetingId(meetingId))
+                .willReturn(java.util.Collections.emptyList());
+        given(topicRepository.findConfirmedTopicDateByMeetingId(meetingId, TopicStatus.CONFIRMED))
+                .willReturn(null);
+
+        try (MockedStatic<SecurityUtil> securityUtilMock = mockStatic(SecurityUtil.class)) {
+            securityUtilMock.when(SecurityUtil::getCurrentUserId).thenReturn(userId);
+
+            // when
+            MeetingDetailResponse upcoming = meetingService.findMeeting(meetingId);
+            MeetingDetailResponse ongoing = meetingService.findMeeting(meetingId);
+            MeetingDetailResponse finished = meetingService.findMeeting(meetingId);
+
+            // then
+            assertThat(upcoming.progressStatus()).isEqualTo(MeetingDetailProgressStatus.PRE);
+            assertThat(ongoing.progressStatus()).isEqualTo(MeetingDetailProgressStatus.ONGOING);
+            assertThat(finished.progressStatus()).isEqualTo(MeetingDetailProgressStatus.POST);
+        }
+    }
+
+    @DisplayName("약속 상세 응답에 주제 확정 여부와 날짜가 내려간다.")
+    @Test
+    void givenConfirmedTopicDate_whenFindMeeting_thenConfirmedTopicFields() {
+        // given
+        Long userId = 1L;
+        LocalDateTime confirmedAt = LocalDateTime.now().minusHours(1);
+        given(meetingValidator.findMeetingOrThrow(meetingId))
+                .willReturn(meeting);
+        given(meetingMemberRepository.findAllByMeetingId(meetingId))
+                .willReturn(java.util.Collections.emptyList());
+        given(topicRepository.findConfirmedTopicDateByMeetingId(meetingId, TopicStatus.CONFIRMED))
+                .willReturn(confirmedAt);
+
+        try (MockedStatic<SecurityUtil> securityUtilMock = mockStatic(SecurityUtil.class)) {
+            securityUtilMock.when(SecurityUtil::getCurrentUserId).thenReturn(userId);
+
+            // when
+            MeetingDetailResponse findMeeting = meetingService.findMeeting(meetingId);
+
+            // then
+            assertThat(findMeeting.confirmedTopic()).isTrue();
+            assertThat(findMeeting.confirmedTopicDate()).isEqualTo(confirmedAt);
         }
     }
 


### PR DESCRIPTION
## PR 요약
> 이 PR이 어떤 변경을 하는지 간단히 설명하고, 체크 표시는 괄호 사이에 소문자 'x'를 삽입하세요.

- [ ] 기능 추가
- [ ] 버그 수정
- [x] 코드 리팩토링
- [ ] 문서 수정
- [ ] 기타 (설명)

---

## 이슈 번호
- #281

---

## 주요 변경 사항
> 주요 파일, 로직, 컴포넌트 등을 구체적으로 적어주세요.

  - src/main/java/com/dokdok/meeting/dto/MeetingDetailProgressStatus.java: 상세 전용 진행 상태 enum(PRE/ONGOING/POST/UNKNOWN) 신설
  - src/main/java/com/dokdok/meeting/dto/MeetingDetailResponse.java: 상세 응답에 progressStatus, confirmedTopic, confirmedTopicDate 추가 및 계산 로직 포함
  - src/main/java/com/dokdok/meeting/service/MeetingService.java: 상세 조회 시 확정 주제 여부/날짜 조회 후 응답에 전달
  - src/main/java/com/dokdok/topic/repository/TopicRepository.java: 확정 주제 날짜 조회 쿼리 추가(상태 파라미터화)
  - src/test/java/com/dokdok/meeting/service/MeetingServiceTest.java: 상세 응답 진행 상태 및 확정 주제 필드 검증 테스트 추가

---

## 참고 사항
> 리뷰어가 알아야 할 추가 정보, 테스트 방법 등을 작성해주세요.

예:
- 테스트 계정 정보
- 관련 API 엔드포인트
- 로컬 테스트 방법

---
