### PR TITLE
[#308][FEAT] 수집된 사전의견 조회 api

### DIFF
--- a/src/main/java/com/dokdok/retrospective/api/MeetingRetrospectiveApi.java
+++ b/src/main/java/com/dokdok/retrospective/api/MeetingRetrospectiveApi.java
@@ -362,13 +362,15 @@ public interface MeetingRetrospectiveApi {
                                           "topics": [
                                             {
                                               "topicId": 1,
-                                              "topicTitle": "가짜욕망, 유사 욕망",
+                                              "title": "가짜욕망, 유사 욕망",
+                                              "confirmOrder": 1,
                                               "answerId": 101,
                                               "content": "어쩌구 저쩌구..."
                                             },
                                             {
                                               "topicId": 2,
-                                              "topicTitle": "진정한 자아 찾기",
+                                              "title": "진정한 자아 찾기",
+                                              "confirmOrder": 2,
                                               "answerId": 102,
                                               "content": "저쩌구 어쩌구..."
                                             }
@@ -381,7 +383,8 @@ public interface MeetingRetrospectiveApi {
                                           "topics": [
                                             {
                                               "topicId": 1,
-                                              "topicTitle": "가짜욕망, 유사 욕망",
+                                              "title": "가짜욕망, 유사 욕망",
+                                              "confirmOrder": 1,
                                               "answerId": 103,
                                               "content": "내 생각은..."
                                             }

--- a/src/main/java/com/dokdok/retrospective/api/MeetingRetrospectiveApi.java
+++ b/src/main/java/com/dokdok/retrospective/api/MeetingRetrospectiveApi.java
@@ -3,9 +3,7 @@ package com.dokdok.retrospective.api;
 import com.dokdok.global.response.ApiResponse;
 import com.dokdok.global.response.CursorResponse;
 import com.dokdok.retrospective.dto.request.MeetingRetrospectiveRequest;
-import com.dokdok.retrospective.dto.response.CommentCursor;
-import com.dokdok.retrospective.dto.response.MeetingRetrospectiveResponse;
-import com.dokdok.retrospective.dto.response.TopicCommentCursorResponse;
+import com.dokdok.retrospective.dto.response.*;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
@@ -331,5 +329,126 @@ public interface MeetingRetrospectiveApi {
     ResponseEntity<ApiResponse<Void>> deleteMeetingRetrospective(
             @PathVariable Long meetingId,
             @PathVariable Long meetingRetrospectiveId
+    );
+
+    @Operation(
+            summary = "수집된 사전 의견 조회 (developer: 오주현)",
+            description = """                                                                                                                                                        
+                  약속 회고 생성 화면에서 멤버별로 그룹화된 사전 의견을 조회합니다.
+                  - 권한: 약속장만 조회 가능
+                  - 커서 기반 무한스크롤을 지원합니다.
+                  - 첫 페이지: cursorUserId 없이 호출
+                  - 다음 페이지: 응답의 nextCursor.userId 값을 cursorUserId로 전달
+                  - 정렬: userId ASC
+                  """
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "수집된 사전 의견 조회 성공",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = CollectedAnswersCursorResponse.class),
+                            examples = @ExampleObject(value = """                                                                                                                    
+                                  {
+                                    "code": "SUCCESS",
+                                    "message": "수집된 사전 의견 조회 성공",
+                                    "data": {
+                                      "items": [
+                                        {
+                                          "userId": 1,
+                                          "nickname": "곰곰",
+                                          "profileImageUrl": "https://example.com/profile.jpg",
+                                          "topics": [
+                                            {
+                                              "topicId": 1,
+                                              "topicTitle": "가짜욕망, 유사 욕망",
+                                              "answerId": 101,
+                                              "content": "어쩌구 저쩌구..."
+                                            },
+                                            {
+                                              "topicId": 2,
+                                              "topicTitle": "진정한 자아 찾기",
+                                              "answerId": 102,
+                                              "content": "저쩌구 어쩌구..."
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "userId": 2,
+                                          "nickname": "독서왕",
+                                          "profileImageUrl": "https://example.com/profile2.jpg",
+                                          "topics": [
+                                            {
+                                              "topicId": 1,
+                                              "topicTitle": "가짜욕망, 유사 욕망",
+                                              "answerId": 103,
+                                              "content": "내 생각은..."
+                                            }
+                                          ]
+                                        }
+                                      ],
+                                      "pageSize": 10,
+                                      "hasNext": true,
+                                      "nextCursor": {
+                                        "userId": 2
+                                      },
+                                      "totalCount": 8
+                                    }
+                                  }
+                                  """)
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "401",
+                    description = "인증 실패 - 로그인이 필요합니다.",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(value = """                                                                                                                    
+                                  {"code": "G102", "message": "인증이 필요합니다.", "data": null}
+                                  """)
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "403",
+                    description = "권한 없음 - 약속장만 조회할 수 있습니다.",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(value = """                                                                                                                    
+                                  {"code": "M003", "message": "약속장만 가능한 작업입니다.", "data": null}
+                                  """)
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "약속을 찾을 수 없음",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(value = """                                                                                                                    
+                                  {"code": "M001", "message": "약속을 찾을 수 없습니다.", "data": null}
+                                  """)
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "500",
+                    description = "서버 오류",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(value = """                                                                                                                    
+                                  {"code": "E000", "message": "서버 에러가 발생했습니다. 담당자에게 문의 바랍니다.", "data": null}
+                                  """)
+                    )
+            )
+    })
+    @GetMapping("/collected-answers")
+    ResponseEntity<ApiResponse<CursorResponse<MemberAnswerResponse, CollectedAnswersCursor>>> getCollectedAnswers(
+            @Parameter(description = "약속 ID", required = true, example = "1")
+            @PathVariable Long meetingId,
+
+            @Parameter(description = "페이지 크기", example = "10")
+            @RequestParam(defaultValue = "10") int pageSize,
+
+            @Parameter(description = "커서 - 마지막 멤버의 userId", example = "2")
+            @RequestParam(required = false) Long cursorUserId
     );
 }

--- a/src/main/java/com/dokdok/retrospective/controller/MeetingRetrospectiveController.java
+++ b/src/main/java/com/dokdok/retrospective/controller/MeetingRetrospectiveController.java
@@ -4,8 +4,10 @@ import com.dokdok.global.response.ApiResponse;
 import com.dokdok.global.response.CursorResponse;
 import com.dokdok.retrospective.api.MeetingRetrospectiveApi;
 import com.dokdok.retrospective.dto.request.MeetingRetrospectiveRequest;
+import com.dokdok.retrospective.dto.response.CollectedAnswersCursor;
 import com.dokdok.retrospective.dto.response.CommentCursor;
 import com.dokdok.retrospective.dto.response.MeetingRetrospectiveResponse;
+import com.dokdok.retrospective.dto.response.MemberAnswerResponse;
 import com.dokdok.retrospective.service.MeetingRetrospectiveService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -66,5 +68,17 @@ public class MeetingRetrospectiveController implements MeetingRetrospectiveApi {
         meetingRetrospectiveService.deleteMeetingRetrospective(meetingId, meetingRetrospectiveId);
 
         return ApiResponse.deleted("공동 회고 코멘트 삭제 완료");
+    }
+
+    @Override
+    @GetMapping("/collected-answers")
+    public ResponseEntity<ApiResponse<CursorResponse<MemberAnswerResponse, CollectedAnswersCursor>>> getCollectedAnswers(
+            @PathVariable Long meetingId,
+            @RequestParam(defaultValue = "10") int pageSize,
+            @RequestParam(required = false) Long cursorUserId
+    ) {
+        CursorResponse<MemberAnswerResponse, CollectedAnswersCursor> response =
+                meetingRetrospectiveService.getCollectedAnswers(meetingId, pageSize, cursorUserId);
+        return ApiResponse.success(response, "수집된 사전 의견 조회 성공");
     }
 }

--- a/src/main/java/com/dokdok/retrospective/dto/response/CollectedAnswersCursor.java
+++ b/src/main/java/com/dokdok/retrospective/dto/response/CollectedAnswersCursor.java
@@ -1,0 +1,13 @@
+package com.dokdok.retrospective.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "수집된 사전 의견 커서")
+public record CollectedAnswersCursor(
+        @Schema(description = "마지막 멤버의 사용자 ID", example = "3")
+        Long userId
+) {
+    public static CollectedAnswersCursor from(Long userId) {
+        return new CollectedAnswersCursor(userId);
+    }
+}

--- a/src/main/java/com/dokdok/retrospective/dto/response/CollectedAnswersCursorResponse.java
+++ b/src/main/java/com/dokdok/retrospective/dto/response/CollectedAnswersCursorResponse.java
@@ -1,0 +1,24 @@
+package com.dokdok.retrospective.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+@Schema(description = "수집된 사전 의견 목록 커서 응답(문서용)")
+public record CollectedAnswersCursorResponse(
+        @Schema(description = "멤버별 사전 의견 목록")
+        List<MemberAnswerResponse> items,
+
+        @Schema(description = "페이지 크기", example = "10")
+        int pageSize,
+
+        @Schema(description = "다음 페이지 존재 여부", example = "true")
+        boolean hasNext,
+
+        @Schema(description = "다음 커서")
+        CollectedAnswersCursor nextCursor,
+
+        @Schema(description = "전체 답변 수 (첫 페이지 요청 시에만 제공)", example = "8")
+        Integer totalCount
+) {
+}

--- a/src/main/java/com/dokdok/retrospective/dto/response/MemberAnswerResponse.java
+++ b/src/main/java/com/dokdok/retrospective/dto/response/MemberAnswerResponse.java
@@ -1,0 +1,36 @@
+package com.dokdok.retrospective.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+@Schema(description = "멤버별 수집된 주제 답변")
+public record MemberAnswerResponse(
+        @Schema(description = "사용자 ID",example = "1")
+        Long userId,
+
+        @Schema(description = "사용자 닉네임", example = "독서왕")
+        String nickname,
+
+        @Schema(description = "프로필 이미지 URL")
+        String profileImageUrl,
+
+        @Schema(description = "주제별 사전 답변목록")
+        List<TopicAnswerItem> topics
+) {
+    @Schema(description = "주제별 사전 답변")
+    public record TopicAnswerItem(
+            @Schema(description = "주제 ID",example = "1")
+            Long topicId,
+
+            @Schema(description = "주제 제목", example = "가짜욕망 유사욕망")
+            String topicTitle,
+
+            @Schema(description = "답변 ID",example = "101")
+            Long answerId,
+
+            @Schema(description = "답변 내용",example = "어쩌구 저쩌구 ...")
+            String content
+    ){
+    }
+}

--- a/src/main/java/com/dokdok/retrospective/dto/response/MemberAnswerResponse.java
+++ b/src/main/java/com/dokdok/retrospective/dto/response/MemberAnswerResponse.java
@@ -24,7 +24,10 @@ public record MemberAnswerResponse(
             Long topicId,
 
             @Schema(description = "주제 제목", example = "가짜욕망 유사욕망")
-            String topicTitle,
+            String title,
+
+            @Schema(description = "확정 순서", example = "1")
+            Integer confirmOrder,
 
             @Schema(description = "답변 ID",example = "101")
             Long answerId,

--- a/src/main/java/com/dokdok/retrospective/service/MeetingRetrospectiveService.java
+++ b/src/main/java/com/dokdok/retrospective/service/MeetingRetrospectiveService.java
@@ -5,8 +5,7 @@ import com.dokdok.global.util.SecurityUtil;
 import com.dokdok.meeting.entity.Meeting;
 import com.dokdok.meeting.service.MeetingValidator;
 import com.dokdok.retrospective.dto.request.MeetingRetrospectiveRequest;
-import com.dokdok.retrospective.dto.response.CommentCursor;
-import com.dokdok.retrospective.dto.response.MeetingRetrospectiveResponse;
+import com.dokdok.retrospective.dto.response.*;
 import com.dokdok.retrospective.entity.MeetingRetrospective;
 import com.dokdok.retrospective.entity.TopicRetrospectiveSummary;
 import com.dokdok.retrospective.exception.RetrospectiveErrorCode;
@@ -15,7 +14,9 @@ import com.dokdok.retrospective.repository.RetrospectiveRepository;
 import com.dokdok.retrospective.repository.TopicRetrospectiveSummaryRepository;
 import com.dokdok.storage.service.StorageService;
 import com.dokdok.topic.entity.Topic;
+import com.dokdok.topic.entity.TopicAnswer;
 import com.dokdok.topic.entity.TopicStatus;
+import com.dokdok.topic.repository.TopicAnswerRepository;
 import com.dokdok.topic.repository.TopicRepository;
 import com.dokdok.topic.service.TopicValidator;
 import com.dokdok.user.entity.User;
@@ -42,6 +43,7 @@ public class MeetingRetrospectiveService {
     private final MeetingValidator meetingValidator;
     private final TopicValidator topicValidator;
     private final StorageService storageService;
+    private final TopicAnswerRepository topicAnswerRepository;
 
     /**
      * 공동 회고 조회 ( 토픽 정보 + 요약 + 키포인트, 코멘트 제외 )
@@ -185,5 +187,98 @@ public class MeetingRetrospectiveService {
         }
         MeetingRetrospective lastComment = comments.get(comments.size() - 1);
         return CommentCursor.from(lastComment);
+    }
+
+    /**
+     * 수집된 사전 의견 조회 (멤버별 그룹화, 커서 기반 무한 스크롤)
+     */
+    public CursorResponse<MemberAnswerResponse, CollectedAnswersCursor> getCollectedAnswers(
+            Long meetingId,
+            int pageSize,
+            Long cursorUserId) {
+        Long userId = SecurityUtil.getCurrentUserId();
+        Meeting meeting = meetingValidator.findMeetingOrThrow(meetingId);
+
+        meetingValidator.validateMeetingLeader(meeting, userId);
+
+        return fetchCollectedAnswers(meetingId, pageSize, cursorUserId);
+    }
+
+    private CursorResponse<MemberAnswerResponse, CollectedAnswersCursor> fetchCollectedAnswers(
+            Long meetingId,
+            int pageSize,
+            Long cursorUserId) {
+        Pageable pageable = PageRequest.of(0, pageSize + 1);
+        boolean isFirstPage = cursorUserId == null;
+
+        // 1. userId 목록 조회 (pageSize + 1개)
+        List<Long> userIds = isFirstPage
+                ? topicAnswerRepository.findDistinctUserIdsByMeetingIdFirstPage(meetingId, pageable)
+                : topicAnswerRepository.findDistinctUserIdsByMeetingIdAfterCursor(meetingId, cursorUserId, pageable);
+
+        // 2. hasNext 판단
+        boolean hasNext = userIds.size() > pageSize;
+        List<Long> pageUserIds = hasNext
+                ? userIds.subList(0, pageSize)
+                : userIds;
+
+        // 3. 해당 userId들의 답변 조회
+        List<TopicAnswer> answers = pageUserIds.isEmpty()
+                ? List.of()
+                : topicAnswerRepository.findSubmittedAnswersByMeetingIdAndUserIds(meetingId, pageUserIds);
+
+        // 4. 멤버별로 그룹화하여 Response 생성
+        List<MemberAnswerResponse> items = buildMemberAnswerResponses(answers, pageUserIds);
+
+        // 5. 커서 및 totalCount 생성
+        CollectedAnswersCursor nextCursor = buildCollectedAnswersCursor(pageUserIds, hasNext);
+        Integer totalCount = isFirstPage
+                ? topicAnswerRepository.countSubmittedAnswersByMeetingId(meetingId)
+                : null;
+
+        return CursorResponse.of(items, pageSize, hasNext, nextCursor, totalCount);
+    }
+
+    private List<MemberAnswerResponse> buildMemberAnswerResponses(
+            List<TopicAnswer> answers,
+            List<Long> orderedUserIds
+    ) {
+        // userId -> 답변 목록 그룹화
+        Map<Long, List<TopicAnswer>> answersByUserId = answers.stream()
+                .collect(Collectors.groupingBy(ta -> ta.getUser().getId()));
+
+        // userId 순서 유지하며 Response 생성
+        return orderedUserIds.stream()
+                .filter(answersByUserId::containsKey)
+                .map(uid -> {
+                    List<TopicAnswer> userAnswers = answersByUserId.get(uid);
+                    User user = userAnswers.get(0).getUser();
+                    String presignedUrl = storageService.getPresignedProfileImage(user.getProfileImageUrl());
+
+                    List<MemberAnswerResponse.TopicAnswerItem> topics = userAnswers.stream()
+                            .map(ta -> new MemberAnswerResponse.TopicAnswerItem(
+                                    ta.getTopic().getId(),
+                                    ta.getTopic().getTitle(),
+                                    ta.getId(),
+                                    ta.getContent()
+                            ))
+                            .toList();
+
+                    return new MemberAnswerResponse(
+                            user.getId(),
+                            user.getNickname(),
+                            presignedUrl,
+                            topics
+                    );
+                })
+                .toList();
+    }
+
+    private CollectedAnswersCursor buildCollectedAnswersCursor(List<Long> userIds, boolean hasNext) {
+        if (!hasNext || userIds.isEmpty()) {
+            return null;
+        }
+        Long lastUserId = userIds.get(userIds.size() - 1);
+        return CollectedAnswersCursor.from(lastUserId);
     }
 }

--- a/src/main/java/com/dokdok/retrospective/service/MeetingRetrospectiveService.java
+++ b/src/main/java/com/dokdok/retrospective/service/MeetingRetrospectiveService.java
@@ -259,6 +259,7 @@ public class MeetingRetrospectiveService {
                             .map(ta -> new MemberAnswerResponse.TopicAnswerItem(
                                     ta.getTopic().getId(),
                                     ta.getTopic().getTitle(),
+                                    ta.getTopic().getConfirmOrder(),
                                     ta.getId(),
                                     ta.getContent()
                             ))

--- a/src/main/java/com/dokdok/topic/api/PreOpinionApi.java
+++ b/src/main/java/com/dokdok/topic/api/PreOpinionApi.java
@@ -45,7 +45,7 @@ public interface PreOpinionApi {
                     content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
                             schema = @Schema(implementation = PreOpinionResponse.class),
                             examples = @ExampleObject(value = """
-                                    {"code":"SUCCESS","message":"약속의 사전 의견 목록 조회를 성공했습니다.","data":{"topics":[{"topicId":1,"title":"책의 주요 메시지","description":"이 책에서 전달하고자 하는 핵심 메시지는 무엇인가요?","topicType":"DISCUSSION","topicTypeLabel":"토론형","confirmOrder":1}],"members":[{"memberInfo":{"memberId":1,"nickname":"독서왕","profileImage":"https://example.com/profile.jpg","role":"GATHERING_LEADER"},"bookReview":{"rating":4.5,"keywordInfo":[{"id":1,"name":"성장","type":"BOOK"},{"id":2,"name":"여운이 남는","type":"IMPRESSION"}]},"topicOpinions":[{"topicId":1,"content":"저는 이 책의 핵심 메시지가 자기 성찰이라고 생각합니다."}],"isSubmitted":true}]}}
+                                    {"code":"SUCCESS","message":"약속의 사전 의견 목록 조회를 성공했습니다.","data":{"topics":[{"topicId":1,"title":"책의 주요 메시지","description":"이 책에서 전달하고자 하는 핵심 메시지는 무엇인가요?","topicType":"DISCUSSION","topicTypeLabel":"토론형","confirmOrder":1}],"members":[{"memberInfo":{"userId":1,"nickname":"독서왕","profileImage":"https://example.com/profile.jpg","role":"GATHERING_LEADER"},"bookReview":{"rating":4.5,"keywordInfo":[{"id":1,"name":"성장","type":"BOOK"},{"id":2,"name":"여운이 남는","type":"IMPRESSION"}]},"topicOpinions":[{"topicId":1,"content":"저는 이 책의 핵심 메시지가 자기 성찰이라고 생각합니다."}],"isSubmitted":true}]}}
                                     """))
             ),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(

--- a/src/main/java/com/dokdok/topic/repository/TopicAnswerRepository.java
+++ b/src/main/java/com/dokdok/topic/repository/TopicAnswerRepository.java
@@ -155,7 +155,7 @@ public interface TopicAnswerRepository extends JpaRepository<TopicAnswer, Long> 
           WHERE t.meeting.id = :meetingId
           AND ta.isSubmitted = true
           AND u.id IN :userIds
-          ORDER BY u.id ASC, t.id ASC
+          ORDER BY u.id ASC, t.confirmOrder ASC NULLS LAST, t.id ASC
           """)
     List<TopicAnswer> findSubmittedAnswersByMeetingIdAndUserIds(
             @Param("meetingId") Long meetingId,

--- a/src/main/java/com/dokdok/topic/repository/TopicAnswerRepository.java
+++ b/src/main/java/com/dokdok/topic/repository/TopicAnswerRepository.java
@@ -1,6 +1,7 @@
 package com.dokdok.topic.repository;
 
 import com.dokdok.topic.entity.TopicAnswer;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -104,4 +105,72 @@ public interface TopicAnswerRepository extends JpaRepository<TopicAnswer, Long> 
             @Param("meetingId") Long meetingId,
             @Param("userId") Long userId
     );
+
+    // === 수집된 사전 의견 조회용 쿼리 ===
+
+    /**
+     * 첫 페이지: 제출된 답변이 있는 userId 목록 조회 (distinct, 오름차순)
+     */
+    @Query("""                                                                                                                                                                       
+          SELECT DISTINCT u.id
+          FROM TopicAnswer ta
+          JOIN ta.user u
+          JOIN ta.topic t
+          WHERE t.meeting.id = :meetingId
+          AND ta.isSubmitted = true
+          ORDER BY u.id ASC
+          """)
+    List<Long> findDistinctUserIdsByMeetingIdFirstPage(
+            @Param("meetingId") Long meetingId,
+            Pageable pageable
+    );
+
+    /**
+     * 다음 페이지: 커서 이후 userId 목록 조회
+     */
+    @Query("""                                                                                                                                                                       
+          SELECT DISTINCT u.id
+          FROM TopicAnswer ta
+          JOIN ta.user u
+          JOIN ta.topic t
+          WHERE t.meeting.id = :meetingId
+          AND ta.isSubmitted = true
+          AND u.id > :cursorUserId
+          ORDER BY u.id ASC
+          """)
+    List<Long> findDistinctUserIdsByMeetingIdAfterCursor(
+            @Param("meetingId") Long meetingId,
+            @Param("cursorUserId") Long cursorUserId,
+            Pageable pageable
+    );
+
+    /**
+     * userId 목록으로 제출된 답변 조회 (user, topic fetch)
+     */
+    @Query("""                                                                                                                                                                       
+          SELECT ta
+          FROM TopicAnswer ta
+          JOIN FETCH ta.user u
+          JOIN FETCH ta.topic t
+          WHERE t.meeting.id = :meetingId
+          AND ta.isSubmitted = true
+          AND u.id IN :userIds
+          ORDER BY u.id ASC, t.id ASC
+          """)
+    List<TopicAnswer> findSubmittedAnswersByMeetingIdAndUserIds(
+            @Param("meetingId") Long meetingId,
+            @Param("userIds") List<Long> userIds
+    );
+
+    /**
+     * 제출된 답변 총 개수
+     */
+    @Query("""                                                                                                                                                                       
+          SELECT COUNT(ta)
+          FROM TopicAnswer ta
+          JOIN ta.topic t
+          WHERE t.meeting.id = :meetingId
+          AND ta.isSubmitted = true
+          """)
+    int countSubmittedAnswersByMeetingId(@Param("meetingId") Long meetingId);
 }

--- a/src/test/java/com/dokdok/retrospective/service/MeetingRetrospectiveServiceTest.java
+++ b/src/test/java/com/dokdok/retrospective/service/MeetingRetrospectiveServiceTest.java
@@ -3,6 +3,7 @@ package com.dokdok.retrospective.service;
 import com.dokdok.gathering.entity.Gathering;
 import com.dokdok.gathering.exception.GatheringErrorCode;
 import com.dokdok.gathering.exception.GatheringException;
+import com.dokdok.global.response.CursorResponse;
 import com.dokdok.global.util.SecurityUtil;
 import com.dokdok.meeting.entity.Meeting;
 import com.dokdok.meeting.exception.MeetingErrorCode;
@@ -10,7 +11,9 @@ import com.dokdok.meeting.exception.MeetingException;
 import com.dokdok.meeting.service.MeetingValidator;
 import com.dokdok.oauth2.CustomOAuth2User;
 import com.dokdok.retrospective.dto.request.MeetingRetrospectiveRequest;
+import com.dokdok.retrospective.dto.response.CollectedAnswersCursor;
 import com.dokdok.retrospective.dto.response.MeetingRetrospectiveResponse;
+import com.dokdok.retrospective.dto.response.MemberAnswerResponse;
 import com.dokdok.retrospective.entity.MeetingRetrospective;
 import com.dokdok.retrospective.entity.TopicRetrospectiveSummary;
 import com.dokdok.retrospective.exception.RetrospectiveErrorCode;
@@ -19,7 +22,9 @@ import com.dokdok.retrospective.repository.RetrospectiveRepository;
 import com.dokdok.retrospective.repository.TopicRetrospectiveSummaryRepository;
 import com.dokdok.storage.service.StorageService;
 import com.dokdok.topic.entity.Topic;
+import com.dokdok.topic.entity.TopicAnswer;
 import com.dokdok.topic.entity.TopicStatus;
+import com.dokdok.topic.repository.TopicAnswerRepository;
 import com.dokdok.topic.repository.TopicRepository;
 import com.dokdok.topic.service.TopicValidator;
 import com.dokdok.user.entity.User;
@@ -30,6 +35,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Pageable;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -56,6 +62,9 @@ class MeetingRetrospectiveServiceTest {
 
 	@Mock
 	private StorageService storageService;
+
+	@Mock
+	private TopicAnswerRepository topicAnswerRepository;
 
 	@InjectMocks
 	private MeetingRetrospectiveService meetingRetrospectiveService;
@@ -365,6 +374,46 @@ class MeetingRetrospectiveServiceTest {
 					.hasFieldOrPropertyWithValue("errorCode", GatheringErrorCode.NOT_GATHERING_LEADER);
 
 			verify(retrospectiveRepository, never()).delete(any());
+		}
+	}
+
+	@Test
+	@DisplayName("수집된 사전 의견 조회 - 첫 페이지")
+	void getCollectedAnswers_firstPage_success() {
+		Long meetingId = 1L;
+		Long userId = 1L;
+		int pageSize = 1;
+
+		User leader = User.builder().id(userId).nickname("리더").profileImageUrl("leader.jpg").build();
+		Meeting meeting = Meeting.builder().id(meetingId).meetingLeader(leader).build();
+		Topic topic = Topic.builder().id(10L).title("주제").build();
+		TopicAnswer answer = TopicAnswer.builder()
+				.id(100L)
+				.topic(topic)
+				.user(leader)
+				.content("답변")
+				.isSubmitted(true)
+				.build();
+
+		try (MockedStatic<SecurityUtil> securityUtilMock = mockStatic(SecurityUtil.class)) {
+			securityUtilMock.when(SecurityUtil::getCurrentUserId).thenReturn(userId);
+
+			when(meetingValidator.findMeetingOrThrow(meetingId)).thenReturn(meeting);
+			when(topicAnswerRepository.findDistinctUserIdsByMeetingIdFirstPage(eq(meetingId), any(Pageable.class)))
+					.thenReturn(List.of(userId, 2L));
+			when(topicAnswerRepository.findSubmittedAnswersByMeetingIdAndUserIds(meetingId, List.of(userId)))
+					.thenReturn(List.of(answer));
+			when(topicAnswerRepository.countSubmittedAnswersByMeetingId(meetingId)).thenReturn(2);
+			when(storageService.getPresignedProfileImage("leader.jpg")).thenReturn("leader.jpg");
+
+			CursorResponse<MemberAnswerResponse, CollectedAnswersCursor> response =
+					meetingRetrospectiveService.getCollectedAnswers(meetingId, pageSize, null);
+
+			assertThat(response.items()).hasSize(1);
+			assertThat(response.items().get(0).userId()).isEqualTo(userId);
+			assertThat(response.hasNext()).isTrue();
+			assertThat(response.nextCursor().userId()).isEqualTo(userId);
+			assertThat(response.totalCount()).isEqualTo(2);
 		}
 	}
 }


### PR DESCRIPTION
## PR 요약
> 이 PR이 어떤 변경을 하는지 간단히 설명하고, 체크 표시는 괄호 사이에 소문자 'x'를 삽입하세요.

- [x] 기능 추가
- [ ] 버그 수정
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 기타 (설명)

---

## 이슈 번호
- #308 

---

## 주요 변경 사항
> 주요 파일, 로직, 컴포넌트 등을 구체적으로 적어주세요.

 - src/test/java/com/dokdok/retrospective/service/MeetingRetrospectiveServiceTest.java: 수집된 사전 의견 조회 기능에 대한 최소 성공 케이스 테스트 추가
  - src/main/java/com/dokdok/retrospective/api/MeetingRetrospectiveApi.java: 수집된 사전 의견 조회 API 스펙 추가
  - src/main/java/com/dokdok/retrospective/controller/MeetingRetrospectiveController.java: 수집된 사전 의견 조회 엔드포인트 구현
  - src/main/java/com/dokdok/retrospective/dto/response/CollectedAnswersCursor.java: 커서 DTO 추가
  - src/main/java/com/dokdok/retrospective/dto/response/CollectedAnswersCursorResponse.java: 문서용 커서 응답 DTO 추가
  - src/main/java/com/dokdok/retrospective/dto/response/MemberAnswerResponse.java: 멤버별 답변 응답 DTO 추가
  - src/main/java/com/dokdok/retrospective/service/MeetingRetrospectiveService.java: 수집된 사전 의견 조회 서비스 로직 추가
  - src/main/java/com/dokdok/topic/repository/TopicAnswerRepository.java: 커서 기반 유저 목록/답변 조회 쿼리 추가

---

## 참고 사항
> 리뷰어가 알아야 할 추가 정보, 테스트 방법 등을 작성해주세요.

예:  
- 테스트 계정 정보  
- 관련 API 엔드포인트  
- 로컬 테스트 방법  

---