### PR TITLE
[#103][REFACTOR] 확정된 주제 공통 응답 형식 변경

### DIFF
--- a/src/main/java/com/dokdok/topic/api/ConfirmTopicApi.java
+++ b/src/main/java/com/dokdok/topic/api/ConfirmTopicApi.java
@@ -47,7 +47,7 @@ public interface ConfirmTopicApi {
                     content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
                             schema = @Schema(implementation = ConfirmedTopicsResponse.class),
                             examples = @ExampleObject(value = """
-                                    {"code":"SUCCESS","message":"확정된 주제 조회를 완료했습니다.","data":{"items":[{"topicId":10,"title":"데미안에서 '자기 자신'이란?","description":"주제에 대한 간단한 설명입니다.","topicType":"DISCUSSION","confirmOrder":1,"createdByInfo":{"userId":1,"nickname":"독서왕"}}],"pageSize":10,"hasNext":false,"nextCursor":null,"totalCount":1,"actions":{"canViewPreOpinions":true,"canWritePreOpinions":false}}}
+                                    {"code":"SUCCESS","message":"확정된 주제 조회를 완료했습니다.","data":{"page":{"items":[{"topicId":10,"title":"데미안에서 '자기 자신'이란?","description":"주제에 대한 간단한 설명입니다.","topicType":"DISCUSSION","confirmOrder":1,"createdByInfo":{"userId":1,"nickname":"독서왕"}}],"pageSize":10,"hasNext":false,"nextCursor":null,"totalCount":1},"actions":{"canViewPreOpinions":true,"canWritePreOpinions":false}}}
                                     """))
             ),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(

--- a/src/main/java/com/dokdok/topic/api/ConfirmTopicApi.java
+++ b/src/main/java/com/dokdok/topic/api/ConfirmTopicApi.java
@@ -14,16 +14,30 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @Tag(name = "주제 관리", description = "주제 관련 API")
 public interface ConfirmTopicApi {
 
     @Operation(
             summary = "확정된 주제 조회 (developer: 양재웅)",
-            description = "약속에서 확정된 주제 목록을 조회합니다.",
+            description = """
+                    약속에서 확정된 주제 목록을 커서 기반 페이지네이션으로 조회합니다.
+
+                    **정렬 기준**
+                    - 1차: confirmOrder 오름차순
+                    - 2차: topicId 오름차순 (동점일 경우)
+
+                    **사용 방법**
+                    - 첫 페이지: `?pageSize=10` (커서 파라미터 없이 요청)
+                    - 다음 페이지: `?pageSize=10&cursorConfirmOrder={nextCursor.confirmOrder}&cursorTopicId={nextCursor.topicId}`
+                    """,
             parameters = {
                     @Parameter(name = "gatheringId", description = "모임 식별자", in = ParameterIn.PATH, required = true),
-                    @Parameter(name = "meetingId", description = "약속 식별자", in = ParameterIn.PATH, required = true)
+                    @Parameter(name = "meetingId", description = "약속 식별자", in = ParameterIn.PATH, required = true),
+                    @Parameter(name = "pageSize", description = "페이지 크기 (기본값: 10)", in = ParameterIn.QUERY),
+                    @Parameter(name = "cursorConfirmOrder", description = "커서: 이전 페이지 마지막 항목의 확정 순서", in = ParameterIn.QUERY),
+                    @Parameter(name = "cursorTopicId", description = "커서: 이전 페이지 마지막 항목의 주제 ID", in = ParameterIn.QUERY)
             }
     )
     @ApiResponses({
@@ -31,7 +45,10 @@ public interface ConfirmTopicApi {
                     responseCode = "200",
                     description = "확정 주제 조회 성공",
                     content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
-                            schema = @Schema(implementation = ConfirmedTopicsResponse.class))
+                            schema = @Schema(implementation = ConfirmedTopicsResponse.class),
+                            examples = @ExampleObject(value = """
+                                    {"code":"SUCCESS","message":"확정된 주제 조회를 완료했습니다.","data":{"items":[{"topicId":10,"title":"데미안에서 '자기 자신'이란?","description":"주제에 대한 간단한 설명입니다.","topicType":"DISCUSSION","confirmOrder":1,"createdByInfo":{"userId":1,"nickname":"독서왕"}}],"pageSize":10,"hasNext":false,"nextCursor":null,"totalCount":1,"actions":{"canViewPreOpinions":true,"canWritePreOpinions":false}}}
+                                    """))
             ),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(
                     responseCode = "400",
@@ -76,6 +93,9 @@ public interface ConfirmTopicApi {
     @GetMapping(value = "/confirm-topics", produces = MediaType.APPLICATION_JSON_VALUE)
     ResponseEntity<ApiResponse<ConfirmedTopicsResponse>> getConfirmedTopics(
             @PathVariable Long gatheringId,
-            @PathVariable Long meetingId
+            @PathVariable Long meetingId,
+            @RequestParam(defaultValue = "10") Integer pageSize,
+            @RequestParam(required = false) Integer cursorConfirmOrder,
+            @RequestParam(required = false) Long cursorTopicId
     );
 }

--- a/src/main/java/com/dokdok/topic/controller/ConfirmTopicController.java
+++ b/src/main/java/com/dokdok/topic/controller/ConfirmTopicController.java
@@ -8,6 +8,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @RestController
 @RequiredArgsConstructor
@@ -19,9 +20,14 @@ public class ConfirmTopicController implements ConfirmTopicApi {
     @Override
     public ResponseEntity<ApiResponse<ConfirmedTopicsResponse>> getConfirmedTopics(
             Long gatheringId,
-            Long meetingId
+            Long meetingId,
+            @RequestParam(defaultValue = "10") Integer pageSize,
+            @RequestParam(required = false) Integer cursorConfirmOrder,
+            @RequestParam(required = false) Long cursorTopicId
     ) {
-        ConfirmedTopicsResponse response = topicService.getConfirmedTopics(gatheringId, meetingId);
+        ConfirmedTopicsResponse response = topicService.getConfirmedTopics(
+                gatheringId, meetingId, pageSize, cursorConfirmOrder, cursorTopicId
+        );
         return ApiResponse.success(response, "확정된 주제 조회를 완료했습니다.");
     }
 }

--- a/src/main/java/com/dokdok/topic/dto/response/ConfirmedTopicsCursor.java
+++ b/src/main/java/com/dokdok/topic/dto/response/ConfirmedTopicsCursor.java
@@ -1,0 +1,22 @@
+package com.dokdok.topic.dto.response;
+
+import com.dokdok.topic.entity.Topic;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+@Builder
+@Schema(description = "확정된 주제 목록 조회를 위한 커서")
+public record ConfirmedTopicsCursor(
+        @Schema(description = "마지막 항목의 확정 순서 (정렬 기준)", example = "3")
+        Integer confirmOrder,
+
+        @Schema(description = "마지막 항목의 주제 ID (동점 대비)", example = "10")
+        Long topicId
+) {
+    public static ConfirmedTopicsCursor from(Topic topic) {
+        return ConfirmedTopicsCursor.builder()
+                .confirmOrder(topic.getConfirmOrder())
+                .topicId(topic.getId())
+                .build();
+    }
+}

--- a/src/main/java/com/dokdok/topic/dto/response/ConfirmedTopicsResponse.java
+++ b/src/main/java/com/dokdok/topic/dto/response/ConfirmedTopicsResponse.java
@@ -2,18 +2,40 @@ package com.dokdok.topic.dto.response;
 
 import com.dokdok.topic.entity.Topic;
 import com.dokdok.topic.entity.TopicType;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
 import java.util.List;
 
+@JsonPropertyOrder({"items", "pageSize", "hasNext", "nextCursor", "totalCount", "actions"})
 @Schema(description = "확정된 주제 목록 응답")
 public record ConfirmedTopicsResponse(
-        @Schema(description = "약속 ID", example = "1")
-        Long meetingId,
         @Schema(description = "확정된 주제 목록")
-        List<ConfirmedTopicDto> topics
+        List<ConfirmedTopicDto> items,
+        @Schema(description = "페이지 크기", example = "10")
+        int pageSize,
+        @Schema(description = "다음 페이지 존재 여부", example = "false")
+        boolean hasNext,
+        @Schema(description = "다음 페이지 커서 (hasNext가 false면 null)")
+        ConfirmedTopicsCursor nextCursor,
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        @Schema(description = "전체 아이템 수", example = "25")
+        Integer totalCount,
+        @Schema(description = "사전 의견 관련 권한 정보")
+        Actions actions
 ) {
+    public record Actions(
+            @Schema(description = "사전 의견 확인 가능 여부", example = "true")
+            Boolean canViewPreOpinions,
+            @Schema(description = "사전 의견 작성 가능 여부", example = "false")
+            Boolean canWritePreOpinions
+    ) {
+        public static Actions of(Boolean canViewPreOpinions, Boolean canWritePreOpinions) {
+            return new Actions(canViewPreOpinions, canWritePreOpinions);
+        }
+    }
 
     @Builder
     @Schema(description = "확정된 주제 정보")
@@ -49,9 +71,20 @@ public record ConfirmedTopicsResponse(
     }
 
     public static ConfirmedTopicsResponse from(
-            Long meetingId,
-            List<ConfirmedTopicDto> topics
+            List<ConfirmedTopicDto> items,
+            int pageSize,
+            boolean hasNext,
+            ConfirmedTopicsCursor nextCursor,
+            Integer totalCount,
+            Actions actions
     ) {
-        return new ConfirmedTopicsResponse(meetingId, topics);
+        return new ConfirmedTopicsResponse(
+                items,
+                pageSize,
+                hasNext,
+                hasNext ? nextCursor : null,
+                totalCount,
+                actions
+        );
     }
 }

--- a/src/main/java/com/dokdok/topic/dto/response/ConfirmedTopicsResponse.java
+++ b/src/main/java/com/dokdok/topic/dto/response/ConfirmedTopicsResponse.java
@@ -1,28 +1,15 @@
 package com.dokdok.topic.dto.response;
 
+import com.dokdok.global.response.CursorResponse;
 import com.dokdok.topic.entity.Topic;
 import com.dokdok.topic.entity.TopicType;
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
-import java.util.List;
-
-@JsonPropertyOrder({"items", "pageSize", "hasNext", "nextCursor", "totalCount", "actions"})
 @Schema(description = "확정된 주제 목록 응답")
 public record ConfirmedTopicsResponse(
-        @Schema(description = "확정된 주제 목록")
-        List<ConfirmedTopicDto> items,
-        @Schema(description = "페이지 크기", example = "10")
-        int pageSize,
-        @Schema(description = "다음 페이지 존재 여부", example = "false")
-        boolean hasNext,
-        @Schema(description = "다음 페이지 커서 (hasNext가 false면 null)")
-        ConfirmedTopicsCursor nextCursor,
-        @JsonInclude(JsonInclude.Include.NON_NULL)
-        @Schema(description = "전체 아이템 수", example = "25")
-        Integer totalCount,
+        @Schema(description = "확정된 주제 목록 페이지 정보")
+        CursorResponse<ConfirmedTopicDto, ConfirmedTopicsCursor> page,
         @Schema(description = "사전 의견 관련 권한 정보")
         Actions actions
 ) {
@@ -71,20 +58,9 @@ public record ConfirmedTopicsResponse(
     }
 
     public static ConfirmedTopicsResponse from(
-            List<ConfirmedTopicDto> items,
-            int pageSize,
-            boolean hasNext,
-            ConfirmedTopicsCursor nextCursor,
-            Integer totalCount,
+            CursorResponse<ConfirmedTopicDto, ConfirmedTopicsCursor> page,
             Actions actions
     ) {
-        return new ConfirmedTopicsResponse(
-                items,
-                pageSize,
-                hasNext,
-                hasNext ? nextCursor : null,
-                totalCount,
-                actions
-        );
+        return new ConfirmedTopicsResponse(page, actions);
     }
 }

--- a/src/main/java/com/dokdok/topic/repository/TopicRepository.java
+++ b/src/main/java/com/dokdok/topic/repository/TopicRepository.java
@@ -25,6 +25,38 @@ public interface TopicRepository extends JpaRepository<Topic, Long> {
             TopicStatus topicStatus
     );
 
+    @Query("SELECT t " +
+            "FROM Topic t " +
+            "JOIN FETCH t.proposedBy p " +
+            "JOIN FETCH t.meeting m " +
+            "JOIN FETCH m.gathering g " +
+            "WHERE t.meeting.id = :meetingId " +
+            "AND t.topicStatus = com.dokdok.topic.entity.TopicStatus.CONFIRMED " +
+            "AND t.deletedAt IS NULL " +
+            "ORDER BY t.confirmOrder ASC, t.id ASC")
+    List<Topic> findConfirmedTopicsFirstPage(
+            @Param("meetingId") Long meetingId,
+            Pageable pageable
+    );
+
+    @Query("SELECT t " +
+            "FROM Topic t " +
+            "JOIN FETCH t.proposedBy p " +
+            "JOIN FETCH t.meeting m " +
+            "JOIN FETCH m.gathering g " +
+            "WHERE t.meeting.id = :meetingId " +
+            "AND t.topicStatus = com.dokdok.topic.entity.TopicStatus.CONFIRMED " +
+            "AND t.deletedAt IS NULL " +
+            "AND (t.confirmOrder > :cursorConfirmOrder " +
+            "     OR (t.confirmOrder = :cursorConfirmOrder AND t.id > :cursorTopicId)) " +
+            "ORDER BY t.confirmOrder ASC, t.id ASC")
+    List<Topic> findConfirmedTopicsAfterCursor(
+            @Param("meetingId") Long meetingId,
+            @Param("cursorConfirmOrder") Integer cursorConfirmOrder,
+            @Param("cursorTopicId") Long cursorTopicId,
+            Pageable pageable
+    );
+
     @Query("""
                     SELECT t
                     FROM Topic t
@@ -182,6 +214,8 @@ public interface TopicRepository extends JpaRepository<Topic, Long> {
     List<Topic> findTopicsInfoByMeetingId(
             @Param("meetingId") Long meetingId
     );
+
+    long countByMeetingIdAndTopicStatusAndDeletedAtIsNull(Long meetingId, TopicStatus topicStatus);
 
     @Query("""
             SELECT MAX(t.updatedAt)

--- a/src/main/java/com/dokdok/topic/service/TopicService.java
+++ b/src/main/java/com/dokdok/topic/service/TopicService.java
@@ -4,10 +4,12 @@ import com.dokdok.gathering.service.GatheringValidator;
 import com.dokdok.global.util.SecurityUtil;
 import com.dokdok.meeting.entity.Meeting;
 import com.dokdok.meeting.entity.MeetingMember;
+import com.dokdok.meeting.entity.MeetingStatus;
 import com.dokdok.meeting.service.MeetingValidator;
 import com.dokdok.topic.dto.request.ConfirmTopicsRequest;
 import com.dokdok.topic.dto.request.SuggestTopicRequest;
 import com.dokdok.topic.dto.response.ConfirmTopicsResponse;
+import com.dokdok.topic.dto.response.ConfirmedTopicsCursor;
 import com.dokdok.topic.dto.response.ConfirmedTopicsResponse;
 import com.dokdok.topic.dto.response.SuggestTopicResponse;
 import com.dokdok.topic.dto.response.TopicLikeResponse;
@@ -15,10 +17,11 @@ import com.dokdok.topic.dto.response.TopicsWithActionsResponse;
 import com.dokdok.topic.entity.Topic;
 import com.dokdok.topic.entity.TopicLike;
 import com.dokdok.topic.entity.TopicMessage;
-import com.dokdok.topic.repository.TopicLikeRepository;
 import com.dokdok.topic.entity.TopicStatus;
 import com.dokdok.topic.exception.TopicErrorCode;
 import com.dokdok.topic.exception.TopicException;
+import com.dokdok.topic.repository.TopicAnswerRepository;
+import com.dokdok.topic.repository.TopicLikeRepository;
 import com.dokdok.topic.repository.TopicRepository;
 import com.dokdok.user.entity.User;
 import lombok.RequiredArgsConstructor;
@@ -41,6 +44,7 @@ public class TopicService {
 
     private final TopicRepository topicRepository;
     private final TopicLikeRepository topicLikeRepository;
+    private final TopicAnswerRepository topicAnswerRepository;
     private final GatheringValidator gatheringValidator;
     private final MeetingValidator meetingValidator;
     private final TopicValidator topicValidator;
@@ -168,23 +172,62 @@ public class TopicService {
     @Transactional(readOnly = true)
     public ConfirmedTopicsResponse getConfirmedTopics(
             Long gatheringId,
-            Long meetingId
+            Long meetingId,
+            int pageSize,
+            Integer cursorConfirmOrder,
+            Long cursorTopicId
     ) {
         Long userId = SecurityUtil.getCurrentUserId();
 
         gatheringValidator.validateMembership(gatheringId, userId);
         meetingValidator.validateMeetingInGathering(meetingId, gatheringId);
 
-        List<Topic> topics = topicRepository.findByMeetingIdAndTopicStatusOrderByConfirmOrderAsc(
-                meetingId,
-                TopicStatus.CONFIRMED
-        );
+        PageRequest pageable = PageRequest.of(0, pageSize + 1);
+        boolean hasCursor = cursorConfirmOrder != null && cursorTopicId != null;
+
+        List<Topic> topics = hasCursor
+                ? topicRepository.findConfirmedTopicsAfterCursor(meetingId, cursorConfirmOrder, cursorTopicId, pageable)
+                : topicRepository.findConfirmedTopicsFirstPage(meetingId, pageable);
+
+        boolean hasNext = topics.size() > pageSize;
+        if (hasNext) {
+            topics = topics.subList(0, pageSize);
+        }
 
         List<ConfirmedTopicsResponse.ConfirmedTopicDto> topicDtos = topics.stream()
                 .map(ConfirmedTopicsResponse.ConfirmedTopicDto::from)
                 .toList();
 
-        return ConfirmedTopicsResponse.from(meetingId, topicDtos);
+        ConfirmedTopicsCursor nextCursor = null;
+        if (hasNext && !topics.isEmpty()) {
+            Topic lastTopic = topics.get(topics.size() - 1);
+            nextCursor = ConfirmedTopicsCursor.from(lastTopic);
+        }
+
+        Integer totalCount = null;
+        if (!hasCursor) {
+            totalCount = (int) topicRepository.countByMeetingIdAndTopicStatusAndDeletedAtIsNull(
+                    meetingId, TopicStatus.CONFIRMED
+            );
+        }
+
+        boolean hasSubmitted = topicAnswerRepository.existsByMeetingIdAndUserId(meetingId, userId);
+        boolean isMeetingConfirmed = meetingValidator.findMeetingOrThrow(meetingId).getMeetingStatus()
+                == MeetingStatus.CONFIRMED;
+        Integer confirmedTopicsCount = totalCount;
+        if (confirmedTopicsCount == null) {
+            confirmedTopicsCount = (int) topicRepository.countByMeetingIdAndTopicStatusAndDeletedAtIsNull(
+                    meetingId, TopicStatus.CONFIRMED
+            );
+        }
+        boolean hasConfirmedTopics = confirmedTopicsCount > 0;
+
+        ConfirmedTopicsResponse.Actions actions = ConfirmedTopicsResponse.Actions.of(
+                hasSubmitted,
+                isMeetingConfirmed && hasConfirmedTopics && !hasSubmitted
+        );
+
+        return ConfirmedTopicsResponse.from(topicDtos, pageSize, hasNext, nextCursor, totalCount, actions);
     }
 
     @Transactional

--- a/src/main/java/com/dokdok/topic/service/TopicService.java
+++ b/src/main/java/com/dokdok/topic/service/TopicService.java
@@ -5,6 +5,7 @@ import com.dokdok.global.util.SecurityUtil;
 import com.dokdok.meeting.entity.Meeting;
 import com.dokdok.meeting.entity.MeetingMember;
 import com.dokdok.meeting.entity.MeetingStatus;
+import com.dokdok.global.response.CursorResponse;
 import com.dokdok.meeting.service.MeetingValidator;
 import com.dokdok.topic.dto.request.ConfirmTopicsRequest;
 import com.dokdok.topic.dto.request.SuggestTopicRequest;
@@ -227,7 +228,10 @@ public class TopicService {
                 isMeetingConfirmed && hasConfirmedTopics && !hasSubmitted
         );
 
-        return ConfirmedTopicsResponse.from(topicDtos, pageSize, hasNext, nextCursor, totalCount, actions);
+        CursorResponse<ConfirmedTopicsResponse.ConfirmedTopicDto, ConfirmedTopicsCursor> page =
+                CursorResponse.of(topicDtos, pageSize, hasNext, nextCursor, totalCount);
+
+        return ConfirmedTopicsResponse.from(page, actions);
     }
 
     @Transactional

--- a/src/test/java/com/dokdok/topic/service/TopicServiceTest.java
+++ b/src/test/java/com/dokdok/topic/service/TopicServiceTest.java
@@ -254,14 +254,14 @@ class TopicServiceTest {
                 ConfirmedTopicsResponse response =
                         topicService.getConfirmedTopics(gatheringId, meetingId, pageSize, null, null);
 
-                assertThat(response.items()).hasSize(2);
-                assertThat(response.items().get(0).topicId()).isEqualTo(12L);
-                assertThat(response.items().get(0).topicType()).isEqualTo(TopicType.DISCUSSION);
-                assertThat(response.items().get(1).confirmOrder()).isEqualTo(2);
-                assertThat(response.pageSize()).isEqualTo(pageSize);
-                assertThat(response.hasNext()).isFalse();
-                assertThat(response.nextCursor()).isNull();
-                assertThat(response.totalCount()).isEqualTo(2);
+                assertThat(response.page().items()).hasSize(2);
+                assertThat(response.page().items().get(0).topicId()).isEqualTo(12L);
+                assertThat(response.page().items().get(0).topicType()).isEqualTo(TopicType.DISCUSSION);
+                assertThat(response.page().items().get(1).confirmOrder()).isEqualTo(2);
+                assertThat(response.page().pageSize()).isEqualTo(pageSize);
+                assertThat(response.page().hasNext()).isFalse();
+                assertThat(response.page().nextCursor()).isNull();
+                assertThat(response.page().totalCount()).isEqualTo(2);
                 assertThat(response.actions().canViewPreOpinions()).isFalse();
                 assertThat(response.actions().canWritePreOpinions()).isTrue();
 

--- a/src/test/java/com/dokdok/topic/service/TopicServiceTest.java
+++ b/src/test/java/com/dokdok/topic/service/TopicServiceTest.java
@@ -25,6 +25,7 @@ import com.dokdok.topic.entity.TopicStatus;
 import com.dokdok.topic.entity.TopicType;
 import com.dokdok.topic.exception.TopicErrorCode;
 import com.dokdok.topic.exception.TopicException;
+import com.dokdok.topic.repository.TopicAnswerRepository;
 import com.dokdok.topic.repository.TopicLikeRepository;
 import com.dokdok.topic.repository.TopicRepository;
 import com.dokdok.user.entity.User;
@@ -58,6 +59,9 @@ class TopicServiceTest {
 
     @Mock
     private TopicLikeRepository topicLikeRepository;
+
+    @Mock
+    private TopicAnswerRepository topicAnswerRepository;
 
     @Mock
     private MeetingValidator meetingValidator;
@@ -211,6 +215,7 @@ class TopicServiceTest {
             Long gatheringId = 1L;
             Long meetingId = 1L;
             Long userId = 1L;
+            int pageSize = 10;
 
             Topic topic1 = Topic.builder()
                     .id(12L)
@@ -238,23 +243,31 @@ class TopicServiceTest {
 
                 doNothing().when(gatheringValidator).validateMembership(gatheringId, userId);
                 doNothing().when(meetingValidator).validateMeetingInGathering(meetingId, gatheringId);
-                given(topicRepository.findByMeetingIdAndTopicStatusOrderByConfirmOrderAsc(
-                        meetingId, TopicStatus.CONFIRMED))
+                given(topicRepository.findConfirmedTopicsFirstPage(eq(meetingId), any(Pageable.class)))
                         .willReturn(List.of(topic1, topic2));
+                given(topicRepository.countByMeetingIdAndTopicStatusAndDeletedAtIsNull(meetingId, TopicStatus.CONFIRMED))
+                        .willReturn(2L);
+                given(topicAnswerRepository.existsByMeetingIdAndUserId(meetingId, userId))
+                        .willReturn(false);
+                given(meetingValidator.findMeetingOrThrow(meetingId)).willReturn(testMeeting);
 
                 ConfirmedTopicsResponse response =
-                        topicService.getConfirmedTopics(gatheringId, meetingId);
+                        topicService.getConfirmedTopics(gatheringId, meetingId, pageSize, null, null);
 
-                assertThat(response.meetingId()).isEqualTo(meetingId);
-                assertThat(response.topics()).hasSize(2);
-                assertThat(response.topics().get(0).topicId()).isEqualTo(12L);
-                assertThat(response.topics().get(0).topicType()).isEqualTo(TopicType.DISCUSSION);
-                assertThat(response.topics().get(1).confirmOrder()).isEqualTo(2);
+                assertThat(response.items()).hasSize(2);
+                assertThat(response.items().get(0).topicId()).isEqualTo(12L);
+                assertThat(response.items().get(0).topicType()).isEqualTo(TopicType.DISCUSSION);
+                assertThat(response.items().get(1).confirmOrder()).isEqualTo(2);
+                assertThat(response.pageSize()).isEqualTo(pageSize);
+                assertThat(response.hasNext()).isFalse();
+                assertThat(response.nextCursor()).isNull();
+                assertThat(response.totalCount()).isEqualTo(2);
+                assertThat(response.actions().canViewPreOpinions()).isFalse();
+                assertThat(response.actions().canWritePreOpinions()).isTrue();
 
                 verify(gatheringValidator).validateMembership(gatheringId, userId);
                 verify(meetingValidator).validateMeetingInGathering(meetingId, gatheringId);
-                verify(topicRepository).findByMeetingIdAndTopicStatusOrderByConfirmOrderAsc(
-                        meetingId, TopicStatus.CONFIRMED);
+                verify(topicRepository).findConfirmedTopicsFirstPage(eq(meetingId), any(Pageable.class));
             }
         }
 
@@ -264,6 +277,7 @@ class TopicServiceTest {
             Long gatheringId = 1L;
             Long meetingId = 1L;
             Long userId = 1L;
+            int pageSize = 10;
 
             try (MockedStatic<SecurityUtil> securityUtilMock = mockStatic(SecurityUtil.class)) {
                 securityUtilMock.when(SecurityUtil::getCurrentUserId).thenReturn(userId);
@@ -271,12 +285,12 @@ class TopicServiceTest {
                 doThrow(new GatheringException(GatheringErrorCode.NOT_GATHERING_MEMBER))
                         .when(gatheringValidator).validateMembership(gatheringId, userId);
 
-                assertThatThrownBy(() -> topicService.getConfirmedTopics(gatheringId, meetingId))
+                assertThatThrownBy(() -> topicService.getConfirmedTopics(gatheringId, meetingId, pageSize, null, null))
                         .isInstanceOf(GatheringException.class)
                         .hasFieldOrPropertyWithValue("errorCode", GatheringErrorCode.NOT_GATHERING_MEMBER);
 
                 verify(topicRepository, never())
-                        .findByMeetingIdAndTopicStatusOrderByConfirmOrderAsc(any(), any());
+                        .findConfirmedTopicsFirstPage(any(), any());
             }
         }
     }


### PR DESCRIPTION
## PR 요약

  - [x] 기능 추가
  - [ ] 버그 수정
  - [ ] 코드 리팩토링
  - [ ] 문서 수정
  - [ ] 기타 (설명)

  ———

  ## 이슈 번호

  - #103 

  ———

  ## 주요 변경 사항

  - src/main/java/com/dokdok/topic/service/TopicService.java: 확정된 주제 조회를 커서 기반 페이지네이션으로 전환하고 actions(사전 의견 버튼 활성화) 계산 추가
  - src/main/java/com/dokdok/topic/repository/TopicRepository.java: 확정 주제 커서 조회/카운트 쿼리 추가
  - src/main/java/com/dokdok/topic/dto/response/ConfirmedTopicsResponse.java: 응답 구조에 items/pageSize/hasNext/nextCursor/totalCount/actions 추가
  - src/main/java/com/dokdok/topic/dto/response/ConfirmedTopicsCursor.java: 확정 주제 커서 DTO 추가
  - src/main/java/com/dokdok/topic/api/ConfirmTopicApi.java: 파라미터/예시 업데이트
  - src/test/java/com/dokdok/topic/service/TopicServiceTest.java: 확정 주제 조회 테스트 시그니처 및 검증 업데이트

  ———

  ## 참고 사항

  - 관련 API 엔드포인트: GET /api/gatherings/{gatheringId}/meetings/{meetingId}/confirm-topics
