### PR TITLE
[#292][REFACTOR] 약속 회고 comment 무한 스크롤 적용

### DIFF
--- a/src/main/java/com/dokdok/retrospective/api/MeetingRetrospectiveApi.java
+++ b/src/main/java/com/dokdok/retrospective/api/MeetingRetrospectiveApi.java
@@ -245,18 +245,18 @@ public interface MeetingRetrospectiveApi {
                     content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
                             schema = @Schema(implementation = MeetingRetrospectiveResponse.CommentResponse.class),
                             examples = @ExampleObject(value = """                                                                                                                
-                                      {                                                                                                                                            
-                                        "code": "CREATED",                                                                                                                         
-                                        "message": "공동 회고 작성 완료",                                                                                                          
-                                        "data": {                                                                                                                                  
-                                          "meetingRetrospectiveId": 1,                                                                                                             
-                                          "userId": 1,                                                                                                                             
-                                          "nickname": "독서왕",                                                                                                                    
-                                          "profileImageUrl": "https://example.com/profile.jpg",                                                                                    
-                                          "comment": "좋았습니다.",                                                                                                                
-                                          "createdAt": "2025-02-01T16:30:00"                                                                                                       
-                                        }                                                                                                                                          
-                                      }                                                                                                                                            
+                                      {
+                                        "code": "CREATED",
+                                        "message": "공동 회고 작성 완료",
+                                        "data": {
+                                          "meetingRetrospectiveId": 1,
+                                          "userId": 1,
+                                          "nickname": "독서왕",
+                                          "profileImageUrl": "https://example.com/profile.jpg",
+                                          "comment": "좋았습니다.",
+                                          "createdAt": "2025-02-01T16:30:00"
+                                        }
+                                      }
                                       """)
                     )
             ),

--- a/src/main/java/com/dokdok/retrospective/api/MeetingRetrospectiveApi.java
+++ b/src/main/java/com/dokdok/retrospective/api/MeetingRetrospectiveApi.java
@@ -1,7 +1,9 @@
 package com.dokdok.retrospective.api;
 
 import com.dokdok.global.response.ApiResponse;
+import com.dokdok.global.response.CursorResponse;
 import com.dokdok.retrospective.dto.request.MeetingRetrospectiveRequest;
+import com.dokdok.retrospective.dto.response.CommentCursor;
 import com.dokdok.retrospective.dto.response.MeetingRetrospectiveResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -12,24 +14,26 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDateTime;
 
 @Tag(name = "공동 회고", description = "공동 회고 관련 API")
+@RequestMapping("/api/meetings/{meetingId}/retrospectives")
 public interface MeetingRetrospectiveApi {
 
     @Operation(
             summary = "공동 회고 조회 (developer: 오주현)",
-            description = """
-            약속에 대한 공동 회고를 조회합니다.
-            - 권한: 모임장, 약속장, 약속 참여자
-            - 제약: 약속에 참여한 사용자만 조회 가능
-            """,
+
+
+            description = """                                                                                                                                                    
+                  공동 회고 정보를 조회합니다.
+                - 토픽 목록, 요약, 주요 포인트를 반환합니다.
+                - 코멘트는 별도 API로 조회합니다.
+                """,
             parameters = {
                     @Parameter(name = "meetingId", description = "약속 식별자", in = ParameterIn.PATH, required = true)
             }
@@ -41,75 +45,54 @@ public interface MeetingRetrospectiveApi {
                     content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
                             schema = @Schema(implementation = MeetingRetrospectiveResponse.class),
                             examples = @ExampleObject(value = """                                                                                                                
-                                      {                                                                                                                                            
-                                        "code": "SUCCESS",                                                                                                                         
-                                        "message": "공동 회고 조회 성공",                                                                                                          
-                                        "data": {                                                                                                                                  
-                                          "meetingId": 1,                                                                                                                          
-                                          "meetingName": "데미안을 읽어보아요",                                                                                                    
-                                          "meetingDate": "2026-01-15",                                                                                                             
-                                          "meetingTime": "19:00-20:00",   
+                                      {
+                                        "code": "SUCCESS",
+                                        "message": "공동 회고 조회 성공",
+                                        "data": {
+                                          "meetingId": 1,
+                                          "meetingName": "데미안을 읽어보아요",
+                                          "meetingDate": "2026-01-15",
+                                          "meetingTime": "19:00-20:00",
                                           "gathering": {
-                                          "gatheringId": 1,
-                                          "gatheringName": "독서 모임"
-                                          },                                                                                                         
-                                          "topics": [                                                                                                                              
-                                            {                                                                                                                                      
-                                              "topicId": 1,                                                                                                                        
-                                              "confirmOrder": 1,                                                                                                                   
-                                              "topicTitle": "가짜 욕망, 유사 욕망",                                                                                                
-                                              "topicDescription": "가짜욕망, 유사욕망에 대해 이야기해봅시다.",                                                                     
-                                              "summary": "참여자들은 『데미안』 속 싱클레어가 느꼈던 혼란을 자신들의 경험과 연결하며...",                                          
-                                              "keyPoints": [                                                                                                                       
-                                                {                                                                                                                                  
-                                                  "title": "사회가 만든 욕망의 구조",                                                                                              
-                                                  "details": [                                                                                                                     
-                                                    "안정적인 직업, 성과, 인정 욕구가 개인의 욕망처럼 내면화된 경험 공유",                                                         
-                                                    "\\"원해서 선택했다\\"기보다 \\"선택하지 않으면 불안해서 택했다\\"는 표현이 반복됨"                                            
-                                                  ]                                                                                                                                
-                                                },                                                                                                                                 
-                                                {                                                                                                                                  
-                                                  "title": "유사 욕망과 진짜 욕망의 차이",                                                                                         
-                                                  "details": [                                                                                                                     
-                                                    "유사 욕망은 비교와 평가 속에서 강화되며, 타인의 반응에 민감함",                                                               
-                                                    "진짜 욕망은 오히려 혼자 있을 때 더 선명해지고, 남에게 말할수록 흐려지는 경우가 많다는 의견"                                   
-                                                  ]                                                                                                                                
-                                                }                                                                                                                                  
-                                              ],                                                                                                                                   
-                                              "comments": [                                                                                                                        
-                                                {                                                                                                                                  
-                                                  "meetingRetrospectiveId": 1,                                                                                                     
-                                                  "userId": 1,                                                                                                                     
-                                                  "nickname": "사용자1",                                                                                                           
-                                                  "profileImageUrl": "https://example.com/profile.jpg",                                                                            
-                                                  "comment": "모임 하기전엔 이랬는데, 누구의 이런 말을 듣고 이렇게 생각이 바뀌었다.",                                              
-                                                  "createdAt": "2026-01-15T15:30:00"                                                                                               
-                                                }                                                                                                                                  
-                                              ]                                                                                                                                    
-                                            },                                                                                                                                     
-                                            {                                                                                                                                      
-                                              "topicId": 2,                                                                                                                        
-                                              "confirmOrder": 2,                                                                                                                   
-                                              "topicTitle": "선과 악",                                                                                                             
-                                              "topicDescription": "인간의 세계에서 선과 악 어느 것이 힘이 더 셀까",                                                                
-                                              "summary": "선과 악 중 어느 쪽이 더 강한지를 묻기보다...",                                                                           
-                                              "keyPoints": [                                                                                                                       
-                                                {                                                                                                                                  
-                                                  "title": "악이 더 강해 보이는 이유",                                                                                             
-                                                  "details": [                                                                                                                     
-                                                    "결과가 빠르고 명확하게 드러나며, 책임을 외부로 돌리기 쉬움"                                                                   
-                                                  ]                                                                                                                                
-                                                }                                                                                                                                  
-                                              ],                                                                                                                                   
-                                              "comments": []                                                                                                                       
-                                            }                                                                                                                                      
-                                          ]                                                                                                                                        
-                                        }                                                                                                                                          
-                                      }                                                                                                                                            
+                                            "gatheringId": 1,
+                                            "gatheringName": "독서 모임"
+                                          },
+                                          "topics": [
+                                            {
+                                              "topicId": 1,
+                                              "confirmOrder": 1,
+                                              "topicTitle": "가짜 욕망, 유사 욕망",
+                                              "topicDescription": "가짜욕망, 유사욕망에 대해 이야기해봅시다.",
+                                              "summary": "참여자들은 데미안 속 싱클레어가 느꼈던 혼란을 자신들의 경험과 연결하며...",
+                                              "keyPoints": [
+                                                {
+                                                  "title": "사회가 만든 욕망의 구조",
+                                                  "details": [
+                                                    "안정적인 직업, 성과, 인정 욕구가 개인의 욕망처럼 내면화된 경험 공유",
+                                                    "원해서 선택했다기보다 선택하지 않으면 불안해서 택했다는 표현이 반복됨"
+                                                  ]
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        }
+                                      }
                                       """)
                     )
             ),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "접근 권한 없음",
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "401",
+                    description = "인증 실패 - 로그인이 필요합니다.",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(value = """                                                                                                                
+                                      {"code": "G102", "message": "인증이 필요합니다.", "data": null}
+                                      """)
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "403",
+                    description = "권한 없음 - 약속 참여자만 조회할 수 있습니다.",
                     content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
                             examples = @ExampleObject(value = """
                                     {"code": "R105", "message": "회고에 접근할 권한이 없습니다.", "data": null}
@@ -127,7 +110,122 @@ public interface MeetingRetrospectiveApi {
     })
     @GetMapping(produces = MediaType.APPLICATION_JSON_VALUE)
     ResponseEntity<ApiResponse<MeetingRetrospectiveResponse>> getMeetingRetrospective(
+            @Parameter(description = "약속 ID", required = true, example = "1")
             @PathVariable Long meetingId
+    );
+
+    @Operation(
+            summary = "토픽별 코멘트 조회 (developer: 오주현)",
+            description = """                                                                                                                                                    
+                  특정 토픽의 코멘트를 조회합니다.
+                  - 커서 기반 무한스크롤을 지원합니다.
+                  - 첫 페이지: cursorCreatedAt, cursorCommentId 없이 호출
+                  - 다음 페이지: 응답의 nextCursor 값을 파라미터로 전달
+                  - 정렬: createdAt DESC, id DESC
+                  """
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "조회 성공",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = CursorResponse.class),
+                            examples = @ExampleObject(value = """                                                                                                                
+                                      {
+                                        "code": "SUCCESS",
+                                        "message": "토픽 코멘트 조회 성공",
+                                        "data": {
+                                          "items": [
+                                            {
+                                              "meetingRetrospectiveId": 1,
+                                              "userId": 1,
+                                              "nickname": "사용자1",
+                                              "profileImageUrl": "https://example.com/profile.jpg",
+                                              "comment": "모임 하기전엔 이랬는데, 누구의 이런 말을 듣고 이렇게 생각이 바뀌었다.",
+                                              "createdAt": "2026-01-15T15:30:00"
+                                            }
+                                          ],
+                                          "pageSize": 10,
+                                          "hasNext": true,
+                                          "nextCursor": {
+                                            "createdAt": "2026-01-15T15:00:00",
+                                            "commentId": 5
+                                          },
+                                          "totalCount": 15
+                                        }
+                                      }
+                                      """)
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "401",
+                    description = "인증 실패 - 로그인이 필요합니다.",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(value = """                                                                                                                
+                                      {"code": "G102", "message": "인증이 필요합니다.", "data": null}
+                                      """)
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "403",
+                    description = "권한 없음 - 약속 참여자만 조회할 수 있습니다.",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(value = """                                                                                                                
+                                      {"code": "R105", "message": "회고 접근 권한이 없습니다.", "data": null}
+                                      """)
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "약속 또는 토픽을 찾을 수 없음",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            examples = {
+                                    @ExampleObject(
+                                            name = "약속 없음",
+                                            value = """                                                                                                                          
+                                                      {"code": "M001", "message": "약속을 찾을 수 없습니다.", "data": null}
+                                                      """
+                                    ),
+                                    @ExampleObject(
+                                            name = "토픽 없음",
+                                            value = """                                                                                                                          
+                                                      {"code": "T001", "message": "토픽을 찾을 수 없습니다.", "data": null}
+                                                      """
+                                    )
+                            }
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "500",
+                    description = "서버 오류",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(value = """                                                                                                                
+                                      {"code": "E000", "message": "서버 에러가 발생했습니다. 담당자에게 문의 바랍니다.", "data": null}
+                                      """)
+                    )
+            )
+    })
+    @GetMapping("/comments")
+    ResponseEntity<ApiResponse<CursorResponse<MeetingRetrospectiveResponse.CommentResponse, CommentCursor>>> getTopicComments(
+            @Parameter(description = "약속 ID", required = true, example = "1")
+            @PathVariable Long meetingId,
+
+            @Parameter(description = "토픽 ID", required = true, example = "1")
+            @RequestParam Long topicId,
+
+            @Parameter(description = "페이지 크기", example = "10")
+            @RequestParam(defaultValue = "10") int pageSize,
+
+            @Parameter(description = "커서 - 마지막 코멘트의 작성일시 (ISO 8601)", example = "2026-01-15T15:00:00")
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime cursorCreatedAt,
+
+            @Parameter(description = "커서 - 마지막 코멘트의 ID", example = "5")
+            @RequestParam(required = false) Long cursorCommentId
     );
 
     @Operation(

--- a/src/main/java/com/dokdok/retrospective/controller/MeetingRetrospectiveController.java
+++ b/src/main/java/com/dokdok/retrospective/controller/MeetingRetrospectiveController.java
@@ -1,14 +1,20 @@
 package com.dokdok.retrospective.controller;
 
 import com.dokdok.global.response.ApiResponse;
+import com.dokdok.global.response.CursorResponse;
 import com.dokdok.retrospective.api.MeetingRetrospectiveApi;
 import com.dokdok.retrospective.dto.request.MeetingRetrospectiveRequest;
+import com.dokdok.retrospective.dto.response.CommentCursor;
 import com.dokdok.retrospective.dto.response.MeetingRetrospectiveResponse;
 import com.dokdok.retrospective.service.MeetingRetrospectiveService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.simpleframework.xml.Order;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDateTime;
 
 @RestController
 @RequiredArgsConstructor
@@ -23,6 +29,22 @@ public class MeetingRetrospectiveController implements MeetingRetrospectiveApi {
         MeetingRetrospectiveResponse response = meetingRetrospectiveService.getMeetingRetrospective(meetingId);
 
         return ApiResponse.success(response,"공동 회고 조회 성공");
+    }
+
+    @Override
+    @GetMapping("/comments")
+    public ResponseEntity<ApiResponse<CursorResponse<MeetingRetrospectiveResponse.CommentResponse, CommentCursor>>> getTopicComments(
+            @PathVariable Long meetingId,
+            @RequestParam Long topicId,
+            @RequestParam(defaultValue = "10") int pageSize,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime cursorCreatedAt,
+            @RequestParam(required = false) Long cursorCommentId
+    ) {
+        CursorResponse<MeetingRetrospectiveResponse.CommentResponse, CommentCursor> response =
+                meetingRetrospectiveService.getTopicComments(
+                        meetingId, topicId, pageSize, cursorCreatedAt, cursorCommentId
+                );
+        return ApiResponse.success(response, "토픽 코멘트 조회 성공");
     }
 
     @Override

--- a/src/main/java/com/dokdok/retrospective/controller/MeetingRetrospectiveController.java
+++ b/src/main/java/com/dokdok/retrospective/controller/MeetingRetrospectiveController.java
@@ -9,7 +9,6 @@ import com.dokdok.retrospective.dto.response.MeetingRetrospectiveResponse;
 import com.dokdok.retrospective.service.MeetingRetrospectiveService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.simpleframework.xml.Order;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;

--- a/src/main/java/com/dokdok/retrospective/dto/response/CommentCursor.java
+++ b/src/main/java/com/dokdok/retrospective/dto/response/CommentCursor.java
@@ -1,0 +1,19 @@
+package com.dokdok.retrospective.dto.response;
+
+import com.dokdok.retrospective.entity.MeetingRetrospective;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+
+@Schema(description = "코멘트 커서")
+public record CommentCursor(
+        @Schema(description = "작성 일시", example = "2026-01-15T15:30:00")
+        LocalDateTime createdAt,
+
+        @Schema(description = "코멘트 ID", example = "10")
+        Long commentId
+) {
+    public static CommentCursor from(MeetingRetrospective retrospective) {
+        return new CommentCursor(retrospective.getCreatedAt(), retrospective.getId());
+    }
+}

--- a/src/main/java/com/dokdok/retrospective/dto/response/MeetingRetrospectiveResponse.java
+++ b/src/main/java/com/dokdok/retrospective/dto/response/MeetingRetrospectiveResponse.java
@@ -1,5 +1,6 @@
 package com.dokdok.retrospective.dto.response;
 
+import com.dokdok.global.response.CursorResponse;
 import com.dokdok.meeting.dto.MeetingResponse;
 import com.dokdok.meeting.entity.Meeting;
 import com.dokdok.retrospective.entity.MeetingRetrospective;
@@ -42,7 +43,7 @@ public record MeetingRetrospectiveResponse(
                 .build();
     }
 
-    @Schema(description = "주제 회고 정보")
+    @Schema(description = "약속 회고 AI요약")
     @Builder
     public record TopicResponse(
             @Schema(description = "주제 ID", example = "1")
@@ -56,14 +57,11 @@ public record MeetingRetrospectiveResponse(
             @Schema(description = "핵심 요약", example = "참여자들은 『데미안』 속 싱클레어가...")
             String summary,
             @Schema(description = "주요 포인트 목록")
-            List<KeyPointResponse> keyPoints,
-            @Schema(description = "코멘트 목록")
-            List<CommentResponse> comments
+            List<KeyPointResponse> keyPoints
     ){
         public static TopicResponse from(
                 Topic topic,
-                TopicRetrospectiveSummary summary,
-                List<CommentResponse> comments
+                TopicRetrospectiveSummary summary
         ) {
             return TopicResponse.builder()
                     .topicId(topic.getId())
@@ -76,7 +74,6 @@ public record MeetingRetrospectiveResponse(
                             .map(KeyPointResponse::from)
                             .toList()
                             : null)
-                    .comments(comments)
                     .build();
         }
     }

--- a/src/main/java/com/dokdok/retrospective/dto/response/MeetingRetrospectiveResponse.java
+++ b/src/main/java/com/dokdok/retrospective/dto/response/MeetingRetrospectiveResponse.java
@@ -1,6 +1,5 @@
 package com.dokdok.retrospective.dto.response;
 
-import com.dokdok.global.response.CursorResponse;
 import com.dokdok.meeting.dto.MeetingResponse;
 import com.dokdok.meeting.entity.Meeting;
 import com.dokdok.retrospective.entity.MeetingRetrospective;

--- a/src/main/java/com/dokdok/retrospective/repository/RetrospectiveRepository.java
+++ b/src/main/java/com/dokdok/retrospective/repository/RetrospectiveRepository.java
@@ -1,9 +1,13 @@
 package com.dokdok.retrospective.repository;
 
 import com.dokdok.retrospective.entity.MeetingRetrospective;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -14,4 +18,28 @@ public interface RetrospectiveRepository extends JpaRepository<MeetingRetrospect
 
     Optional<MeetingRetrospective> findByIdAndMeetingId(Long meetingRetrospectiveId, Long meetingId);
 
+    @Query("SELECT mr FROM MeetingRetrospective mr " +
+            "JOIN FETCH mr.createdBy " +
+            "WHERE mr.topic.id = :topicId " +
+            "ORDER BY mr.createdAt DESC, mr.id DESC")
+    List<MeetingRetrospective> findByTopicIdFirstPage(
+            @Param("topicId") Long topicId,
+            Pageable pageable
+    );
+
+    @Query("SELECT mr FROM MeetingRetrospective mr " +
+            "JOIN FETCH mr.createdBy " +
+            "WHERE mr.topic.id = :topicId " +
+            "AND (mr.createdAt < :cursorCreatedAt " +
+            "     OR (mr.createdAt = :cursorCreatedAt AND mr.id < :cursorCommentId)) " +
+            "ORDER BY mr.createdAt DESC, mr.id DESC")
+    List<MeetingRetrospective> findByTopicIdAfterCursor(
+            @Param("topicId") Long topicId,
+            @Param("cursorCreatedAt") LocalDateTime cursorCreatedAt,
+            @Param("cursorCommentId") Long cursorCommentId,
+            Pageable pageable
+    );
+
+    @Query("SELECT COUNT(mr) FROM MeetingRetrospective mr WHERE mr.topic.id = :topicId")
+    int countByTopicId(@Param("topicId") Long topicId);
 }

--- a/src/main/java/com/dokdok/retrospective/repository/RetrospectiveRepository.java
+++ b/src/main/java/com/dokdok/retrospective/repository/RetrospectiveRepository.java
@@ -14,8 +14,6 @@ import java.util.Optional;
 @Repository
 public interface RetrospectiveRepository extends JpaRepository<MeetingRetrospective, Long> {
 
-    List<MeetingRetrospective> findAllByMeetingId(Long meetingId);
-
     Optional<MeetingRetrospective> findByIdAndMeetingId(Long meetingRetrospectiveId, Long meetingId);
 
     @Query("SELECT mr FROM MeetingRetrospective mr " +

--- a/src/main/java/com/dokdok/retrospective/service/MeetingRetrospectiveService.java
+++ b/src/main/java/com/dokdok/retrospective/service/MeetingRetrospectiveService.java
@@ -1,9 +1,11 @@
 package com.dokdok.retrospective.service;
 
+import com.dokdok.global.response.CursorResponse;
 import com.dokdok.global.util.SecurityUtil;
 import com.dokdok.meeting.entity.Meeting;
 import com.dokdok.meeting.service.MeetingValidator;
 import com.dokdok.retrospective.dto.request.MeetingRetrospectiveRequest;
+import com.dokdok.retrospective.dto.response.CommentCursor;
 import com.dokdok.retrospective.dto.response.MeetingRetrospectiveResponse;
 import com.dokdok.retrospective.entity.MeetingRetrospective;
 import com.dokdok.retrospective.entity.TopicRetrospectiveSummary;
@@ -18,9 +20,12 @@ import com.dokdok.topic.repository.TopicRepository;
 import com.dokdok.topic.service.TopicValidator;
 import com.dokdok.user.entity.User;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -38,6 +43,9 @@ public class MeetingRetrospectiveService {
     private final TopicValidator topicValidator;
     private final StorageService storageService;
 
+    /**
+     * 공동 회고 조회 ( 토픽 정보 + 요약 + 키포인트, 코멘트 제외 )
+     */
     public MeetingRetrospectiveResponse getMeetingRetrospective(Long meetingId){
         Long userId = SecurityUtil.getCurrentUserId();
 
@@ -53,45 +61,36 @@ public class MeetingRetrospectiveService {
         // 확정된 토픽 조회 (confirmOrder 순)
         List<Topic> topics = topicRepository.findByMeetingIdAndTopicStatusOrderByConfirmOrderAsc(meetingId, TopicStatus.CONFIRMED);
 
-        // 토픽별 요약 조회
-        List<Long> topicIds = topics.stream()
-                .map(Topic::getId)
-                .toList();
-
-        Map<Long, TopicRetrospectiveSummary> summaryMap = topicRetrospectiveSummaryRepository
-                .findAllByTopicIdIn(topicIds)
-                .stream()
-                .collect(Collectors.toMap(s-> s.getTopic().getId(), s->s));
-
-        // 토픽별 회고 조회
-        List<MeetingRetrospective> allComments = retrospectiveRepository.findAllByMeetingId(meetingId);
-
-        Map<Long, List<MeetingRetrospective>> commentsByTopic = allComments.stream()
-                .filter(r-> r.getTopic() != null)
-                .collect(Collectors.groupingBy(r-> r.getTopic().getId()));
+        Map<Long, TopicRetrospectiveSummary> summaryMap = buildSummaryMap(topics);
 
         List<MeetingRetrospectiveResponse.TopicResponse> topicResponses = topics.stream()
                 .map(topic -> MeetingRetrospectiveResponse.TopicResponse.from(
                         topic,
-                        summaryMap.get(topic.getId()),
-                        buildCommentResponses(commentsByTopic.get(topic.getId()))
+                        summaryMap.get(topic.getId())
                 ))
                 .toList();
 
-        return MeetingRetrospectiveResponse.from(meeting,topicResponses);
+        return MeetingRetrospectiveResponse.from(meeting, topicResponses);
     }
 
-    private List<MeetingRetrospectiveResponse.CommentResponse> buildCommentResponses(List<MeetingRetrospective> comments) {
-        if (comments == null || comments.isEmpty()) {
-            return List.of();
-        }
-        return comments.stream()
-                .map(comment -> {
-                    String profileImageUrl = comment.getCreatedBy().getProfileImageUrl();
-                    String presignedUrl = storageService.getPresignedProfileImage(profileImageUrl);
-                    return MeetingRetrospectiveResponse.CommentResponse.from(comment, presignedUrl);
-                })
-                .toList();
+    /**
+     * 토픽별 코멘트 조회 (무한 스크롤)
+     */
+    public CursorResponse<MeetingRetrospectiveResponse.CommentResponse, CommentCursor> getTopicComments(
+            Long meetingId,
+            Long topicId,
+            int pageSize,
+            LocalDateTime cursorCreatedAt,
+            Long cursorCommentId
+    ) {
+        Long userId = SecurityUtil.getCurrentUserId();
+        Meeting meeting = meetingValidator.findMeetingOrThrow(meetingId);
+
+        retrospectiveValidator.validateMeetingRetrospectiveAccess(meeting.getGathering().getId(), meetingId, userId);
+
+        topicValidator.getTopicInMeeting(topicId, meetingId);
+
+        return fetchComments(topicId, pageSize, cursorCreatedAt, cursorCommentId);
     }
 
     @Transactional
@@ -116,10 +115,7 @@ public class MeetingRetrospectiveService {
         MeetingRetrospective retrospective = MeetingRetrospective.of(meeting, user, topic, request.comment());
         MeetingRetrospective saved = retrospectiveRepository.save(retrospective);
 
-        String profileImageUrl = saved.getCreatedBy().getProfileImageUrl();
-        String presignedUrl = storageService.getPresignedProfileImage(profileImageUrl);
-
-        return MeetingRetrospectiveResponse.CommentResponse.from(saved, presignedUrl);
+        return buildCommentResponse(saved);
     }
 
     @Transactional
@@ -133,5 +129,61 @@ public class MeetingRetrospectiveService {
         retrospectiveValidator.validateMeetingRetrospectiveDeletePermission(retrospective, userId);
 
         retrospectiveRepository.delete(retrospective);
+    }
+
+    private Map<Long, TopicRetrospectiveSummary> buildSummaryMap(List<Topic> topics) {
+        List<Long> topicIds = topics.stream()
+                .map(Topic::getId)
+                .toList();
+
+        return topicRetrospectiveSummaryRepository
+                .findAllByTopicIdIn(topicIds)
+                .stream()
+                .collect(Collectors.toMap(
+                        summary -> summary.getTopic().getId(),
+                        summary -> summary
+                ));
+    }
+
+    private CursorResponse<MeetingRetrospectiveResponse.CommentResponse, CommentCursor> fetchComments(
+            Long topicId,
+            int pageSize,
+            LocalDateTime cursorCreatedAt,
+            Long cursorCommentId
+    ) {
+        Pageable pageable = PageRequest.of(0, pageSize + 1);
+        boolean isFirstPage = cursorCreatedAt == null || cursorCommentId == null;
+
+        List<MeetingRetrospective> comments = isFirstPage
+                ? retrospectiveRepository.findByTopicIdFirstPage(topicId, pageable)
+                : retrospectiveRepository.findByTopicIdAfterCursor(topicId, cursorCreatedAt, cursorCommentId, pageable);
+
+        boolean hasNext = comments.size() > pageSize;
+        List<MeetingRetrospective> pageComments = hasNext
+                ? comments.subList(0, pageSize)
+                : comments;
+
+        List<MeetingRetrospectiveResponse.CommentResponse> items = pageComments.stream()
+                .map(this::buildCommentResponse)
+                .toList();
+
+        CommentCursor nextCursor = buildNextCursor(pageComments, hasNext);
+        Integer totalCount = isFirstPage ? retrospectiveRepository.countByTopicId(topicId) : null;
+
+        return CursorResponse.of(items, pageSize, hasNext, nextCursor, totalCount);
+    }
+
+    private MeetingRetrospectiveResponse.CommentResponse buildCommentResponse(MeetingRetrospective comment) {
+        String profileImageUrl = comment.getCreatedBy().getProfileImageUrl();
+        String presignedUrl = storageService.getPresignedProfileImage(profileImageUrl);
+        return MeetingRetrospectiveResponse.CommentResponse.from(comment, presignedUrl);
+    }
+
+    private CommentCursor buildNextCursor(List<MeetingRetrospective> comments, boolean hasNext) {
+        if (!hasNext || comments.isEmpty()) {
+            return null;
+        }
+        MeetingRetrospective lastComment = comments.get(comments.size() - 1);
+        return CommentCursor.from(lastComment);
     }
 }

--- a/src/test/java/com/dokdok/retrospective/service/MeetingRetrospectiveServiceTest.java
+++ b/src/test/java/com/dokdok/retrospective/service/MeetingRetrospectiveServiceTest.java
@@ -132,39 +132,6 @@ class MeetingRetrospectiveServiceTest {
 	}
 
 	@Test
-	@DisplayName("확정된 토픽이 없으면 빈 목록을 반환한다")
-	void getMeetingRetrospective_withNoTopics_returnsEmptyList() {
-		Long meetingId = 1L;
-		Long userId = 1L;
-		Long gatheringId = 1L;
-
-		Gathering gathering = Gathering.builder().id(gatheringId).build();
-		Meeting meeting = Meeting.builder()
-				.id(meetingId)
-				.gathering(gathering)
-				.meetingName("모임")
-				.meetingStartDate(LocalDateTime.of(2026, 1, 15, 19, 0))
-				.meetingEndDate(LocalDateTime.of(2026, 1, 15, 21, 0))
-				.build();
-
-		try (MockedStatic<SecurityUtil> securityUtilMock = mockStatic(SecurityUtil.class)) {
-			securityUtilMock.when(SecurityUtil::getCurrentUserId).thenReturn(userId);
-
-			when(meetingValidator.findMeetingOrThrow(meetingId)).thenReturn(meeting);
-			doNothing().when(retrospectiveValidator).validateMeetingRetrospectiveAccess(gatheringId, meetingId, userId);
-			when(topicRepository.findByMeetingIdAndTopicStatusOrderByConfirmOrderAsc(meetingId, TopicStatus.CONFIRMED))
-					.thenReturn(List.of());
-			when(topicRetrospectiveSummaryRepository.findAllByTopicIdIn(List.of())).thenReturn(List.of());
-			when(retrospectiveRepository.findAllByMeetingId(meetingId)).thenReturn(List.of());
-
-			MeetingRetrospectiveResponse response = meetingRetrospectiveService.getMeetingRetrospective(meetingId);
-
-			assertThat(response.meetingId()).isEqualTo(meetingId);
-			assertThat(response.topics()).isEmpty();
-		}
-	}
-
-	@Test
 	@DisplayName("코멘트가 없어도 정상적으로 조회한다")
 	void getMeetingRetrospective_withNoComments_success() {
 		Long meetingId = 1L;
@@ -199,7 +166,6 @@ class MeetingRetrospectiveServiceTest {
 			when(topicRepository.findByMeetingIdAndTopicStatusOrderByConfirmOrderAsc(meetingId, TopicStatus.CONFIRMED))
 					.thenReturn(List.of(topic));
 			when(topicRetrospectiveSummaryRepository.findAllByTopicIdIn(List.of(1L))).thenReturn(List.of(summary));
-			when(retrospectiveRepository.findAllByMeetingId(meetingId)).thenReturn(List.of());
 
 			MeetingRetrospectiveResponse response = meetingRetrospectiveService.getMeetingRetrospective(meetingId);
 
@@ -207,7 +173,6 @@ class MeetingRetrospectiveServiceTest {
 			assertThat(response.topics().get(0).summary()).isEqualTo("요약1");
 			assertThat(response.topics().get(0).keyPoints()).hasSize(1);
 			assertThat(response.topics().get(0).keyPoints().get(0).title()).isEqualTo("핵심 포인트");
-			assertThat(response.topics().get(0).comments()).isEmpty();
 		}
 	}
 

--- a/src/test/java/com/dokdok/retrospective/service/MeetingRetrospectiveServiceTest.java
+++ b/src/test/java/com/dokdok/retrospective/service/MeetingRetrospectiveServiceTest.java
@@ -7,7 +7,6 @@ import com.dokdok.global.util.SecurityUtil;
 import com.dokdok.meeting.entity.Meeting;
 import com.dokdok.meeting.exception.MeetingErrorCode;
 import com.dokdok.meeting.exception.MeetingException;
-import com.dokdok.meeting.repository.MeetingRepository;
 import com.dokdok.meeting.service.MeetingValidator;
 import com.dokdok.oauth2.CustomOAuth2User;
 import com.dokdok.retrospective.dto.request.MeetingRetrospectiveRequest;


### PR DESCRIPTION
## PR 요약
> 이 PR이 어떤 변경을 하는지 간단히 설명하고, 체크 표시는 괄호 사이에 소문자 'x'를 삽입하세요.

- [ ] 기능 추가
- [ ] 버그 수정
- [x] 코드 리팩토링
- [ ] 문서 수정
- [ ] 기타 (설명)

---

## 이슈 번호
- #292 

---

## 주요 변경 사항
> 주요 파일, 로직, 컴포넌트 등을 구체적으로 적어주세요.

- src/main/java/com/dokdok/retrospective/api/MeetingRetrospectiveApi.java: 공동회고 조회/댓글 무한스크롤 API 문서 정리 및 불필요 import 제거
  - src/main/java/com/dokdok/retrospective/controller/MeetingRetrospectiveController.java: 공동회고 조회/댓글 무한스크롤 엔드포인트 정리 및 불필요 import 제거
  - src/main/java/com/dokdok/retrospective/dto/response/MeetingRetrospectiveResponse.java: 댓글 무한스크롤 응답 구조 및 관련 DTO 정리(불필요 import 제거 포함)
  - src/main/java/com/dokdok/retrospective/repository/RetrospectiveRepository.java: 댓글 커서 조회 쿼리 사용처 정리 및 import 정리
  - src/test/java/com/dokdok/retrospective/service/MeetingRetrospectiveServiceTest.java: 무한스크롤 변경에 맞춘 테스트 보정 + 불필요 import 제거
  - src/test/java/com/dokdok/retrospective/service/MeetingRetrospectiveServiceTest.java: 최신 변경사항(댓글 무한스크롤/응답 구조)에 맞춘 테스트 수정
  - src/main/java/com/dokdok/retrospective/dto/response/CommentCursor.java: 댓글 커서 DTO 추가
  - src/main/java/com/dokdok/retrospective/service/MeetingRetrospectiveService.java: 댓글 무한스크롤 로직 구현(커서/hasNext/nextCursor)
  - src/main/java/com/dokdok/retrospective/repository/RetrospectiveRepository.java: 커서 기반 댓글 조회 쿼리 추가
  - src/main/java/com/dokdok/retrospective/api/MeetingRetrospectiveApi.java: 댓글 무한스크롤 API 정의 추가
  - src/main/java/com/dokdok/retrospective/controller/MeetingRetrospectiveController.java: 댓글 무한스크롤 API 라우팅 추가
  - src/main/java/com/dokdok/retrospective/dto/response/MeetingRetrospectiveResponse.java: 댓글 응답 구조 조정

---

## 참고 사항
> 리뷰어가 알아야 할 추가 정보, 테스트 방법 등을 작성해주세요.

예:  
- 테스트 계정 정보  
- 관련 API 엔드포인트  
- 로컬 테스트 방법  

---