### PR TITLE
[#330][FIX] 개인회고 API retrospectiveId 없이 조회하도록 변경

### DIFF
--- a/src/main/java/com/dokdok/retrospective/api/PersonalRetrospectiveApi.java
+++ b/src/main/java/com/dokdok/retrospective/api/PersonalRetrospectiveApi.java
@@ -226,7 +226,7 @@ public interface PersonalRetrospectiveApi {
             summary = "개인 회고 수정 폼 조회 (developer: 경서영)",
             description = """
             기존에 작성한 개인 회고를 수정하기 위한 데이터를 조회합니다.
-            - 권한: 약속 멤버
+            - 권한: 약속 멤버 (본인이 작성한 회고만 조회 가능)
 
             **응답 구조**
             - changedThoughts: 기존 생각의 변화 목록 (confirmOrder 순)
@@ -236,8 +236,7 @@ public interface PersonalRetrospectiveApi {
             - meetingMembers: 본인 제외 약속 멤버 목록
             """,
             parameters = {
-                    @Parameter(name = "meetingId", description = "약속 식별자", in = ParameterIn.PATH, required = true),
-                    @Parameter(name = "retrospectiveId", description = "개인 회고 식별자", in = ParameterIn.PATH, required = true)
+                    @Parameter(name = "meetingId", description = "약속 식별자", in = ParameterIn.PATH, required = true)
             }
     )
     @ApiResponses({
@@ -311,17 +310,16 @@ public interface PersonalRetrospectiveApi {
                     )
             )
     })
-    @GetMapping(value = "/{retrospectiveId}/form", produces = MediaType.APPLICATION_JSON_VALUE)
+    @GetMapping(value = "/form/edit", produces = MediaType.APPLICATION_JSON_VALUE)
     ResponseEntity<ApiResponse<PersonalRetrospectiveEditResponse>> getPersonalRetrospectiveEditForm(
-            @PathVariable Long meetingId,
-            @PathVariable Long retrospectiveId
+            @PathVariable Long meetingId
     );
 
     @Operation(
             summary = "개인 회고 상세 조회 (developer: 경서영)",
             description = """
-            특정 개인 회고의 상세 정보를 조회합니다.
-            - 권한: 약속 멤버
+            본인이 작성한 개인 회고의 상세 정보를 조회합니다.
+            - 권한: 약속 멤버 (본인 회고만 조회 가능)
 
             **응답 구조**
             - changedThoughts: 생각의 변화 목록 (confirmOrder 순, 주제별 사전/사후 의견)
@@ -329,8 +327,7 @@ public interface PersonalRetrospectiveApi {
             - freeTexts: 자유 기록 목록
             """,
             parameters = {
-                    @Parameter(name = "meetingId", description = "약속 식별자", in = ParameterIn.PATH, required = true),
-                    @Parameter(name = "retrospectiveId", description = "개인 회고 식별자", in = ParameterIn.PATH, required = true)
+                    @Parameter(name = "meetingId", description = "약속 식별자", in = ParameterIn.PATH, required = true)
             }
     )
     @ApiResponses({
@@ -404,10 +401,9 @@ public interface PersonalRetrospectiveApi {
                     )
             )
     })
-    @GetMapping(value = "/{retrospectiveId}", produces = MediaType.APPLICATION_JSON_VALUE)
+    @GetMapping(produces = MediaType.APPLICATION_JSON_VALUE)
     ResponseEntity<ApiResponse<PersonalRetrospectiveDetailResponse>> getPersonalRetrospective(
-            @PathVariable Long meetingId,
-            @PathVariable Long retrospectiveId
+            @PathVariable Long meetingId
     );
 
     @Operation(
@@ -419,8 +415,7 @@ public interface PersonalRetrospectiveApi {
             - 동작: 기존 데이터 삭제 후 새로운 데이터로 전체 교체
             """,
             parameters = {
-                    @Parameter(name = "meetingId", description = "약속 식별자", in = ParameterIn.PATH, required = true),
-                    @Parameter(name = "retrospectiveId", description = "개인 회고 식별자", in = ParameterIn.PATH, required = true)
+                    @Parameter(name = "meetingId", description = "약속 식별자", in = ParameterIn.PATH, required = true)
             }
     )
     @ApiResponses({
@@ -506,10 +501,9 @@ public interface PersonalRetrospectiveApi {
                     )
             )
     })
-    @PutMapping(value = "/{retrospectiveId}", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
+    @PutMapping(consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     ResponseEntity<ApiResponse<PersonalRetrospectiveResponse>> editPersonalRetrospective(
             @PathVariable Long meetingId,
-            @PathVariable Long retrospectiveId,
             @Valid @RequestBody PersonalRetrospectiveRequest request
     );
 
@@ -522,8 +516,7 @@ public interface PersonalRetrospectiveApi {
             - 제약: 이미 삭제된 회고는 다시 삭제 불가
             """,
             parameters = {
-                    @Parameter(name = "meetingId", description = "약속 식별자", in = ParameterIn.PATH, required = true),
-                    @Parameter(name = "retrospectiveId", description = "개인 회고 식별자", in = ParameterIn.PATH, required = true)
+                    @Parameter(name = "meetingId", description = "약속 식별자", in = ParameterIn.PATH, required = true)
             }
     )
     @ApiResponses({
@@ -604,9 +597,8 @@ public interface PersonalRetrospectiveApi {
                     )
             )
     })
-    @DeleteMapping(value = "/{retrospectiveId}", produces = MediaType.APPLICATION_JSON_VALUE)
+    @DeleteMapping(produces = MediaType.APPLICATION_JSON_VALUE)
     ResponseEntity<ApiResponse<Void>> deletePersonalRetrospective(
-            @PathVariable Long meetingId,
-            @PathVariable Long retrospectiveId
+            @PathVariable Long meetingId
     );
 }

--- a/src/main/java/com/dokdok/retrospective/controller/PersonalRetrospectiveController.java
+++ b/src/main/java/com/dokdok/retrospective/controller/PersonalRetrospectiveController.java
@@ -45,50 +45,45 @@ public class PersonalRetrospectiveController implements PersonalRetrospectiveApi
 
 
     @Override
-    @GetMapping("/{retrospectiveId}/form")
+    @GetMapping("/form/edit")
     public ResponseEntity<ApiResponse<PersonalRetrospectiveEditResponse>> getPersonalRetrospectiveEditForm(
-            @PathVariable Long meetingId,
-            @PathVariable Long retrospectiveId
+            @PathVariable Long meetingId
     ) {
         PersonalRetrospectiveEditResponse response
-                = personalRetrospectiveService.getPersonalRetrospectiveEditForm(meetingId, retrospectiveId);
+                = personalRetrospectiveService.getPersonalRetrospectiveEditForm(meetingId);
 
         return ApiResponse.success(response, "개인 회고 수정 폼 조회를 성공했습니다.");
     }
 
     @Override
-    @PutMapping("/{retrospectiveId}")
+    @PutMapping
     public ResponseEntity<ApiResponse<PersonalRetrospectiveResponse>> editPersonalRetrospective(
             @PathVariable Long meetingId,
-            @PathVariable Long retrospectiveId,
             @Valid @RequestBody PersonalRetrospectiveRequest request
     ) {
         PersonalRetrospectiveResponse response =
-                personalRetrospectiveService.editPersonalRetrospective(meetingId, retrospectiveId, request);
+                personalRetrospectiveService.editPersonalRetrospective(meetingId, request);
 
         return ApiResponse.success(response, "개인 회고 수정을 성공했습니다.");
     }
 
     @Override
-    @DeleteMapping("/{retrospectiveId}")
+    @DeleteMapping
     public ResponseEntity<ApiResponse<Void>> deletePersonalRetrospective(
-            @PathVariable Long meetingId,
-            @PathVariable Long retrospectiveId
+            @PathVariable Long meetingId
     ) {
-
-        personalRetrospectiveService.deletePersonalRetrospective(meetingId, retrospectiveId);
+        personalRetrospectiveService.deletePersonalRetrospective(meetingId);
 
         return ApiResponse.deleted("개인 회고 삭제를 성공했습니다.");
     }
 
     @Override
-    @GetMapping("/{retrospectiveId}")
+    @GetMapping
     public ResponseEntity<ApiResponse<PersonalRetrospectiveDetailResponse>> getPersonalRetrospective(
-            @PathVariable Long meetingId,
-            @PathVariable Long retrospectiveId
+            @PathVariable Long meetingId
     ) {
         PersonalRetrospectiveDetailResponse response
-                = personalRetrospectiveService.getPersonalRetrospective(meetingId, retrospectiveId);
+                = personalRetrospectiveService.getPersonalRetrospective(meetingId);
 
         return ApiResponse.success(response, "개인 회고 조회를 성공했습니다.");
     }

--- a/src/main/java/com/dokdok/retrospective/repository/PersonalRetrospectiveRepository.java
+++ b/src/main/java/com/dokdok/retrospective/repository/PersonalRetrospectiveRepository.java
@@ -85,6 +85,8 @@ public interface PersonalRetrospectiveRepository extends JpaRepository<PersonalM
 
     boolean existsByIdAndUserId(Long retrospectiveId, Long userId);
 
+    Optional<PersonalMeetingRetrospective> findByMeeting_IdAndUser_Id(Long meetingId, Long userId);
+
     @Query("""
             SELECT pmr
             FROM PersonalMeetingRetrospective pmr

--- a/src/main/java/com/dokdok/retrospective/service/PersonalRetrospectiveService.java
+++ b/src/main/java/com/dokdok/retrospective/service/PersonalRetrospectiveService.java
@@ -100,16 +100,16 @@ public class PersonalRetrospectiveService {
     }
 
     @Transactional(readOnly = true)
-    public PersonalRetrospectiveEditResponse getPersonalRetrospectiveEditForm(
-            Long meetingId,
-            Long retrospectiveId
-    ) {
+    public PersonalRetrospectiveEditResponse getPersonalRetrospectiveEditForm(Long meetingId) {
 
         Long userId = SecurityUtil.getCurrentUserId();
 
         meetingValidator.validateMeeting(meetingId);
         meetingValidator.validateMeetingMember(meetingId, userId);
-        retrospectiveValidator.validateRetrospective(retrospectiveId);
+
+        PersonalMeetingRetrospective retrospective
+                = retrospectiveValidator.getRetrospectiveByMeetingAndUser(meetingId, userId);
+        Long retrospectiveId = retrospective.getId();
 
         List<RetrospectiveChangedThought> changedThoughts
                 = changedThoughtRepository.findByPersonalMeetingRetrospective(retrospectiveId);
@@ -138,16 +138,14 @@ public class PersonalRetrospectiveService {
     @Transactional
     public PersonalRetrospectiveResponse editPersonalRetrospective(
             Long meetingId,
-            Long retrospectiveId,
             PersonalRetrospectiveRequest request
     ) {
         Long userId = SecurityUtil.getCurrentUserId();
 
         meetingValidator.validateMeeting(meetingId);
         meetingValidator.validateMeetingMember(meetingId, userId);
-        retrospectiveValidator.validateRetrospective(retrospectiveId);
         PersonalMeetingRetrospective retrospective
-                = retrospectiveValidator.getRetrospective(retrospectiveId, userId);
+                = retrospectiveValidator.getRetrospectiveByMeetingAndUser(meetingId, userId);
 
         retrospective.clearChangedThoughts();
         retrospective.clearOthersPerspectives();
@@ -230,29 +228,28 @@ public class PersonalRetrospectiveService {
     }
 
     @Transactional
-    public void deletePersonalRetrospective(Long meetingId, Long retrospectiveId) {
+    public void deletePersonalRetrospective(Long meetingId) {
         Long userId = SecurityUtil.getCurrentUserId();
 
         meetingValidator.validateMeeting(meetingId);
         meetingValidator.validateMeetingMember(meetingId, userId);
 
         PersonalMeetingRetrospective retrospective
-                = retrospectiveValidator.getRetrospective(retrospectiveId, userId);
+                = retrospectiveValidator.getRetrospectiveByMeetingAndUser(meetingId, userId);
 
         retrospective.softDelete();
     }
 
     @Transactional(readOnly = true)
-    public PersonalRetrospectiveDetailResponse getPersonalRetrospective(
-            Long meetingId,
-            Long retrospectiveId
-    ) {
+    public PersonalRetrospectiveDetailResponse getPersonalRetrospective(Long meetingId) {
         Long userId = SecurityUtil.getCurrentUserId();
 
         meetingValidator.validateMeeting(meetingId);
         meetingValidator.validateMeetingMember(meetingId, userId);
-        retrospectiveValidator.validateRetrospective(retrospectiveId);
-        retrospectiveValidator.validateRetrospectiveByUser(retrospectiveId, userId);
+
+        PersonalMeetingRetrospective retrospective
+                = retrospectiveValidator.getRetrospectiveByMeetingAndUser(meetingId, userId);
+        Long retrospectiveId = retrospective.getId();
 
         List<RetrospectiveChangedThought> changedThoughts
                 = changedThoughtRepository.findByPersonalMeetingRetrospective(retrospectiveId);

--- a/src/main/java/com/dokdok/retrospective/service/RetrospectiveValidator.java
+++ b/src/main/java/com/dokdok/retrospective/service/RetrospectiveValidator.java
@@ -76,6 +76,11 @@ public class RetrospectiveValidator {
 
     }
 
+    public PersonalMeetingRetrospective getRetrospectiveByMeetingAndUser(Long meetingId, Long userId) {
+        return personalRetrospectiveRepository.findByMeeting_IdAndUser_Id(meetingId, userId)
+                .orElseThrow(() -> new RetrospectiveException(RetrospectiveErrorCode.RETROSPECTIVE_NOT_FOUND));
+    }
+
     public void validateMeetingRetrospectiveDeletePermission(MeetingRetrospective retrospective, Long userId) {
         // 삭제하는 사람이 작성자 본인인지 확인
         if (retrospective.getCreatedBy().getId().equals(userId)) {

--- a/src/test/java/com/dokdok/retrospective/service/PersonalRetrospectiveServiceTest.java
+++ b/src/test/java/com/dokdok/retrospective/service/PersonalRetrospectiveServiceTest.java
@@ -709,6 +709,14 @@ class PersonalRetrospectiveServiceTest {
         Long retrospectiveId = 100L;
         Long userId = 3L;
 
+        Meeting meeting = Meeting.builder().id(meetingId).build();
+        User user = User.builder().id(userId).build();
+        PersonalMeetingRetrospective retrospective = PersonalMeetingRetrospective.builder()
+                .id(retrospectiveId)
+                .meeting(meeting)
+                .user(user)
+                .build();
+
         List<RetrospectiveChangedThought> changedThoughts = List.of();
         List<RetrospectiveOthersPerspective> othersPerspectives = List.of();
         List<RetrospectiveFreeText> freeTexts = List.of();
@@ -727,7 +735,7 @@ class PersonalRetrospectiveServiceTest {
 
             doNothing().when(meetingValidator).validateMeeting(meetingId);
             doNothing().when(meetingValidator).validateMeetingMember(meetingId, userId);
-            doNothing().when(retrospectiveValidator).validateRetrospective(retrospectiveId);
+            when(retrospectiveValidator.getRetrospectiveByMeetingAndUser(meetingId, userId)).thenReturn(retrospective);
             when(changedThoughtRepository.findByPersonalMeetingRetrospective(retrospectiveId))
                     .thenReturn(changedThoughts);
             when(othersPerspectiveRepository.findByPersonalMeetingRetrospective(retrospectiveId))
@@ -743,7 +751,7 @@ class PersonalRetrospectiveServiceTest {
 
             // when
             PersonalRetrospectiveEditResponse response =
-                    personalRetrospectiveService.getPersonalRetrospectiveEditForm(meetingId, retrospectiveId);
+                    personalRetrospectiveService.getPersonalRetrospectiveEditForm(meetingId);
 
             // then
             assertThat(response.retrospectiveId()).isEqualTo(retrospectiveId);
@@ -753,7 +761,7 @@ class PersonalRetrospectiveServiceTest {
 
             verify(meetingValidator).validateMeeting(meetingId);
             verify(meetingValidator).validateMeetingMember(meetingId, userId);
-            verify(retrospectiveValidator).validateRetrospective(retrospectiveId);
+            verify(retrospectiveValidator).getRetrospectiveByMeetingAndUser(meetingId, userId);
             verify(changedThoughtRepository).findByPersonalMeetingRetrospective(retrospectiveId);
             verify(othersPerspectiveRepository).findByPersonalMeetingRetrospective(retrospectiveId);
             verify(freeTextRepository).findByPersonalMeetingRetrospective_Id(retrospectiveId);
@@ -770,6 +778,14 @@ class PersonalRetrospectiveServiceTest {
         Long meetingId = 1L;
         Long retrospectiveId = 100L;
         Long userId = 3L;
+
+        Meeting meeting = Meeting.builder().id(meetingId).build();
+        User user = User.builder().id(userId).build();
+        PersonalMeetingRetrospective retrospective = PersonalMeetingRetrospective.builder()
+                .id(retrospectiveId)
+                .meeting(meeting)
+                .user(user)
+                .build();
 
         List<RetrospectiveChangedThought> changedThoughts = List.of();
         List<RetrospectiveOthersPerspective> othersPerspectives = List.of();
@@ -791,7 +807,7 @@ class PersonalRetrospectiveServiceTest {
 
             doNothing().when(meetingValidator).validateMeeting(meetingId);
             doNothing().when(meetingValidator).validateMeetingMember(meetingId, userId);
-            doNothing().when(retrospectiveValidator).validateRetrospective(retrospectiveId);
+            when(retrospectiveValidator.getRetrospectiveByMeetingAndUser(meetingId, userId)).thenReturn(retrospective);
             when(changedThoughtRepository.findByPersonalMeetingRetrospective(retrospectiveId))
                     .thenReturn(changedThoughts);
             when(othersPerspectiveRepository.findByPersonalMeetingRetrospective(retrospectiveId))
@@ -805,7 +821,7 @@ class PersonalRetrospectiveServiceTest {
 
             // when
             PersonalRetrospectiveEditResponse response =
-                    personalRetrospectiveService.getPersonalRetrospectiveEditForm(meetingId, retrospectiveId);
+                    personalRetrospectiveService.getPersonalRetrospectiveEditForm(meetingId);
 
             // then
             assertThat(response.retrospective().changedThoughts()).isEmpty();
@@ -819,7 +835,6 @@ class PersonalRetrospectiveServiceTest {
     void getPersonalRetrospectiveEditForm_throwsWhenMeetingNotFound() {
         // given
         Long meetingId = 999L;
-        Long retrospectiveId = 100L;
         Long userId = 3L;
 
         try (MockedStatic<SecurityUtil> securityUtilMock = mockStatic(SecurityUtil.class)) {
@@ -830,7 +845,7 @@ class PersonalRetrospectiveServiceTest {
 
             // when & then
             assertThatThrownBy(() ->
-                    personalRetrospectiveService.getPersonalRetrospectiveEditForm(meetingId, retrospectiveId))
+                    personalRetrospectiveService.getPersonalRetrospectiveEditForm(meetingId))
                     .isInstanceOf(MeetingException.class)
                     .hasFieldOrPropertyWithValue("errorCode", MeetingErrorCode.MEETING_NOT_FOUND);
 
@@ -843,7 +858,6 @@ class PersonalRetrospectiveServiceTest {
     void getPersonalRetrospectiveEditForm_throwsWhenNotMeetingMember() {
         // given
         Long meetingId = 1L;
-        Long retrospectiveId = 100L;
         Long userId = 999L;
 
         try (MockedStatic<SecurityUtil> securityUtilMock = mockStatic(SecurityUtil.class)) {
@@ -855,7 +869,7 @@ class PersonalRetrospectiveServiceTest {
 
             // when & then
             assertThatThrownBy(() ->
-                    personalRetrospectiveService.getPersonalRetrospectiveEditForm(meetingId, retrospectiveId))
+                    personalRetrospectiveService.getPersonalRetrospectiveEditForm(meetingId))
                     .isInstanceOf(MeetingException.class)
                     .hasFieldOrPropertyWithValue("errorCode", MeetingErrorCode.NOT_MEETING_MEMBER);
 
@@ -868,7 +882,6 @@ class PersonalRetrospectiveServiceTest {
     void getPersonalRetrospectiveEditForm_throwsWhenRetrospectiveNotFound() {
         // given
         Long meetingId = 1L;
-        Long retrospectiveId = 999L;
         Long userId = 3L;
 
         try (MockedStatic<SecurityUtil> securityUtilMock = mockStatic(SecurityUtil.class)) {
@@ -876,12 +889,12 @@ class PersonalRetrospectiveServiceTest {
 
             doNothing().when(meetingValidator).validateMeeting(meetingId);
             doNothing().when(meetingValidator).validateMeetingMember(meetingId, userId);
-            doThrow(new RetrospectiveException(RetrospectiveErrorCode.RETROSPECTIVE_NOT_FOUND))
-                    .when(retrospectiveValidator).validateRetrospective(retrospectiveId);
+            when(retrospectiveValidator.getRetrospectiveByMeetingAndUser(meetingId, userId))
+                    .thenThrow(new RetrospectiveException(RetrospectiveErrorCode.RETROSPECTIVE_NOT_FOUND));
 
             // when & then
             assertThatThrownBy(() ->
-                    personalRetrospectiveService.getPersonalRetrospectiveEditForm(meetingId, retrospectiveId))
+                    personalRetrospectiveService.getPersonalRetrospectiveEditForm(meetingId))
                     .isInstanceOf(RetrospectiveException.class)
                     .hasFieldOrPropertyWithValue("errorCode", RetrospectiveErrorCode.RETROSPECTIVE_NOT_FOUND);
 
@@ -894,7 +907,6 @@ class PersonalRetrospectiveServiceTest {
     void getPersonalRetrospectiveEditForm_throwsWhenUnauthenticated() {
         // given
         Long meetingId = 1L;
-        Long retrospectiveId = 100L;
 
         try (MockedStatic<SecurityUtil> securityUtilMock = mockStatic(SecurityUtil.class)) {
             securityUtilMock.when(SecurityUtil::getCurrentUserId)
@@ -902,7 +914,7 @@ class PersonalRetrospectiveServiceTest {
 
             // when & then
             assertThatThrownBy(() ->
-                    personalRetrospectiveService.getPersonalRetrospectiveEditForm(meetingId, retrospectiveId))
+                    personalRetrospectiveService.getPersonalRetrospectiveEditForm(meetingId))
                     .isInstanceOf(GlobalException.class)
                     .hasFieldOrPropertyWithValue("errorCode", GlobalErrorCode.UNAUTHORIZED);
 
@@ -971,7 +983,7 @@ class PersonalRetrospectiveServiceTest {
 
             doNothing().when(meetingValidator).validateMeeting(meetingId);
             doNothing().when(meetingValidator).validateMeetingMember(meetingId, userId);
-            when(retrospectiveValidator.getRetrospective(retrospectiveId, userId)).thenReturn(existingRetrospective);
+            when(retrospectiveValidator.getRetrospectiveByMeetingAndUser(meetingId, userId)).thenReturn(existingRetrospective);
             when(topicValidator.getTopicInMeeting(topicId, meetingId)).thenReturn(topic);
             when(topicAnswerRepository.findPreOpinion(topicId, userId)).thenReturn(topicAnswer);
             when(topicRepository.findById(topicId)).thenReturn(Optional.of(topic));
@@ -980,7 +992,7 @@ class PersonalRetrospectiveServiceTest {
 
             // when
             PersonalRetrospectiveResponse response =
-                    personalRetrospectiveService.editPersonalRetrospective(meetingId, retrospectiveId, request);
+                    personalRetrospectiveService.editPersonalRetrospective(meetingId, request);
 
             // then
             assertThat(response.personalMeetingRetrospectiveId()).isEqualTo(retrospectiveId);
@@ -989,7 +1001,7 @@ class PersonalRetrospectiveServiceTest {
 
             verify(meetingValidator).validateMeeting(meetingId);
             verify(meetingValidator).validateMeetingMember(meetingId, userId);
-            verify(retrospectiveValidator).getRetrospective(retrospectiveId, userId);
+            verify(retrospectiveValidator).getRetrospectiveByMeetingAndUser(meetingId, userId);
             verify(topicValidator).getTopicInMeeting(topicId, meetingId);
             verify(topicAnswerRepository).findPreOpinion(topicId, userId);
             verify(topicRepository).findById(topicId);
@@ -1032,12 +1044,12 @@ class PersonalRetrospectiveServiceTest {
 
             doNothing().when(meetingValidator).validateMeeting(meetingId);
             doNothing().when(meetingValidator).validateMeetingMember(meetingId, userId);
-            when(retrospectiveValidator.getRetrospective(retrospectiveId, userId)).thenReturn(existingRetrospective);
+            when(retrospectiveValidator.getRetrospectiveByMeetingAndUser(meetingId, userId)).thenReturn(existingRetrospective);
             when(personalRetrospectiveRepository.save(any(PersonalMeetingRetrospective.class))).thenReturn(saved);
 
             // when
             PersonalRetrospectiveResponse response =
-                    personalRetrospectiveService.editPersonalRetrospective(meetingId, retrospectiveId, request);
+                    personalRetrospectiveService.editPersonalRetrospective(meetingId, request);
 
             // then
             assertThat(response.personalMeetingRetrospectiveId()).isEqualTo(retrospectiveId);
@@ -1100,7 +1112,7 @@ class PersonalRetrospectiveServiceTest {
 
             doNothing().when(meetingValidator).validateMeeting(meetingId);
             doNothing().when(meetingValidator).validateMeetingMember(meetingId, userId);
-            when(retrospectiveValidator.getRetrospective(retrospectiveId, userId)).thenReturn(existingRetrospective);
+            when(retrospectiveValidator.getRetrospectiveByMeetingAndUser(meetingId, userId)).thenReturn(existingRetrospective);
             when(topicValidator.getTopicInMeeting(10L, meetingId)).thenReturn(topic1);
             when(topicValidator.getTopicInMeeting(20L, meetingId)).thenReturn(topic2);
             when(topicAnswerRepository.findPreOpinion(anyLong(), eq(userId))).thenReturn(null);
@@ -1112,7 +1124,7 @@ class PersonalRetrospectiveServiceTest {
 
             // when
             PersonalRetrospectiveResponse response =
-                    personalRetrospectiveService.editPersonalRetrospective(meetingId, retrospectiveId, request);
+                    personalRetrospectiveService.editPersonalRetrospective(meetingId, request);
 
             // then
             assertThat(response.personalMeetingRetrospectiveId()).isEqualTo(retrospectiveId);
@@ -1131,7 +1143,6 @@ class PersonalRetrospectiveServiceTest {
     void editPersonalRetrospective_throwsWhenMeetingNotFound() {
         // given
         Long meetingId = 999L;
-        Long retrospectiveId = 100L;
         Long userId = 3L;
         PersonalRetrospectiveRequest request = new PersonalRetrospectiveRequest(null, null, null);
 
@@ -1143,7 +1154,7 @@ class PersonalRetrospectiveServiceTest {
 
             // when & then
             assertThatThrownBy(() ->
-                    personalRetrospectiveService.editPersonalRetrospective(meetingId, retrospectiveId, request))
+                    personalRetrospectiveService.editPersonalRetrospective(meetingId, request))
                     .isInstanceOf(MeetingException.class)
                     .hasFieldOrPropertyWithValue("errorCode", MeetingErrorCode.MEETING_NOT_FOUND);
 
@@ -1156,7 +1167,6 @@ class PersonalRetrospectiveServiceTest {
     void editPersonalRetrospective_throwsWhenNotMeetingMember() {
         // given
         Long meetingId = 1L;
-        Long retrospectiveId = 100L;
         Long userId = 999L;
         PersonalRetrospectiveRequest request = new PersonalRetrospectiveRequest(null, null, null);
 
@@ -1169,7 +1179,7 @@ class PersonalRetrospectiveServiceTest {
 
             // when & then
             assertThatThrownBy(() ->
-                    personalRetrospectiveService.editPersonalRetrospective(meetingId, retrospectiveId, request))
+                    personalRetrospectiveService.editPersonalRetrospective(meetingId, request))
                     .isInstanceOf(MeetingException.class)
                     .hasFieldOrPropertyWithValue("errorCode", MeetingErrorCode.NOT_MEETING_MEMBER);
 
@@ -1182,7 +1192,6 @@ class PersonalRetrospectiveServiceTest {
     void editPersonalRetrospective_throwsWhenRetrospectiveNotFound() {
         // given
         Long meetingId = 1L;
-        Long retrospectiveId = 999L;
         Long userId = 3L;
         PersonalRetrospectiveRequest request = new PersonalRetrospectiveRequest(null, null, null);
 
@@ -1191,12 +1200,12 @@ class PersonalRetrospectiveServiceTest {
 
             doNothing().when(meetingValidator).validateMeeting(meetingId);
             doNothing().when(meetingValidator).validateMeetingMember(meetingId, userId);
-            when(retrospectiveValidator.getRetrospective(retrospectiveId, userId))
+            when(retrospectiveValidator.getRetrospectiveByMeetingAndUser(meetingId, userId))
                     .thenThrow(new RetrospectiveException(RetrospectiveErrorCode.RETROSPECTIVE_NOT_FOUND));
 
             // when & then
             assertThatThrownBy(() ->
-                    personalRetrospectiveService.editPersonalRetrospective(meetingId, retrospectiveId, request))
+                    personalRetrospectiveService.editPersonalRetrospective(meetingId, request))
                     .isInstanceOf(RetrospectiveException.class)
                     .hasFieldOrPropertyWithValue("errorCode", RetrospectiveErrorCode.RETROSPECTIVE_NOT_FOUND);
 
@@ -1209,7 +1218,6 @@ class PersonalRetrospectiveServiceTest {
     void editPersonalRetrospective_throwsWhenUnauthenticated() {
         // given
         Long meetingId = 1L;
-        Long retrospectiveId = 100L;
         PersonalRetrospectiveRequest request = new PersonalRetrospectiveRequest(null, null, null);
 
         try (MockedStatic<SecurityUtil> securityUtilMock = mockStatic(SecurityUtil.class)) {
@@ -1218,7 +1226,7 @@ class PersonalRetrospectiveServiceTest {
 
             // when & then
             assertThatThrownBy(() ->
-                    personalRetrospectiveService.editPersonalRetrospective(meetingId, retrospectiveId, request))
+                    personalRetrospectiveService.editPersonalRetrospective(meetingId, request))
                     .isInstanceOf(GlobalException.class)
                     .hasFieldOrPropertyWithValue("errorCode", GlobalErrorCode.UNAUTHORIZED);
 
@@ -1260,13 +1268,13 @@ class PersonalRetrospectiveServiceTest {
 
             doNothing().when(meetingValidator).validateMeeting(meetingId);
             doNothing().when(meetingValidator).validateMeetingMember(meetingId, userId);
-            when(retrospectiveValidator.getRetrospective(retrospectiveId, userId)).thenReturn(existingRetrospective);
+            when(retrospectiveValidator.getRetrospectiveByMeetingAndUser(meetingId, userId)).thenReturn(existingRetrospective);
             when(topicValidator.getTopicInMeeting(topicId, meetingId))
                     .thenThrow(new TopicException(TopicErrorCode.TOPIC_NOT_FOUND));
 
             // when & then
             assertThatThrownBy(() ->
-                    personalRetrospectiveService.editPersonalRetrospective(meetingId, retrospectiveId, request))
+                    personalRetrospectiveService.editPersonalRetrospective(meetingId, request))
                     .isInstanceOf(TopicException.class)
                     .hasFieldOrPropertyWithValue("errorCode", TopicErrorCode.TOPIC_NOT_FOUND);
 
@@ -1443,15 +1451,15 @@ class PersonalRetrospectiveServiceTest {
 
             doNothing().when(meetingValidator).validateMeeting(meetingId);
             doNothing().when(meetingValidator).validateMeetingMember(meetingId, userId);
-            when(retrospectiveValidator.getRetrospective(retrospectiveId, userId)).thenReturn(retrospective);
+            when(retrospectiveValidator.getRetrospectiveByMeetingAndUser(meetingId, userId)).thenReturn(retrospective);
 
             // when
-            personalRetrospectiveService.deletePersonalRetrospective(meetingId, retrospectiveId);
+            personalRetrospectiveService.deletePersonalRetrospective(meetingId);
 
             // then
             verify(meetingValidator).validateMeeting(meetingId);
             verify(meetingValidator).validateMeetingMember(meetingId, userId);
-            verify(retrospectiveValidator).getRetrospective(retrospectiveId, userId);
+            verify(retrospectiveValidator).getRetrospectiveByMeetingAndUser(meetingId, userId);
         }
     }
 
@@ -1460,7 +1468,6 @@ class PersonalRetrospectiveServiceTest {
     void deletePersonalRetrospective_throwsWhenMeetingNotFound() {
         // given
         Long meetingId = 999L;
-        Long retrospectiveId = 100L;
         Long userId = 3L;
 
         try (MockedStatic<SecurityUtil> securityUtilMock = mockStatic(SecurityUtil.class)) {
@@ -1471,11 +1478,11 @@ class PersonalRetrospectiveServiceTest {
 
             // when & then
             assertThatThrownBy(() ->
-                    personalRetrospectiveService.deletePersonalRetrospective(meetingId, retrospectiveId))
+                    personalRetrospectiveService.deletePersonalRetrospective(meetingId))
                     .isInstanceOf(MeetingException.class)
                     .hasFieldOrPropertyWithValue("errorCode", MeetingErrorCode.MEETING_NOT_FOUND);
 
-            verify(retrospectiveValidator, never()).getRetrospective(any(), any());
+            verify(retrospectiveValidator, never()).getRetrospectiveByMeetingAndUser(any(), any());
         }
     }
 
@@ -1484,7 +1491,6 @@ class PersonalRetrospectiveServiceTest {
     void deletePersonalRetrospective_throwsWhenNotMeetingMember() {
         // given
         Long meetingId = 1L;
-        Long retrospectiveId = 100L;
         Long userId = 999L;
 
         try (MockedStatic<SecurityUtil> securityUtilMock = mockStatic(SecurityUtil.class)) {
@@ -1496,11 +1502,11 @@ class PersonalRetrospectiveServiceTest {
 
             // when & then
             assertThatThrownBy(() ->
-                    personalRetrospectiveService.deletePersonalRetrospective(meetingId, retrospectiveId))
+                    personalRetrospectiveService.deletePersonalRetrospective(meetingId))
                     .isInstanceOf(MeetingException.class)
                     .hasFieldOrPropertyWithValue("errorCode", MeetingErrorCode.NOT_MEETING_MEMBER);
 
-            verify(retrospectiveValidator, never()).getRetrospective(any(), any());
+            verify(retrospectiveValidator, never()).getRetrospectiveByMeetingAndUser(any(), any());
         }
     }
 
@@ -1509,7 +1515,6 @@ class PersonalRetrospectiveServiceTest {
     void deletePersonalRetrospective_throwsWhenRetrospectiveNotFound() {
         // given
         Long meetingId = 1L;
-        Long retrospectiveId = 999L;
         Long userId = 3L;
 
         try (MockedStatic<SecurityUtil> securityUtilMock = mockStatic(SecurityUtil.class)) {
@@ -1517,12 +1522,12 @@ class PersonalRetrospectiveServiceTest {
 
             doNothing().when(meetingValidator).validateMeeting(meetingId);
             doNothing().when(meetingValidator).validateMeetingMember(meetingId, userId);
-            when(retrospectiveValidator.getRetrospective(retrospectiveId, userId))
+            when(retrospectiveValidator.getRetrospectiveByMeetingAndUser(meetingId, userId))
                     .thenThrow(new RetrospectiveException(RetrospectiveErrorCode.RETROSPECTIVE_NOT_FOUND));
 
             // when & then
             assertThatThrownBy(() ->
-                    personalRetrospectiveService.deletePersonalRetrospective(meetingId, retrospectiveId))
+                    personalRetrospectiveService.deletePersonalRetrospective(meetingId))
                     .isInstanceOf(RetrospectiveException.class)
                     .hasFieldOrPropertyWithValue("errorCode", RetrospectiveErrorCode.RETROSPECTIVE_NOT_FOUND);
         }
@@ -1533,7 +1538,6 @@ class PersonalRetrospectiveServiceTest {
     void deletePersonalRetrospective_throwsWhenUnauthenticated() {
         // given
         Long meetingId = 1L;
-        Long retrospectiveId = 100L;
 
         try (MockedStatic<SecurityUtil> securityUtilMock = mockStatic(SecurityUtil.class)) {
             securityUtilMock.when(SecurityUtil::getCurrentUserId)
@@ -1541,7 +1545,7 @@ class PersonalRetrospectiveServiceTest {
 
             // when & then
             assertThatThrownBy(() ->
-                    personalRetrospectiveService.deletePersonalRetrospective(meetingId, retrospectiveId))
+                    personalRetrospectiveService.deletePersonalRetrospective(meetingId))
                     .isInstanceOf(GlobalException.class)
                     .hasFieldOrPropertyWithValue("errorCode", GlobalErrorCode.UNAUTHORIZED);
 
@@ -1596,13 +1600,20 @@ class PersonalRetrospectiveServiceTest {
                 List.of(new PersonalRetrospectiveDetailResponse.FreeText("자유 서술 제목", "자유 서술 내용"))
         );
 
+        Meeting meeting = Meeting.builder().id(meetingId).build();
+        User user = User.builder().id(userId).build();
+        PersonalMeetingRetrospective retrospective = PersonalMeetingRetrospective.builder()
+                .id(retrospectiveId)
+                .meeting(meeting)
+                .user(user)
+                .build();
+
         try (MockedStatic<SecurityUtil> securityUtilMock = mockStatic(SecurityUtil.class)) {
             securityUtilMock.when(SecurityUtil::getCurrentUserId).thenReturn(userId);
 
             doNothing().when(meetingValidator).validateMeeting(meetingId);
             doNothing().when(meetingValidator).validateMeetingMember(meetingId, userId);
-            doNothing().when(retrospectiveValidator).validateRetrospective(retrospectiveId);
-            doNothing().when(retrospectiveValidator).validateRetrospectiveByUser(retrospectiveId, userId);
+            when(retrospectiveValidator.getRetrospectiveByMeetingAndUser(meetingId, userId)).thenReturn(retrospective);
             when(changedThoughtRepository.findByPersonalMeetingRetrospective(retrospectiveId))
                     .thenReturn(changedThoughts);
             when(othersPerspectiveRepository.findByPersonalMeetingRetrospective(retrospectiveId))
@@ -1614,7 +1625,7 @@ class PersonalRetrospectiveServiceTest {
 
             // when
             PersonalRetrospectiveDetailResponse response =
-                    personalRetrospectiveService.getPersonalRetrospective(meetingId, retrospectiveId);
+                    personalRetrospectiveService.getPersonalRetrospective(meetingId);
 
             // then
             assertThat(response.retrospectiveId()).isEqualTo(retrospectiveId);
@@ -1624,8 +1635,7 @@ class PersonalRetrospectiveServiceTest {
 
             verify(meetingValidator).validateMeeting(meetingId);
             verify(meetingValidator).validateMeetingMember(meetingId, userId);
-            verify(retrospectiveValidator).validateRetrospective(retrospectiveId);
-            verify(retrospectiveValidator).validateRetrospectiveByUser(retrospectiveId, userId);
+            verify(retrospectiveValidator).getRetrospectiveByMeetingAndUser(meetingId, userId);
             verify(changedThoughtRepository).findByPersonalMeetingRetrospective(retrospectiveId);
             verify(othersPerspectiveRepository).findByPersonalMeetingRetrospective(retrospectiveId);
             verify(freeTextRepository).findByPersonalMeetingRetrospective_Id(retrospectiveId);
@@ -1652,13 +1662,20 @@ class PersonalRetrospectiveServiceTest {
                 List.of()
         );
 
+        Meeting meeting = Meeting.builder().id(meetingId).build();
+        User user = User.builder().id(userId).build();
+        PersonalMeetingRetrospective retrospective = PersonalMeetingRetrospective.builder()
+                .id(retrospectiveId)
+                .meeting(meeting)
+                .user(user)
+                .build();
+
         try (MockedStatic<SecurityUtil> securityUtilMock = mockStatic(SecurityUtil.class)) {
             securityUtilMock.when(SecurityUtil::getCurrentUserId).thenReturn(userId);
 
             doNothing().when(meetingValidator).validateMeeting(meetingId);
             doNothing().when(meetingValidator).validateMeetingMember(meetingId, userId);
-            doNothing().when(retrospectiveValidator).validateRetrospective(retrospectiveId);
-            doNothing().when(retrospectiveValidator).validateRetrospectiveByUser(retrospectiveId, userId);
+            when(retrospectiveValidator.getRetrospectiveByMeetingAndUser(meetingId, userId)).thenReturn(retrospective);
             when(changedThoughtRepository.findByPersonalMeetingRetrospective(retrospectiveId))
                     .thenReturn(changedThoughts);
             when(othersPerspectiveRepository.findByPersonalMeetingRetrospective(retrospectiveId))
@@ -1670,7 +1687,7 @@ class PersonalRetrospectiveServiceTest {
 
             // when
             PersonalRetrospectiveDetailResponse response =
-                    personalRetrospectiveService.getPersonalRetrospective(meetingId, retrospectiveId);
+                    personalRetrospectiveService.getPersonalRetrospective(meetingId);
 
             // then
             assertThat(response.retrospective().changedThoughts()).isEmpty();
@@ -1684,7 +1701,6 @@ class PersonalRetrospectiveServiceTest {
     void getPersonalRetrospective_throwsWhenMeetingNotFound() {
         // given
         Long meetingId = 999L;
-        Long retrospectiveId = 100L;
         Long userId = 3L;
 
         try (MockedStatic<SecurityUtil> securityUtilMock = mockStatic(SecurityUtil.class)) {
@@ -1695,7 +1711,7 @@ class PersonalRetrospectiveServiceTest {
 
             // when & then
             assertThatThrownBy(() ->
-                    personalRetrospectiveService.getPersonalRetrospective(meetingId, retrospectiveId))
+                    personalRetrospectiveService.getPersonalRetrospective(meetingId))
                     .isInstanceOf(MeetingException.class)
                     .hasFieldOrPropertyWithValue("errorCode", MeetingErrorCode.MEETING_NOT_FOUND);
 
@@ -1708,7 +1724,6 @@ class PersonalRetrospectiveServiceTest {
     void getPersonalRetrospective_throwsWhenNotMeetingMember() {
         // given
         Long meetingId = 1L;
-        Long retrospectiveId = 100L;
         Long userId = 999L;
 
         try (MockedStatic<SecurityUtil> securityUtilMock = mockStatic(SecurityUtil.class)) {
@@ -1720,7 +1735,7 @@ class PersonalRetrospectiveServiceTest {
 
             // when & then
             assertThatThrownBy(() ->
-                    personalRetrospectiveService.getPersonalRetrospective(meetingId, retrospectiveId))
+                    personalRetrospectiveService.getPersonalRetrospective(meetingId))
                     .isInstanceOf(MeetingException.class)
                     .hasFieldOrPropertyWithValue("errorCode", MeetingErrorCode.NOT_MEETING_MEMBER);
 
@@ -1733,7 +1748,6 @@ class PersonalRetrospectiveServiceTest {
     void getPersonalRetrospective_throwsWhenRetrospectiveNotFound() {
         // given
         Long meetingId = 1L;
-        Long retrospectiveId = 999L;
         Long userId = 3L;
 
         try (MockedStatic<SecurityUtil> securityUtilMock = mockStatic(SecurityUtil.class)) {
@@ -1741,12 +1755,12 @@ class PersonalRetrospectiveServiceTest {
 
             doNothing().when(meetingValidator).validateMeeting(meetingId);
             doNothing().when(meetingValidator).validateMeetingMember(meetingId, userId);
-            doThrow(new RetrospectiveException(RetrospectiveErrorCode.RETROSPECTIVE_NOT_FOUND))
-                    .when(retrospectiveValidator).validateRetrospective(retrospectiveId);
+            when(retrospectiveValidator.getRetrospectiveByMeetingAndUser(meetingId, userId))
+                    .thenThrow(new RetrospectiveException(RetrospectiveErrorCode.RETROSPECTIVE_NOT_FOUND));
 
             // when & then
             assertThatThrownBy(() ->
-                    personalRetrospectiveService.getPersonalRetrospective(meetingId, retrospectiveId))
+                    personalRetrospectiveService.getPersonalRetrospective(meetingId))
                     .isInstanceOf(RetrospectiveException.class)
                     .hasFieldOrPropertyWithValue("errorCode", RetrospectiveErrorCode.RETROSPECTIVE_NOT_FOUND);
 
@@ -1759,7 +1773,6 @@ class PersonalRetrospectiveServiceTest {
     void getPersonalRetrospective_throwsWhenUnauthenticated() {
         // given
         Long meetingId = 1L;
-        Long retrospectiveId = 100L;
 
         try (MockedStatic<SecurityUtil> securityUtilMock = mockStatic(SecurityUtil.class)) {
             securityUtilMock.when(SecurityUtil::getCurrentUserId)
@@ -1767,7 +1780,7 @@ class PersonalRetrospectiveServiceTest {
 
             // when & then
             assertThatThrownBy(() ->
-                    personalRetrospectiveService.getPersonalRetrospective(meetingId, retrospectiveId))
+                    personalRetrospectiveService.getPersonalRetrospective(meetingId))
                     .isInstanceOf(GlobalException.class)
                     .hasFieldOrPropertyWithValue("errorCode", GlobalErrorCode.UNAUTHORIZED);
 
@@ -1819,13 +1832,20 @@ class PersonalRetrospectiveServiceTest {
                 List.of()
         );
 
+        Meeting meeting = Meeting.builder().id(meetingId).build();
+        User user = User.builder().id(userId).build();
+        PersonalMeetingRetrospective retrospective = PersonalMeetingRetrospective.builder()
+                .id(retrospectiveId)
+                .meeting(meeting)
+                .user(user)
+                .build();
+
         try (MockedStatic<SecurityUtil> securityUtilMock = mockStatic(SecurityUtil.class)) {
             securityUtilMock.when(SecurityUtil::getCurrentUserId).thenReturn(userId);
 
             doNothing().when(meetingValidator).validateMeeting(meetingId);
             doNothing().when(meetingValidator).validateMeetingMember(meetingId, userId);
-            doNothing().when(retrospectiveValidator).validateRetrospective(retrospectiveId);
-            doNothing().when(retrospectiveValidator).validateRetrospectiveByUser(retrospectiveId, userId);
+            when(retrospectiveValidator.getRetrospectiveByMeetingAndUser(meetingId, userId)).thenReturn(retrospective);
             when(changedThoughtRepository.findByPersonalMeetingRetrospective(retrospectiveId))
                     .thenReturn(changedThoughts);
             when(othersPerspectiveRepository.findByPersonalMeetingRetrospective(retrospectiveId))
@@ -1837,7 +1857,7 @@ class PersonalRetrospectiveServiceTest {
 
             // when
             PersonalRetrospectiveDetailResponse response =
-                    personalRetrospectiveService.getPersonalRetrospective(meetingId, retrospectiveId);
+                    personalRetrospectiveService.getPersonalRetrospective(meetingId);
 
             // then
             assertThat(response.retrospective().othersPerspectives()).hasSize(2);


### PR DESCRIPTION
## PR 요약
> 이 PR이 어떤 변경을 하는지 간단히 설명하고, 체크 표시는 괄호 사이에 소문자 'x'를 삽입하세요.

- [ ] 기능 추가
- [x] 버그 수정
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 기타 (설명)

---

## 이슈 번호
- #330

---

## 주요 변경 사항
> 주요 파일, 로직, 컴포넌트 등을 구체적으로 적어주세요.

- `src/main/java/com/dokdok/retrospective`: +45/-54 (5 files) — 요구사항 반영
- `src/test/java/com/dokdok/retrospective`: +88/-68 (1 files) — 요구사항 반영

---

## 참고 사항
> 리뷰어가 알아야 할 추가 정보, 테스트 방법 등을 작성해주세요.

예:
- 테스트 계정 정보
- 관련 API 엔드포인트
- 로컬 테스트 방법

---
