### PR TITLE
[#285][FIX] 책 리뷰 히스토리 응답에 totalCount 추가

### DIFF
--- a/src/main/java/com/dokdok/book/api/BookReviewApi.java
+++ b/src/main/java/com/dokdok/book/api/BookReviewApi.java
@@ -281,6 +281,7 @@ public interface BookReviewApi {
             책 리뷰의 변경 이력을 조회합니다.
             - 커서 기반 무한스크롤 페이징 (기본 5건)
             - snapshot의 createdAt 기준 최신순 정렬
+            - totalCount: 첫 페이지 요청 시에만 전체 이력 수 제공 (이후 페이지는 null)
             - 권한: 로그인 사용자 (본인 리뷰만 조회 가능)
             """,
             parameters = {
@@ -303,7 +304,7 @@ public interface BookReviewApi {
                                         "items": [
                                           {
                                             "bookReviewHistoryId": 1,
-                                            "createdAt": "25.12.08 작성",
+                                            "createdAt": "2026-01-13T08:36:03.043",
                                             "rating": 4.0,
                                             "bookKeywords": [
                                               { "id": 1, "name": "관계", "type": "BOOK" },
@@ -315,6 +316,7 @@ public interface BookReviewApi {
                                             ]
                                           }
                                         ],
+                                        "totalCount": 12,
                                         "pageSize": 5,
                                         "hasNext": true,
                                         "nextCursor": {

--- a/src/main/java/com/dokdok/book/service/BookReviewService.java
+++ b/src/main/java/com/dokdok/book/service/BookReviewService.java
@@ -105,7 +105,9 @@ public class BookReviewService {
                 ? BookReviewHistoryCursor.from(paged.get(paged.size() - 1))
                 : null;
 
-        return CursorResponse.of(items, pageSize, hasNext, nextCursor);
+        Integer totalCount = (cursorHistoryId == null) ? sorted.size() : null;
+
+        return CursorResponse.of(items, pageSize, hasNext, nextCursor, totalCount);
     }
 
     private List<BookReviewHistory> sortByUpdatedAtDesc(List<BookReviewHistory> histories) {

--- a/src/main/java/com/dokdok/history/dto/BookReviewHistoryResponse.java
+++ b/src/main/java/com/dokdok/history/dto/BookReviewHistoryResponse.java
@@ -6,7 +6,7 @@ import com.dokdok.keyword.entity.Keyword;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.math.BigDecimal;
-import java.time.format.DateTimeFormatter;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -16,8 +16,8 @@ public record BookReviewHistoryResponse(
 		@Schema(description = "리뷰 이력 ID", example = "1")
 		Long bookReviewHistoryId,
 
-		@Schema(description = "작성 일시", example = "25.12.08 작성")
-		String createdAt,
+		@Schema(description = "작성 일시", example = "2025-12-08T14:30:00")
+		LocalDateTime createdAt,
 
 		@Schema(description = "별점", example = "4.0")
 		BigDecimal rating,
@@ -28,8 +28,6 @@ public record BookReviewHistoryResponse(
 		@Schema(description = "감상 키워드 목록")
 		List<KeywordInfo> impressionKeywords
 ) {
-
-	private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yy.MM.dd");
 
 	public static BookReviewHistoryResponse from(BookReviewHistory history, Map<Long, Keyword> keywordMap) {
 		BookReviewSnapshot snapshot = history.getSnapshot();
@@ -44,11 +42,9 @@ public record BookReviewHistoryResponse(
 				))
 				.collect(Collectors.groupingBy(KeywordInfo::type));
 
-		String formattedDate = snapshot.getUpdatedAt().format(DATE_FORMATTER) + " 작성";
-
 		return new BookReviewHistoryResponse(
 				history.getId(),
-				formattedDate,
+				snapshot.getUpdatedAt(),
 				snapshot.getRating(),
 				groupedKeywords.getOrDefault(KeywordType.BOOK, List.of()),
 				groupedKeywords.getOrDefault(KeywordType.IMPRESSION, List.of())

--- a/src/test/java/com/dokdok/book/service/BookReviewServiceTest.java
+++ b/src/test/java/com/dokdok/book/service/BookReviewServiceTest.java
@@ -481,6 +481,7 @@ class BookReviewServiceTest {
             assertThat(response.items().get(1).bookReviewHistoryId()).isEqualTo(1L);
             assertThat(response.hasNext()).isFalse();
             assertThat(response.nextCursor()).isNull();
+            assertThat(response.totalCount()).isEqualTo(2);
         }
     }
 
@@ -543,6 +544,7 @@ class BookReviewServiceTest {
             assertThat(firstPage.items().get(4).bookReviewHistoryId()).isEqualTo(3L);
             assertThat(firstPage.hasNext()).isTrue();
             assertThat(firstPage.nextCursor().historyId()).isEqualTo(3L);
+            assertThat(firstPage.totalCount()).isEqualTo(7);
 
             // 두 번째 페이지 (커서 3L 이후: 2, 1)
             CursorResponse<BookReviewHistoryResponse, BookReviewHistoryCursor> secondPage =
@@ -553,6 +555,7 @@ class BookReviewServiceTest {
             assertThat(secondPage.items().get(1).bookReviewHistoryId()).isEqualTo(1L);
             assertThat(secondPage.hasNext()).isFalse();
             assertThat(secondPage.nextCursor()).isNull();
+            assertThat(secondPage.totalCount()).isNull();
         }
     }
 
@@ -648,13 +651,14 @@ class BookReviewServiceTest {
     }
 
     @Test
-    @DisplayName("응답 날짜가 yy.MM.dd 작성 형식으로 포맷된다")
+    @DisplayName("응답 날짜가 LocalDateTime 형식으로 응답된다")
     void getReviewHistory_dateFormatted() {
         BookReview review = BookReview.builder().id(10L).build();
         Keyword keyword = Keyword.builder().id(42L).keywordName("사랑").keywordType(KeywordType.BOOK).build();
 
+        LocalDateTime expectedDateTime = LocalDateTime.of(2025, 12, 8, 15, 30, 0);
         BookReviewHistory history = createHistory(1L, HistoryAction.INSERT, new BigDecimal("4.5"),
-                List.of(42L), LocalDateTime.of(2025, 12, 8, 15, 30, 0));
+                List.of(42L), expectedDateTime);
 
         try (MockedStatic<SecurityUtil> securityUtilMock = org.mockito.Mockito.mockStatic(SecurityUtil.class)) {
             securityUtilMock.when(SecurityUtil::getCurrentUserId).thenReturn(3L);
@@ -666,7 +670,7 @@ class BookReviewServiceTest {
             CursorResponse<BookReviewHistoryResponse, BookReviewHistoryCursor> response =
                     bookReviewService.getReviewHistory(1L, 5, null);
 
-            assertThat(response.items().get(0).createdAt()).isEqualTo("25.12.08 작성");
+            assertThat(response.items().get(0).createdAt()).isEqualTo(expectedDateTime);
         }
     }
 }


### PR DESCRIPTION
## PR 요약
> 이 PR이 어떤 변경을 하는지 간단히 설명하고, 체크 표시는 괄호 사이에 소문자 'x'를 삽입하세요.

- [ ] 기능 추가
- [x] 버그 수정
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 기타 (설명)

---

## 이슈 번호
- #285

---

## 주요 변경 사항
> 주요 파일, 로직, 컴포넌트 등을 구체적으로 적어주세요.

- `src/main/java/com/dokdok/history/dto/BookReviewHistoryResponse.java`: 날짜 응답을 LocDateTime로 변경
- `src/main/java/com/dokdok/book/service/BookReviewService.java`: 첫 페이지 응답일 때만 totalCount를 포함.

---
