### PR TITLE
[#103][REFACTOR] 확정된 주제 필드 추가

### DIFF
--- a/src/main/java/com/dokdok/topic/api/ConfirmTopicApi.java
+++ b/src/main/java/com/dokdok/topic/api/ConfirmTopicApi.java
@@ -47,7 +47,7 @@ public interface ConfirmTopicApi {
                     content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
                             schema = @Schema(implementation = ConfirmedTopicsResponse.class),
                             examples = @ExampleObject(value = """
-                                    {"code":"SUCCESS","message":"확정된 주제 조회를 완료했습니다.","data":{"page":{"items":[{"topicId":10,"title":"데미안에서 '자기 자신'이란?","description":"주제에 대한 간단한 설명입니다.","topicType":"DISCUSSION","confirmOrder":1,"createdByInfo":{"userId":1,"nickname":"독서왕"}}],"pageSize":10,"hasNext":false,"nextCursor":null,"totalCount":1},"actions":{"canViewPreOpinions":true,"canWritePreOpinions":false}}}
+                                    {"code":"SUCCESS","message":"확정된 주제 조회를 완료했습니다.","data":{"items":[{"topicId":10,"title":"데미안에서 '자기 자신'이란?","description":"주제에 대한 간단한 설명입니다.","topicType":"DISCUSSION","topicTypeLabel":"토론형","likeCount":5,"confirmOrder":1,"createdByInfo":{"userId":1,"nickname":"독서왕"}}],"pageSize":10,"hasNext":false,"nextCursor":null,"totalCount":1,"actions":{"canViewPreOpinions":true,"canWritePreOpinions":false}}}
                                     """))
             ),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(

--- a/src/main/java/com/dokdok/topic/dto/response/ConfirmedTopicsResponse.java
+++ b/src/main/java/com/dokdok/topic/dto/response/ConfirmedTopicsResponse.java
@@ -3,12 +3,15 @@ package com.dokdok.topic.dto.response;
 import com.dokdok.global.response.CursorResponse;
 import com.dokdok.topic.entity.Topic;
 import com.dokdok.topic.entity.TopicType;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.annotation.JsonUnwrapped;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
+@JsonPropertyOrder({"items", "pageSize", "hasNext", "nextCursor", "totalCount", "actions"})
 @Schema(description = "확정된 주제 목록 응답")
 public record ConfirmedTopicsResponse(
-        @Schema(description = "확정된 주제 목록 페이지 정보")
+        @JsonUnwrapped
         CursorResponse<ConfirmedTopicDto, ConfirmedTopicsCursor> page,
         @Schema(description = "사전 의견 관련 권한 정보")
         Actions actions
@@ -35,6 +38,10 @@ public record ConfirmedTopicsResponse(
             String description,
             @Schema(description = "주제 타입", example = "DISCUSSION")
             TopicType topicType,
+            @Schema(description = "주제 타입 라벨", example = "토론형")
+            String topicTypeLabel,
+            @Schema(description = "좋아요 수", example = "5")
+            Integer likeCount,
             @Schema(description = "확정 순서", example = "1")
             Integer confirmOrder,
             @Schema(description = "주제 제안자 정보")
@@ -46,6 +53,8 @@ public record ConfirmedTopicsResponse(
                     .title(topic.getTitle())
                     .description(topic.getDescription())
                     .topicType(topic.getTopicType())
+                    .topicTypeLabel(topic.getTopicType().getDisplayName())
+                    .likeCount(topic.getLikeCount())
                     .confirmOrder(topic.getConfirmOrder())
                     .createdByInfo(
                             CreatedByInfo.of(


### PR DESCRIPTION
 ## PR 요약

  - [ ] 기능 추가
  - [ ] 버그 수정
  - [x] 코드 리팩토링
  - [ ] 문서 수정
  - [ ] 기타 (설명)

  ———

  ## 이슈 번호

  - #103 

  ———

  ## 주요 변경 사항

  - src/main/java/com/dokdok/topic/dto/response/ConfirmedTopicsResponse.java: CursorResponse 평탄화 + actions + likeCount + topicTypeLabel 추가
  - src/main/java/com/dokdok/topic/api/ConfirmTopicApi.java: 파라미터/응답 예시 갱신

  ———

  ## 참고 사항

  - 관련 API 엔드포인트: GET /api/gatherings/{gatheringId}/meetings/{meetingId}/confirm-topics
