### PR TITLE
[#290][REFACTOR]이미지 URL 경로 수정

### DIFF
--- a/src/main/java/com/dokdok/gathering/dto/response/GatheringDetailResponse.java
+++ b/src/main/java/com/dokdok/gathering/dto/response/GatheringDetailResponse.java
@@ -8,6 +8,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
 import java.util.List;
+import java.util.Map;
 
 @Schema(description = "모임 상세 응답")
 @Builder
@@ -38,10 +39,11 @@ public record GatheringDetailResponse(
     public static GatheringDetailResponse from(
             GatheringMember currentMember,
             List<GatheringMember> allMember,
-            int totalMeetings
+            int totalMeetings,
+            Map<Long, String> profileImageUrlMap
     ){
         List<MemberInfo> memberInfoList = allMember.stream()
-                .map(MemberInfo::from)
+                .map(member -> MemberInfo.from(member, profileImageUrlMap.get(member.getUser().getId())))
                 .toList();
 
         Gathering gathering = currentMember.getGathering();
@@ -75,7 +77,7 @@ public record GatheringDetailResponse(
             @Schema(description = "모임 역할", example = "LEADER")
             GatheringRole role
     ){
-        public static MemberInfo from(GatheringMember member){
+        public static MemberInfo from(GatheringMember member, String presignedProfileImageUrl){
             if(member == null){
                 return null;
             }
@@ -83,7 +85,7 @@ public record GatheringDetailResponse(
                     .gatheringMemberId(member.getId())
                     .userId(member.getUser().getId())
                     .nickname(member.getUser().getNickname())
-                    .profileImageUrl(member.getUser().getProfileImageUrl())
+                    .profileImageUrl(presignedProfileImageUrl)
                     .role(member.getRole())
                     .build();
         }

--- a/src/main/java/com/dokdok/gathering/service/GatheringService.java
+++ b/src/main/java/com/dokdok/gathering/service/GatheringService.java
@@ -19,6 +19,7 @@ import com.dokdok.meeting.entity.MeetingMember;
 import com.dokdok.meeting.entity.MeetingStatus;
 import com.dokdok.meeting.repository.MeetingMemberRepository;
 import com.dokdok.meeting.repository.MeetingRepository;
+import com.dokdok.storage.service.StorageService;
 import com.dokdok.user.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -29,6 +30,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
@@ -46,6 +48,7 @@ public class GatheringService {
     private final GatheringBookRepository gatheringBookRepository;
     private final BookReviewRepository bookReviewRepository;
     private final MeetingMemberRepository meetingMemberRepository;
+    private final StorageService storageService;
 
     /**
      * 모임을 생성합니다.
@@ -192,11 +195,29 @@ public class GatheringService {
         // 총 약속 수
         int totalMeetings = meetingRepository.countByGatheringIdAndMeetingStatus(gathering.getId(), MeetingStatus.DONE);
 
+        Map<Long, String> profileImageUrlMap = buildProfileImageUrlMap(allMember);
+
         return GatheringDetailResponse.from(
                 currentMember,
                 allMember,
-                totalMeetings
+                totalMeetings,
+                profileImageUrlMap
         );
+    }
+
+    /**
+     * 멤버들의 프로필 이미지 presigned URL Map 생성
+     */
+    private Map<Long, String> buildProfileImageUrlMap(List<GatheringMember> members) {
+        Map<Long, String> profileImageUrlMap = new HashMap<>();
+
+        members.forEach(member -> {
+            String profileImageUrl = member.getUser().getProfileImageUrl();
+            String presignedUrl = storageService.getPresignedProfileImage(profileImageUrl);
+            profileImageUrlMap.put(member.getUser().getId(), presignedUrl);
+        });
+
+        return profileImageUrlMap;
     }
 
     /**

--- a/src/main/java/com/dokdok/retrospective/dto/response/MeetingRetrospectiveResponse.java
+++ b/src/main/java/com/dokdok/retrospective/dto/response/MeetingRetrospectiveResponse.java
@@ -114,12 +114,12 @@ public record MeetingRetrospectiveResponse(
             LocalDateTime createdAt
     ) {
 
-        public static CommentResponse from(MeetingRetrospective retrospective) {
+        public static CommentResponse from(MeetingRetrospective retrospective, String presignedProfileImageUrl) {
             return CommentResponse.builder()
                     .meetingRetrospectiveId(retrospective.getId())
                     .userId(retrospective.getCreatedBy().getId())
                     .nickname(retrospective.getCreatedBy().getNickname())
-                    .profileImageUrl(retrospective.getCreatedBy().getProfileImageUrl())
+                    .profileImageUrl(presignedProfileImageUrl)
                     .comment(retrospective.getComment())
                     .createdAt(retrospective.getCreatedAt())
                     .build();

--- a/src/main/java/com/dokdok/retrospective/service/MeetingRetrospectiveService.java
+++ b/src/main/java/com/dokdok/retrospective/service/MeetingRetrospectiveService.java
@@ -11,6 +11,7 @@ import com.dokdok.retrospective.exception.RetrospectiveErrorCode;
 import com.dokdok.retrospective.exception.RetrospectiveException;
 import com.dokdok.retrospective.repository.RetrospectiveRepository;
 import com.dokdok.retrospective.repository.TopicRetrospectiveSummaryRepository;
+import com.dokdok.storage.service.StorageService;
 import com.dokdok.topic.entity.Topic;
 import com.dokdok.topic.entity.TopicStatus;
 import com.dokdok.topic.repository.TopicRepository;
@@ -35,6 +36,7 @@ public class MeetingRetrospectiveService {
     private final RetrospectiveRepository retrospectiveRepository;
     private final MeetingValidator meetingValidator;
     private final TopicValidator topicValidator;
+    private final StorageService storageService;
 
     public MeetingRetrospectiveResponse getMeetingRetrospective(Long meetingId){
         Long userId = SecurityUtil.getCurrentUserId();
@@ -84,7 +86,11 @@ public class MeetingRetrospectiveService {
             return List.of();
         }
         return comments.stream()
-                .map(MeetingRetrospectiveResponse.CommentResponse::from)
+                .map(comment -> {
+                    String profileImageUrl = comment.getCreatedBy().getProfileImageUrl();
+                    String presignedUrl = storageService.getPresignedProfileImage(profileImageUrl);
+                    return MeetingRetrospectiveResponse.CommentResponse.from(comment, presignedUrl);
+                })
                 .toList();
     }
 
@@ -110,7 +116,10 @@ public class MeetingRetrospectiveService {
         MeetingRetrospective retrospective = MeetingRetrospective.of(meeting, user, topic, request.comment());
         MeetingRetrospective saved = retrospectiveRepository.save(retrospective);
 
-        return MeetingRetrospectiveResponse.CommentResponse.from(saved);
+        String profileImageUrl = saved.getCreatedBy().getProfileImageUrl();
+        String presignedUrl = storageService.getPresignedProfileImage(profileImageUrl);
+
+        return MeetingRetrospectiveResponse.CommentResponse.from(saved, presignedUrl);
     }
 
     @Transactional

--- a/src/test/java/com/dokdok/gathering/service/GatheringServiceTest.java
+++ b/src/test/java/com/dokdok/gathering/service/GatheringServiceTest.java
@@ -31,6 +31,7 @@ import com.dokdok.global.util.SecurityUtil;
 import com.dokdok.meeting.entity.MeetingStatus;
 import com.dokdok.meeting.repository.MeetingMemberRepository;
 import com.dokdok.meeting.repository.MeetingRepository;
+import com.dokdok.storage.service.StorageService;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
@@ -90,6 +91,9 @@ class GatheringServiceTest {
 
 	@Mock
 	private MeetingMemberRepository meetingMemberRepository;
+
+	@Mock
+	private StorageService storageService;
 
 	private MockedStatic<SecurityUtil> securityUtilMock;
 
@@ -475,6 +479,8 @@ class GatheringServiceTest {
 		given(gatheringValidator.validateAndGetMember(gatheringId, userId)).willReturn(normalMember);
 		given(gatheringMemberRepository.findAllMembersByGatheringId(gatheringId)).willReturn(allMembers);
 		given(meetingRepository.countByGatheringIdAndMeetingStatus(gatheringId, MeetingStatus.DONE)).willReturn(3);
+		given(storageService.getPresignedProfileImage("leader.jpg")).willReturn("leader.jpg");
+		given(storageService.getPresignedProfileImage("member.jpg")).willReturn("member.jpg");
 
 		// when
 		GatheringDetailResponse response = gatheringService.getGatheringDetail(gatheringId);

--- a/src/test/java/com/dokdok/retrospective/service/MeetingRetrospectiveServiceTest.java
+++ b/src/test/java/com/dokdok/retrospective/service/MeetingRetrospectiveServiceTest.java
@@ -18,6 +18,7 @@ import com.dokdok.retrospective.exception.RetrospectiveErrorCode;
 import com.dokdok.retrospective.exception.RetrospectiveException;
 import com.dokdok.retrospective.repository.RetrospectiveRepository;
 import com.dokdok.retrospective.repository.TopicRetrospectiveSummaryRepository;
+import com.dokdok.storage.service.StorageService;
 import com.dokdok.topic.entity.Topic;
 import com.dokdok.topic.entity.TopicStatus;
 import com.dokdok.topic.repository.TopicRepository;
@@ -53,6 +54,9 @@ class MeetingRetrospectiveServiceTest {
 
 	@Mock
 	private RetrospectiveRepository retrospectiveRepository;
+
+	@Mock
+	private StorageService storageService;
 
 	@InjectMocks
 	private MeetingRetrospectiveService meetingRetrospectiveService;
@@ -242,6 +246,7 @@ class MeetingRetrospectiveServiceTest {
 			doNothing().when(retrospectiveValidator).validateMeetingRetrospectiveAccess(gatheringId, meetingId, userId);
 			when(topicValidator.getTopicInMeeting(topicId, meetingId)).thenReturn(topic);
 			when(retrospectiveRepository.save(any(MeetingRetrospective.class))).thenReturn(saved);
+			when(storageService.getPresignedProfileImage("https://image.jpg")).thenReturn("https://image.jpg");
 
 			// when
 			MeetingRetrospectiveResponse.CommentResponse response =


### PR DESCRIPTION
## PR 요약
> 이 PR이 어떤 변경을 하는지 간단히 설명하고, 체크 표시는 괄호 사이에 소문자 'x'를 삽입하세요.

- [ ] 기능 추가
- [ ] 버그 수정
- [x] 코드 리팩토링
- [ ] 문서 수정
- [ ] 기타 (설명)

---

## 이슈 번호
- #290 

---

## 주요 변경 사항
> 주요 파일, 로직, 컴포넌트 등을 구체적으로 적어주세요.

 - src/main/java/com/dokdok/gathering/dto/response/GatheringDetailResponse.java: 멤버 프로필 이미지 URL을 presigned로 내려받도록 MemberInfo.from에 presigned 파라미터 추가
  - src/main/java/com/dokdok/gathering/service/GatheringService.java: 모임 멤버 프로필 이미지 presigned URL 맵 생성 후 상세 응답에 반영
  - src/main/java/com/dokdok/retrospective/dto/response/MeetingRetrospectiveResponse.java: 회고 코멘트 프로필 이미지 URL을 presigned로 받도록 CommentResponse.from 시그니처 변경
  - src/main/java/com/dokdok/retrospective/service/MeetingRetrospectiveService.java: 코멘트 조회/작성 시 presigned URL 생성해 응답에 반영
  - src/test/java/com/dokdok/gathering/service/GatheringServiceTest.java: presigned URL 사용 로직에 맞춰 StorageService mock/stub 추가
  - src/test/java/com/dokdok/retrospective/service/MeetingRetrospectiveServiceTest.java: 코멘트 응답 presigned URL 생성 로직에 맞춰 StorageService mock/stub 추가


---

## 참고 사항
> 리뷰어가 알아야 할 추가 정보, 테스트 방법 등을 작성해주세요.

예:  
- 테스트 계정 정보  
- 관련 API 엔드포인트  
- 로컬 테스트 방법  

---