### PR TITLE
[#339][REFACTOR] 메인페이지 약속 리스트 응답 값 변경

### DIFF
--- a/src/main/java/com/dokdok/meeting/api/MyMeetingListApi.java
+++ b/src/main/java/com/dokdok/meeting/api/MyMeetingListApi.java
@@ -62,7 +62,8 @@ public interface MyMeetingListApi {
                                             "endDateTime": "2025-02-01T16:00:00",
                                             "meetingStatus": "CONFIRMED",
                                             "myRole": "LEADER",
-                                            "progressStatus": "UPCOMING"
+                                            "progressStatus": "UPCOMING",
+                                            "preOpinionTemplateConfirmed": true
                                           }
                                         ],
                                         "totalCount": 8,

--- a/src/main/java/com/dokdok/meeting/dto/MyMeetingListItemResponse.java
+++ b/src/main/java/com/dokdok/meeting/dto/MyMeetingListItemResponse.java
@@ -38,6 +38,9 @@ public record MyMeetingListItemResponse(
         MeetingMyRole myRole,
 
         @Schema(description = "약속 진행 상태(시간 기준)", example = "UPCOMING")
-        MeetingProgressStatus progressStatus
+        MeetingProgressStatus progressStatus,
+
+        @Schema(description = "사전 의견 템플릿 확정 여부", example = "true")
+        boolean preOpinionTemplateConfirmed
 ) {
 }

--- a/src/main/java/com/dokdok/meeting/repository/MeetingMemberRepository.java
+++ b/src/main/java/com/dokdok/meeting/repository/MeetingMemberRepository.java
@@ -3,6 +3,7 @@ package com.dokdok.meeting.repository;
 import com.dokdok.meeting.entity.MeetingMember;
 import com.dokdok.meeting.entity.MeetingStatus;
 import com.dokdok.meeting.entity.Meeting;
+import com.dokdok.retrospective.entity.PersonalMeetingRetrospective;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -111,6 +112,23 @@ public interface MeetingMemberRepository extends JpaRepository<MeetingMember, Lo
             WHERE mm.user.id = :userId
             AND mm.canceledAt IS NULL
             AND m.meetingStatus = :meetingStatus
+            AND NOT EXISTS (
+                SELECT 1 FROM PersonalMeetingRetrospective pmr
+                WHERE pmr.meeting = m
+                AND pmr.user.id = :userId
+            )
+            """)
+    int countMyMeetingsByStatusWithoutPersonalRetrospective(
+            @Param("userId") Long userId,
+            @Param("meetingStatus") MeetingStatus meetingStatus
+    );
+
+    @Query("""
+            SELECT count(mm) FROM MeetingMember mm
+            JOIN mm.meeting m
+            WHERE mm.user.id = :userId
+            AND mm.canceledAt IS NULL
+            AND m.meetingStatus = :meetingStatus
             AND m.meetingStartDate BETWEEN :startDate AND :endDate
             """)
     int countMyUpcomingMeetings(
@@ -209,6 +227,34 @@ public interface MeetingMemberRepository extends JpaRepository<MeetingMember, Lo
                     """
     )
     List<Meeting> findMyMeetingsByStatusAfterCursor(
+            @Param("userId") Long userId,
+            @Param("meetingStatus") MeetingStatus meetingStatus,
+            @Param("cursorStartDateTime") LocalDateTime cursorStartDateTime,
+            @Param("cursorMeetingId") Long cursorMeetingId,
+            Pageable pageable
+    );
+
+    @Query(
+            value = """
+                    SELECT m FROM MeetingMember mm
+                    JOIN mm.meeting m
+                    JOIN FETCH m.book
+                    JOIN FETCH m.gathering
+                    WHERE mm.user.id = :userId
+                    AND mm.canceledAt IS NULL
+                    AND m.meetingStatus = :meetingStatus
+                    AND NOT EXISTS (
+                        SELECT 1 FROM PersonalMeetingRetrospective pmr
+                        WHERE pmr.meeting = m
+                        AND pmr.user.id = :userId
+                    )
+                    AND (CAST(:cursorStartDateTime AS timestamp) IS NULL
+                        OR m.meetingStartDate > :cursorStartDateTime
+                        OR (m.meetingStartDate = :cursorStartDateTime AND m.id > :cursorMeetingId))
+                    ORDER BY m.meetingStartDate ASC, m.id ASC
+                    """
+    )
+    List<Meeting> findMyDoneMeetingsWithoutPersonalRetrospectiveAfterCursor(
             @Param("userId") Long userId,
             @Param("meetingStatus") MeetingStatus meetingStatus,
             @Param("cursorStartDateTime") LocalDateTime cursorStartDateTime,

--- a/src/main/java/com/dokdok/meeting/service/MeetingService.java
+++ b/src/main/java/com/dokdok/meeting/service/MeetingService.java
@@ -666,7 +666,7 @@ public class MeetingService {
                     cursorMeetingId(cursor),
                     pageable
             );
-            case DONE -> meetingMemberRepository.findMyMeetingsByStatusAfterCursor(
+            case DONE -> meetingMemberRepository.findMyDoneMeetingsWithoutPersonalRetrospectiveAfterCursor(
                     userId,
                     MeetingStatus.DONE,
                     cursorStartDateTime(cursor),
@@ -691,7 +691,7 @@ public class MeetingService {
                         now,
                         now.plusDays(3)
                 );
-                case DONE -> meetingMemberRepository.countMyMeetingsByStatus(
+                case DONE -> meetingMemberRepository.countMyMeetingsByStatusWithoutPersonalRetrospective(
                         userId,
                         MeetingStatus.DONE
                 );
@@ -724,7 +724,7 @@ public class MeetingService {
                 now,
                 now.plusDays(3)
         );
-        int doneCount = meetingMemberRepository.countMyMeetingsByStatus(
+        int doneCount = meetingMemberRepository.countMyMeetingsByStatusWithoutPersonalRetrospective(
                 userId,
                 MeetingStatus.DONE
         );
@@ -899,6 +899,13 @@ public class MeetingService {
         LocalDateTime now = LocalDateTime.now();
         List<MyMeetingListItemResponse> items = new ArrayList<>();
 
+        List<Long> meetingIds = meetings.stream()
+                .map(Meeting::getId)
+                .toList();
+        Set<Long> meetingIdsWithConfirmedTopics = new HashSet<>(
+                topicRepository.findMeetingIdsWithConfirmedTopics(meetingIds)
+        );
+
         for (Meeting meeting : meetings) {
             MeetingProgressStatus progressStatus = resolveProgressStatus(
                     meeting.getMeetingStartDate(),
@@ -906,6 +913,7 @@ public class MeetingService {
                     now
             );
             MeetingMyRole myRole = resolveMyMeetingRole(meeting, userId);
+            boolean preOpinionTemplateConfirmed = meetingIdsWithConfirmedTopics.contains(meeting.getId());
 
             items.add(new MyMeetingListItemResponse(
                     meeting.getId(),
@@ -918,7 +926,8 @@ public class MeetingService {
                     meeting.getMeetingEndDate(),
                     meeting.getMeetingStatus(),
                     myRole,
-                    progressStatus
+                    progressStatus,
+                    preOpinionTemplateConfirmed
             ));
         }
         return items;

--- a/src/main/java/com/dokdok/topic/repository/TopicRepository.java
+++ b/src/main/java/com/dokdok/topic/repository/TopicRepository.java
@@ -229,6 +229,17 @@ public interface TopicRepository extends JpaRepository<Topic, Long> {
     );
 
     @Query("""
+            SELECT DISTINCT t.meeting.id
+            FROM Topic t
+            WHERE t.meeting.id IN :meetingIds
+            AND t.topicStatus = com.dokdok.topic.entity.TopicStatus.CONFIRMED
+            AND t.deletedAt IS NULL
+            """)
+    List<Long> findMeetingIdsWithConfirmedTopics(
+            @Param("meetingIds") List<Long> meetingIds
+    );
+
+    @Query("""
             SELECT MAX(t.updatedAt)
             FROM Topic t
             WHERE t.meeting.id = :meetingId

--- a/src/test/java/com/dokdok/meeting/service/MeetingServiceTest.java
+++ b/src/test/java/com/dokdok/meeting/service/MeetingServiceTest.java
@@ -1438,6 +1438,8 @@ class MeetingServiceTest {
                 any(),
                 any()
         )).willReturn(List.of(myMeeting));
+        given(topicRepository.findMeetingIdsWithConfirmedTopics(List.of(myMeeting.getId())))
+                .willReturn(List.of(myMeeting.getId()));
 
         try (MockedStatic<SecurityUtil> mock = mockStatic(SecurityUtil.class)) {
             mock.when(SecurityUtil::getCurrentUserId).thenReturn(userId);
@@ -1482,6 +1484,8 @@ class MeetingServiceTest {
                 any(),
                 any()
         )).willReturn(List.of(upcomingMeeting));
+        given(topicRepository.findMeetingIdsWithConfirmedTopics(List.of(upcomingMeeting.getId())))
+                .willReturn(List.of());
 
         try (MockedStatic<SecurityUtil> mock = mockStatic(SecurityUtil.class)) {
             mock.when(SecurityUtil::getCurrentUserId).thenReturn(userId);
@@ -1512,8 +1516,10 @@ class MeetingServiceTest {
                 any(),
                 any()
         )).willReturn(2);
-        given(meetingMemberRepository.countMyMeetingsByStatus(userId, MeetingStatus.DONE))
-                .willReturn(3);
+        given(meetingMemberRepository.countMyMeetingsByStatusWithoutPersonalRetrospective(
+                userId,
+                MeetingStatus.DONE
+        )).willReturn(3);
 
         try (MockedStatic<SecurityUtil> mock = mockStatic(SecurityUtil.class)) {
             mock.when(SecurityUtil::getCurrentUserId).thenReturn(userId);


### PR DESCRIPTION
## PR 요약
> 이 PR이 어떤 변경을 하는지 간단히 설명하고, 체크 표시는 괄호 사이에 소문자 'x'를 삽입하세요.

- [ ] 기능 추가
- [ ] 버그 수정
- [x] 코드 리팩토링
- [ ] 문서 수정
- [ ] 기타 (설명)

---

## 이슈 번호
- #339

---

## 주요 변경 사항
> 주요 파일, 로직, 컴포넌트 등을 구체적으로 적어주세요.

  - 메인 내 약속 “완료(DONE)” 탭에서 개인 회고 작성 완료 약속을 제외하도록 필터링/카운트 로직 수정.
  - 메인 내 약속 리스트 응답에 사전 의견 템플릿 확정 여부(preOpinionTemplateConfirmed) 추가.
  - 관련 테스트/예시 응답 업데이트.


---

## 참고 사항
> 리뷰어가 알아야 할 추가 정보, 테스트 방법 등을 작성해주세요.

예:
- 테스트 계정 정보
- 관련 API 엔드포인트
- 로컬 테스트 방법

---
