### PR TITLE
[#279][FEAT] 약속 생성 확정 시 기본 주제 등록

### DIFF
--- a/src/main/java/com/dokdok/meeting/service/MeetingService.java
+++ b/src/main/java/com/dokdok/meeting/service/MeetingService.java
@@ -30,6 +30,7 @@ import com.dokdok.topic.entity.TopicStatus;
 import com.dokdok.topic.entity.TopicType;
 import com.dokdok.topic.repository.TopicAnswerRepository;
 import com.dokdok.topic.repository.TopicRepository;
+import com.dokdok.topic.service.TopicService;
 import com.dokdok.user.entity.User;
 import com.dokdok.user.service.UserValidator;
 import lombok.RequiredArgsConstructor;
@@ -50,6 +51,7 @@ public class MeetingService {
     private final MeetingMemberRepository meetingMemberRepository;
     private final TopicRepository topicRepository;
     private final TopicAnswerRepository topicAnswerRepository;
+    private final TopicService topicService;
     private final GatheringRepository gatheringRepository;
     private final GatheringMemberRepository gatheringMemberRepository;
     private final GatheringValidator gatheringValidator;
@@ -155,6 +157,7 @@ public class MeetingService {
 
         meeting.changeStatus(MeetingStatus.CONFIRMED);
         saveMeetingBookForUser(meeting, meeting.getGathering(), meeting.getMeetingLeader().getId());
+        topicService.createDefaultTopic(meeting);
 
         return MeetingStatusResponse.from(meeting);
     }

--- a/src/main/java/com/dokdok/topic/service/TopicService.java
+++ b/src/main/java/com/dokdok/topic/service/TopicService.java
@@ -19,6 +19,7 @@ import com.dokdok.topic.entity.Topic;
 import com.dokdok.topic.entity.TopicLike;
 import com.dokdok.topic.entity.TopicMessage;
 import com.dokdok.topic.entity.TopicStatus;
+import com.dokdok.topic.entity.TopicType;
 import com.dokdok.topic.exception.TopicErrorCode;
 import com.dokdok.topic.exception.TopicException;
 import com.dokdok.topic.repository.TopicAnswerRepository;
@@ -49,6 +50,32 @@ public class TopicService {
     private final GatheringValidator gatheringValidator;
     private final MeetingValidator meetingValidator;
     private final TopicValidator topicValidator;
+
+    @Transactional
+    public void createDefaultTopic(Meeting meeting) {
+        if (meeting == null || meeting.getId() == null) {
+            return;
+        }
+        if (topicRepository.countByMeetingIdAndDeletedAtIsNull(meeting.getId()) > 0) {
+            return;
+        }
+
+        User leader = meeting.getMeetingLeader();
+        if (leader == null) {
+            return;
+        }
+        TopicType type = TopicType.FREE;
+
+        Topic topic = Topic.create(
+                meeting,
+                leader,
+                type.getDisplayName(),
+                type.getDescription(),
+                type
+        );
+
+        topicRepository.save(topic);
+    }
 
     @Transactional
     public SuggestTopicResponse createTopic(

--- a/src/test/java/com/dokdok/meeting/service/MeetingServiceTest.java
+++ b/src/test/java/com/dokdok/meeting/service/MeetingServiceTest.java
@@ -26,6 +26,7 @@ import com.dokdok.topic.entity.TopicStatus;
 import com.dokdok.topic.entity.TopicType;
 import com.dokdok.topic.repository.TopicAnswerRepository;
 import com.dokdok.topic.repository.TopicRepository;
+import com.dokdok.topic.service.TopicService;
 import com.dokdok.user.entity.User;
 import com.dokdok.user.service.UserValidator;
 import org.junit.jupiter.api.BeforeEach;
@@ -67,6 +68,9 @@ class MeetingServiceTest {
 
     @Mock
     private TopicAnswerRepository topicAnswerRepository;
+
+    @Mock
+    private TopicService topicService;
 
     @Mock
     private GatheringRepository gatheringRepository;
@@ -561,6 +565,7 @@ class MeetingServiceTest {
             MeetingMember savedMember = meetingMemberCaptor.getValue();
             assertThat(savedMember.getUser().getId()).isEqualTo(leader.getId());
             assertThat(savedMember.getMeetingRole()).isEqualTo(MeetingMemberRole.LEADER);
+            verify(topicService).createDefaultTopic(meeting);
         }
     }
 

--- a/src/test/java/com/dokdok/topic/service/TopicServiceTest.java
+++ b/src/test/java/com/dokdok/topic/service/TopicServiceTest.java
@@ -121,6 +121,61 @@ class TopicServiceTest {
     }
 
     @Test
+    @DisplayName("기본 자유형 토픽이 없으면 생성한다")
+    void createDefaultTopic_Success() {
+        Meeting meeting = Meeting.builder()
+                .id(10L)
+                .meetingLeader(testUser)
+                .build();
+
+        given(topicRepository.countByMeetingIdAndDeletedAtIsNull(meeting.getId()))
+                .willReturn(0L);
+
+        topicService.createDefaultTopic(meeting);
+
+        var captor = org.mockito.ArgumentCaptor.forClass(Topic.class);
+        verify(topicRepository).save(captor.capture());
+        Topic saved = captor.getValue();
+        assertThat(saved.getMeeting()).isEqualTo(meeting);
+        assertThat(saved.getProposedBy()).isEqualTo(testUser);
+        assertThat(saved.getTopicType()).isEqualTo(TopicType.FREE);
+        assertThat(saved.getTitle()).isEqualTo(TopicType.FREE.getDisplayName());
+        assertThat(saved.getDescription()).isEqualTo(TopicType.FREE.getDescription());
+    }
+
+    @Test
+    @DisplayName("이미 토픽이 있으면 기본 토픽을 생성하지 않는다")
+    void createDefaultTopic_SkipWhenExists() {
+        Meeting meeting = Meeting.builder()
+                .id(10L)
+                .meetingLeader(testUser)
+                .build();
+
+        given(topicRepository.countByMeetingIdAndDeletedAtIsNull(meeting.getId()))
+                .willReturn(1L);
+
+        topicService.createDefaultTopic(meeting);
+
+        verify(topicRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("약속장이 없으면 기본 토픽을 생성하지 않는다")
+    void createDefaultTopic_SkipWhenLeaderMissing() {
+        Meeting meeting = Meeting.builder()
+                .id(10L)
+                .meetingLeader(null)
+                .build();
+
+        given(topicRepository.countByMeetingIdAndDeletedAtIsNull(meeting.getId()))
+                .willReturn(0L);
+
+        topicService.createDefaultTopic(meeting);
+
+        verify(topicRepository, never()).save(any());
+    }
+
+    @Test
     @DisplayName("선택한 주제를 확정 상태로 변경한다")
     void confirmTopics_Success() {
         Long gatheringId = 1L;


### PR DESCRIPTION
## PR 요약
> 이 PR이 어떤 변경을 하는지 간단히 설명하고, 체크 표시는 괄호 사이에 소문자 'x'를 삽입하세요.

- [x] 기능 추가
- [ ] 버그 수정
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 기타 (설명)

---

## 이슈 번호
- #279

---

## 주요 변경 사항
> 주요 파일, 로직, 컴포넌트 등을 구체적으로 적어주세요.

  - src/main/java/com/dokdok/meeting: +3/-0 (1 files) — 약속 확정 시 기본 토픽 자동
    생성 호출 추가 (MeetingService.confirmMeeting)
  - src/main/java/com/dokdok/topic: +27/-0 (1 files) — 기본 자유형 토픽 생성 메서드
    createDefaultTopic 추가 (미팅에 토픽 없을 때만 생성, 약속장 기준)
  - src/test/java/com/dokdok/meeting: +5/-0 (1 files) — 약속 확정 시 기본 토픽 생성
    호출 검증 테스트 추가
  - src/test/java/com/dokdok/topic: +55/-0 (1 files) — createDefaultTopic 생성/스
    킵/리더 없음 케이스 테스트 추가


---

## 참고 사항
> 리뷰어가 알아야 할 추가 정보, 테스트 방법 등을 작성해주세요.

예:
- 테스트 계정 정보
- 관련 API 엔드포인트
- 로컬 테스트 방법

---
