### PR TITLE
[#341][FIX] 개인 회고 API 약속 관련 헤더 정보 필드 추가

### DIFF
--- a/src/main/java/com/dokdok/retrospective/api/PersonalRetrospectiveApi.java
+++ b/src/main/java/com/dokdok/retrospective/api/PersonalRetrospectiveApi.java
@@ -152,7 +152,7 @@ public interface PersonalRetrospectiveApi {
                     content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
                             schema = @Schema(implementation = PersonalRetrospectiveFormResponse.class),
                             examples = @ExampleObject(value = """
-                                    {"code": "SUCCESS", "message": "개인 회고 입력 폼 조회를 성공했습니다.", "data": {"meetingId": 1, "preOpinions": [{"topicId": 1, "topicName": "깨끗한 코드", "content": "사전 의견 내용을 작성합니다."}], "topics": [{"topicId": 1, "topicName": "깨끗한 코드", "confirmOrder": 1}], "meetingMembers": [{"meetingMemberId": 10, "nickname": "독서왕", "profileImage": "https://example.com/profile.jpg"}]}}
+                                    {"code": "SUCCESS", "message": "개인 회고 입력 폼 조회를 성공했습니다.", "data": {"meetingId": 1, "meetingHeaderInfo": {"gatheringName": "독서 모임", "bookTitle": "클린 코드", "bookAuthor": "로버트 마틴"}, "preOpinions": [{"topicId": 1, "topicName": "깨끗한 코드", "content": "사전 의견 내용을 작성합니다."}], "topics": [{"topicId": 1, "topicName": "깨끗한 코드", "confirmOrder": 1}], "meetingMembers": [{"meetingMemberId": 10, "nickname": "독서왕", "profileImage": "https://example.com/profile.jpg"}]}}
                                     """)
                     )
             ),
@@ -246,7 +246,7 @@ public interface PersonalRetrospectiveApi {
                     content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
                             schema = @Schema(implementation = PersonalRetrospectiveEditResponse.class),
                             examples = @ExampleObject(value = """
-                                    {"code": "SUCCESS", "message": "개인 회고 수정 폼 조회를 성공했습니다.", "data": {"retrospectiveId": 1, "retrospective": {"changedThoughts": [{"topicId": 1, "keyIssue": "요약된 핵심 쟁점", "preOpinion": "토론 전 나의 생각", "postOpinion": "토론 후 바뀐 생각"}], "othersPerspectives": [{"topicId": 1, "meetingMemberId": 10, "opinionContent": "상대 의견이 인상적이었습니다.", "impressiveReason": "새로운 관점을 제공했기 때문입니다."}], "freeTexts": [{"title": "오늘의 한 줄", "content": "회고 내용을 작성합니다."}]}, "topics": [{"topicId": 1, "topicName": "깨끗한 코드", "confirmOrder": 1}], "meetingMembers": [{"meetingMemberId": 10, "nickname": "독서왕", "profileImage": "https://example.com/profile.jpg"}]}}
+                                    {"code": "SUCCESS", "message": "개인 회고 수정 폼 조회를 성공했습니다.", "data": {"retrospectiveId": 1, "meetingHeaderInfo": {"gatheringName": "독서 모임", "bookTitle": "클린 코드", "bookAuthor": "로버트 마틴"}, "retrospective": {"changedThoughts": [{"topicId": 1, "keyIssue": "요약된 핵심 쟁점", "preOpinion": "토론 전 나의 생각", "postOpinion": "토론 후 바뀐 생각"}], "othersPerspectives": [{"topicId": 1, "meetingMemberId": 10, "opinionContent": "상대 의견이 인상적이었습니다.", "impressiveReason": "새로운 관점을 제공했기 때문입니다."}], "freeTexts": [{"title": "오늘의 한 줄", "content": "회고 내용을 작성합니다."}]}, "topics": [{"topicId": 1, "topicName": "깨끗한 코드", "confirmOrder": 1}], "meetingMembers": [{"meetingMemberId": 10, "nickname": "독서왕", "profileImage": "https://example.com/profile.jpg"}]}}
                                     """)
                     )
             ),
@@ -337,7 +337,7 @@ public interface PersonalRetrospectiveApi {
                     content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
                             schema = @Schema(implementation = PersonalRetrospectiveDetailResponse.class),
                             examples = @ExampleObject(value = """
-                                    {"code": "SUCCESS", "message": "개인 회고 조회를 성공했습니다.", "data": {"retrospectiveId": 1, "retrospective": {"changedThoughts": [{"topicId": 1, "topicTitle": "깨끗한 코드", "keyIssue": "요약된 핵심 쟁점", "preOpinion": "토론 전 나의 생각", "postOpinion": "토론 후 바뀐 생각"}], "othersPerspectives": [{"topicId": 1, "meetingMemberId": 10, "profileImage": "https://example.com/profile.jpg", "nickname": "독서왕", "opinionContent": "상대 의견이 인상적이었습니다.", "impressiveReason": "새로운 관점을 제공했기 때문입니다."}], "freeTexts": [{"title": "오늘의 한 줄", "content": "회고 내용을 작성합니다."}]}}}
+                                    {"code": "SUCCESS", "message": "개인 회고 조회를 성공했습니다.", "data": {"retrospectiveId": 1, "meetingHeaderInfo": {"gatheringName": "독서 모임", "bookTitle": "클린 코드", "bookAuthor": "로버트 마틴"}, "retrospective": {"changedThoughts": [{"topicId": 1, "topicTitle": "깨끗한 코드", "keyIssue": "요약된 핵심 쟁점", "preOpinion": "토론 전 나의 생각", "postOpinion": "토론 후 바뀐 생각"}], "othersPerspectives": [{"topicId": 1, "meetingMemberId": 10, "profileImage": "https://example.com/profile.jpg", "nickname": "독서왕", "opinionContent": "상대 의견이 인상적이었습니다.", "impressiveReason": "새로운 관점을 제공했기 때문입니다."}], "freeTexts": [{"title": "오늘의 한 줄", "content": "회고 내용을 작성합니다."}]}}}
                                     """)
                     )
             ),

--- a/src/main/java/com/dokdok/retrospective/dto/response/MeetingHeaderInfo.java
+++ b/src/main/java/com/dokdok/retrospective/dto/response/MeetingHeaderInfo.java
@@ -1,0 +1,22 @@
+package com.dokdok.retrospective.dto.response;
+
+import com.dokdok.meeting.entity.Meeting;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "약속 헤더 정보")
+public record MeetingHeaderInfo(
+        @Schema(description = "모임 이름", example = "독서 모임")
+        String gatheringName,
+        @Schema(description = "책 제목", example = "클린 코드")
+        String bookTitle,
+        @Schema(description = "저자", example = "로버트 마틴")
+        String bookAuthor
+) {
+    public static MeetingHeaderInfo from(Meeting meeting) {
+        return new MeetingHeaderInfo(
+                meeting.getGathering().getGatheringName(),
+                meeting.getBook().getBookName(),
+                meeting.getBook().getAuthor()
+        );
+    }
+}

--- a/src/main/java/com/dokdok/retrospective/dto/response/PersonalRetrospectiveDetailResponse.java
+++ b/src/main/java/com/dokdok/retrospective/dto/response/PersonalRetrospectiveDetailResponse.java
@@ -11,6 +11,8 @@ import java.util.List;
 public record PersonalRetrospectiveDetailResponse(
         @Schema(description = "개인 회고 ID", example = "1")
         Long retrospectiveId,
+        @Schema(description = "약속 헤더 정보")
+        MeetingHeaderInfo meetingHeaderInfo,
         @Schema(description = "개인 회고 데이터")
         RetrospectiveData retrospective
 ) {
@@ -101,12 +103,14 @@ public record PersonalRetrospectiveDetailResponse(
 
     public static PersonalRetrospectiveDetailResponse from(
             Long retrospectiveId,
+            MeetingHeaderInfo meetingHeaderInfo,
             List<ChangedThought> changedThoughts,
             List<OthersPerspective> othersPerspectives,
             List<FreeText> freeTexts
     ) {
         return new PersonalRetrospectiveDetailResponse(
                 retrospectiveId,
+                meetingHeaderInfo,
                 new RetrospectiveData(changedThoughts, othersPerspectives, freeTexts)
         );
     }

--- a/src/main/java/com/dokdok/retrospective/dto/response/PersonalRetrospectiveEditResponse.java
+++ b/src/main/java/com/dokdok/retrospective/dto/response/PersonalRetrospectiveEditResponse.java
@@ -11,6 +11,8 @@ import java.util.List;
 public record PersonalRetrospectiveEditResponse(
         @Schema(description = "개인 회고 ID", example = "1")
         Long retrospectiveId,
+        @Schema(description = "약속 헤더 정보")
+        MeetingHeaderInfo meetingHeaderInfo,
         @Schema(description = "개인 회고 데이터")
         RetrospectiveData retrospective,  // 작성 데이터 묶음
         @Schema(description = "확정된 주제 목록")
@@ -92,6 +94,7 @@ public record PersonalRetrospectiveEditResponse(
 
     public static PersonalRetrospectiveEditResponse from(
             Long retrospectiveId,
+            MeetingHeaderInfo meetingHeaderInfo,
             List<ChangedThought> changedThoughts,
             List<OthersPerspective> othersPerspectives,
             List<FreeText> freeTexts,
@@ -100,6 +103,7 @@ public record PersonalRetrospectiveEditResponse(
     ) {
         return new PersonalRetrospectiveEditResponse(
                 retrospectiveId,
+                meetingHeaderInfo,
                 new RetrospectiveData(changedThoughts, othersPerspectives, freeTexts), // 묶어서 전달
                 topics,
                 meetingMembers

--- a/src/main/java/com/dokdok/retrospective/dto/response/PersonalRetrospectiveFormResponse.java
+++ b/src/main/java/com/dokdok/retrospective/dto/response/PersonalRetrospectiveFormResponse.java
@@ -10,6 +10,8 @@ import java.util.List;
 public record PersonalRetrospectiveFormResponse(
         @Schema(description = "약속 ID", example = "1")
         Long meetingId,
+        @Schema(description = "약속 헤더 정보")
+        MeetingHeaderInfo meetingHeaderInfo,
         @Schema(description = "사전 의견 목록")
         List<PreOpinions> preOpinions,
         @Schema(description = "확정된 주제 목록")
@@ -38,12 +40,14 @@ public record PersonalRetrospectiveFormResponse(
 
     public static PersonalRetrospectiveFormResponse of(
             Long meetingId,
+            MeetingHeaderInfo meetingHeaderInfo,
             List<PreOpinions> preOpinions,
             List<TopicInfo> topics,
             List<MemberInfo> meetingMembers
     ) {
         return new PersonalRetrospectiveFormResponse(
                 meetingId,
+                meetingHeaderInfo,
                 preOpinions,
                 topics,
                 meetingMembers

--- a/src/main/java/com/dokdok/retrospective/service/PersonalRetrospectiveAssembler.java
+++ b/src/main/java/com/dokdok/retrospective/service/PersonalRetrospectiveAssembler.java
@@ -1,5 +1,6 @@
 package com.dokdok.retrospective.service;
 
+import com.dokdok.meeting.entity.Meeting;
 import com.dokdok.meeting.entity.MeetingMember;
 import com.dokdok.retrospective.dto.projection.ChangedThoughtProjection;
 import com.dokdok.retrospective.dto.projection.FreeTextProjection;
@@ -29,7 +30,7 @@ public class PersonalRetrospectiveAssembler {
     private final StorageService storageService;
 
     public PersonalRetrospectiveFormResponse assembleCreate(
-            Long meetingId,
+            Meeting meeting,
             List<Topic> topics,
             List<TopicAnswer> topicAnswers,
             List<MeetingMember> meetingMembers
@@ -58,7 +59,8 @@ public class PersonalRetrospectiveAssembler {
         List<MemberInfo> memberDtos = toMemberDtos(meetingMembers);
 
         return PersonalRetrospectiveFormResponse.of(
-                meetingId,
+                meeting.getId(),
+                MeetingHeaderInfo.from(meeting),
                 preOpinions,
                 topicDtos,
                 memberDtos
@@ -66,6 +68,7 @@ public class PersonalRetrospectiveAssembler {
     }
 
     public PersonalRetrospectiveEditResponse assembleEdit(
+            Meeting meeting,
             Long retrospectiveId,
             List<RetrospectiveChangedThought> changedThoughts,
             List<RetrospectiveOthersPerspective> othersPerspectives,
@@ -93,6 +96,7 @@ public class PersonalRetrospectiveAssembler {
 
         return PersonalRetrospectiveEditResponse.from(
                 retrospectiveId,
+                MeetingHeaderInfo.from(meeting),
                 changedThoughtList,
                 othersPerspectiveList,
                 freeTextList,
@@ -102,6 +106,7 @@ public class PersonalRetrospectiveAssembler {
     }
 
     public PersonalRetrospectiveDetailResponse assembleView(
+            Meeting meeting,
             Long retrospectiveId,
             List<RetrospectiveChangedThought> changedThoughts,
             List<RetrospectiveOthersPerspective> othersPerspectives,
@@ -129,6 +134,7 @@ public class PersonalRetrospectiveAssembler {
 
         return PersonalRetrospectiveDetailResponse.from(
                 retrospectiveId,
+                MeetingHeaderInfo.from(meeting),
                 changedThoughtList,
                 othersPerspectiveList,
                 freeTextList

--- a/src/main/java/com/dokdok/retrospective/service/PersonalRetrospectiveService.java
+++ b/src/main/java/com/dokdok/retrospective/service/PersonalRetrospectiveService.java
@@ -83,7 +83,7 @@ public class PersonalRetrospectiveService {
 
         Long userId = SecurityUtil.getCurrentUserId();
 
-        meetingValidator.validateMeeting(meetingId);
+        Meeting meeting = meetingValidator.findMeetingOrThrow(meetingId);
         meetingValidator.validateMeetingMember(meetingId, userId);
         retrospectiveValidator.validateRetrospective(meetingId, userId);
 
@@ -92,7 +92,7 @@ public class PersonalRetrospectiveService {
         List<MeetingMember> meetingMembers = meetingMemberRepository.findOtherMembersByMeetingId(meetingId, userId);
 
         return assembler.assembleCreate(
-                meetingId,
+                meeting,
                 topics,
                 topicAnswers,
                 meetingMembers
@@ -110,6 +110,7 @@ public class PersonalRetrospectiveService {
         PersonalMeetingRetrospective retrospective
                 = retrospectiveValidator.getRetrospectiveByMeetingAndUser(meetingId, userId);
         Long retrospectiveId = retrospective.getId();
+        Meeting meeting = retrospective.getMeeting();
 
         List<RetrospectiveChangedThought> changedThoughts
                 = changedThoughtRepository.findByPersonalMeetingRetrospective(retrospectiveId);
@@ -126,6 +127,7 @@ public class PersonalRetrospectiveService {
                 = meetingMemberRepository.findOtherMembersByMeetingId(meetingId, userId);
 
         return assembler.assembleEdit(
+                meeting,
                 retrospectiveId,
                 changedThoughts,
                 othersPerspectives,
@@ -250,6 +252,7 @@ public class PersonalRetrospectiveService {
         PersonalMeetingRetrospective retrospective
                 = retrospectiveValidator.getRetrospectiveByMeetingAndUser(meetingId, userId);
         Long retrospectiveId = retrospective.getId();
+        Meeting meeting = retrospective.getMeeting();
 
         List<RetrospectiveChangedThought> changedThoughts
                 = changedThoughtRepository.findByPersonalMeetingRetrospective(retrospectiveId);
@@ -261,6 +264,7 @@ public class PersonalRetrospectiveService {
                 freeTextRepository.findByPersonalMeetingRetrospective_Id(retrospectiveId);
 
         return assembler.assembleView(
+                meeting,
                 retrospectiveId,
                 changedThoughts,
                 othersPerspectives,

--- a/src/test/java/com/dokdok/retrospective/service/PersonalRetrospectiveServiceTest.java
+++ b/src/test/java/com/dokdok/retrospective/service/PersonalRetrospectiveServiceTest.java
@@ -499,8 +499,11 @@ class PersonalRetrospectiveServiceTest {
         MeetingMember member2 = MeetingMember.builder().id(2L).user(user2).build();
         List<MeetingMember> meetingMembers = List.of(member1, member2);
 
+        Meeting meeting = Meeting.builder().id(meetingId).build();
+
         PersonalRetrospectiveFormResponse expectedResponse = PersonalRetrospectiveFormResponse.of(
                 meetingId,
+                null,
                 List.of(new PersonalRetrospectiveFormResponse.PreOpinions(10L, "주제1", "사전 의견1")),
                 List.of(
                         new TopicInfo(10L, "주제1", 1),
@@ -515,13 +518,13 @@ class PersonalRetrospectiveServiceTest {
         try (MockedStatic<SecurityUtil> securityUtilMock = mockStatic(SecurityUtil.class)) {
             securityUtilMock.when(SecurityUtil::getCurrentUserId).thenReturn(userId);
 
-            doNothing().when(meetingValidator).validateMeeting(meetingId);
+            when(meetingValidator.findMeetingOrThrow(meetingId)).thenReturn(meeting);
             doNothing().when(meetingValidator).validateMeetingMember(meetingId, userId);
             doNothing().when(retrospectiveValidator).validateRetrospective(meetingId, userId);
             when(topicValidator.getConfirmedTopics(meetingId)).thenReturn(topics);
             when(topicAnswerRepository.findByMeetingIdUserId(meetingId, userId)).thenReturn(topicAnswers);
             when(meetingMemberRepository.findOtherMembersByMeetingId(meetingId, userId)).thenReturn(meetingMembers);
-            when(assembler.assembleCreate(meetingId, topics, topicAnswers, meetingMembers))
+            when(assembler.assembleCreate(meeting, topics, topicAnswers, meetingMembers))
                     .thenReturn(expectedResponse);
 
             // when
@@ -533,13 +536,13 @@ class PersonalRetrospectiveServiceTest {
             assertThat(response.preOpinions()).hasSize(1);
             assertThat(response.meetingMembers()).hasSize(2);
 
-            verify(meetingValidator).validateMeeting(meetingId);
+            verify(meetingValidator).findMeetingOrThrow(meetingId);
             verify(meetingValidator).validateMeetingMember(meetingId, userId);
             verify(retrospectiveValidator).validateRetrospective(meetingId, userId);
             verify(topicValidator).getConfirmedTopics(meetingId);
             verify(topicAnswerRepository).findByMeetingIdUserId(meetingId, userId);
             verify(meetingMemberRepository).findOtherMembersByMeetingId(meetingId, userId);
-            verify(assembler).assembleCreate(meetingId, topics, topicAnswers, meetingMembers);
+            verify(assembler).assembleCreate(meeting, topics, topicAnswers, meetingMembers);
         }
     }
 
@@ -549,6 +552,8 @@ class PersonalRetrospectiveServiceTest {
         // given
         Long meetingId = 1L;
         Long userId = 3L;
+
+        Meeting meeting = Meeting.builder().id(meetingId).build();
 
         User user1 = User.builder().id(userId).nickname("사용자1").build();
         Topic topic1 = Topic.builder().id(10L).title("주제1").build();
@@ -560,6 +565,7 @@ class PersonalRetrospectiveServiceTest {
 
         PersonalRetrospectiveFormResponse expectedResponse = PersonalRetrospectiveFormResponse.of(
                 meetingId,
+                null,
                 List.of(), // 빈 사전 의견
                 List.of(new TopicInfo(10L, "주제1", 1)),
                 List.of(new MemberInfo(1L, "사용자1", "url"))
@@ -568,13 +574,13 @@ class PersonalRetrospectiveServiceTest {
         try (MockedStatic<SecurityUtil> securityUtilMock = mockStatic(SecurityUtil.class)) {
             securityUtilMock.when(SecurityUtil::getCurrentUserId).thenReturn(userId);
 
-            doNothing().when(meetingValidator).validateMeeting(meetingId);
+            when(meetingValidator.findMeetingOrThrow(meetingId)).thenReturn(meeting);
             doNothing().when(meetingValidator).validateMeetingMember(meetingId, userId);
             doNothing().when(retrospectiveValidator).validateRetrospective(meetingId, userId);
             when(topicValidator.getConfirmedTopics(meetingId)).thenReturn(topics);
             when(topicAnswerRepository.findByMeetingIdUserId(meetingId, userId)).thenReturn(topicAnswers);
             when(meetingMemberRepository.findOtherMembersByMeetingId(meetingId, userId)).thenReturn(meetingMembers);
-            when(assembler.assembleCreate(meetingId, topics, topicAnswers, meetingMembers))
+            when(assembler.assembleCreate(meeting, topics, topicAnswers, meetingMembers))
                     .thenReturn(expectedResponse);
 
             // when
@@ -596,8 +602,8 @@ class PersonalRetrospectiveServiceTest {
         try (MockedStatic<SecurityUtil> securityUtilMock = mockStatic(SecurityUtil.class)) {
             securityUtilMock.when(SecurityUtil::getCurrentUserId).thenReturn(userId);
 
-            doThrow(new MeetingException(MeetingErrorCode.MEETING_NOT_FOUND))
-                    .when(meetingValidator).validateMeeting(meetingId);
+            when(meetingValidator.findMeetingOrThrow(meetingId))
+                    .thenThrow(new MeetingException(MeetingErrorCode.MEETING_NOT_FOUND));
 
             // when & then
             assertThatThrownBy(() -> personalRetrospectiveService.getPersonalRetrospectiveForm(meetingId))
@@ -615,10 +621,12 @@ class PersonalRetrospectiveServiceTest {
         Long meetingId = 1L;
         Long userId = 999L;
 
+        Meeting meeting = Meeting.builder().id(meetingId).build();
+
         try (MockedStatic<SecurityUtil> securityUtilMock = mockStatic(SecurityUtil.class)) {
             securityUtilMock.when(SecurityUtil::getCurrentUserId).thenReturn(userId);
 
-            doNothing().when(meetingValidator).validateMeeting(meetingId);
+            when(meetingValidator.findMeetingOrThrow(meetingId)).thenReturn(meeting);
             doThrow(new MeetingException(MeetingErrorCode.NOT_MEETING_MEMBER))
                     .when(meetingValidator).validateMeetingMember(meetingId, userId);
 
@@ -638,10 +646,12 @@ class PersonalRetrospectiveServiceTest {
         Long meetingId = 1L;
         Long userId = 3L;
 
+        Meeting meeting = Meeting.builder().id(meetingId).build();
+
         try (MockedStatic<SecurityUtil> securityUtilMock = mockStatic(SecurityUtil.class)) {
             securityUtilMock.when(SecurityUtil::getCurrentUserId).thenReturn(userId);
 
-            doNothing().when(meetingValidator).validateMeeting(meetingId);
+            when(meetingValidator.findMeetingOrThrow(meetingId)).thenReturn(meeting);
             doNothing().when(meetingValidator).validateMeetingMember(meetingId, userId);
             doThrow(new RetrospectiveException(RetrospectiveErrorCode.RETROSPECTIVE_ALREADY_EXISTS))
                     .when(retrospectiveValidator).validateRetrospective(meetingId, userId);
@@ -662,10 +672,12 @@ class PersonalRetrospectiveServiceTest {
         Long meetingId = 1L;
         Long userId = 3L;
 
+        Meeting meeting = Meeting.builder().id(meetingId).build();
+
         try (MockedStatic<SecurityUtil> securityUtilMock = mockStatic(SecurityUtil.class)) {
             securityUtilMock.when(SecurityUtil::getCurrentUserId).thenReturn(userId);
 
-            doNothing().when(meetingValidator).validateMeeting(meetingId);
+            when(meetingValidator.findMeetingOrThrow(meetingId)).thenReturn(meeting);
             doNothing().when(meetingValidator).validateMeetingMember(meetingId, userId);
             doNothing().when(retrospectiveValidator).validateRetrospective(meetingId, userId);
             when(topicValidator.getConfirmedTopics(meetingId))
@@ -723,6 +735,7 @@ class PersonalRetrospectiveServiceTest {
 
         PersonalRetrospectiveEditResponse expectedResponse = PersonalRetrospectiveEditResponse.from(
                 retrospectiveId,
+                null,
                 List.of(new PersonalRetrospectiveEditResponse.ChangedThought(10L, "핵심 쟁점", "사전의견","사후 의견")),
                 List.of(new PersonalRetrospectiveEditResponse.OthersPerspective(10L, 5L, "타인 의견", "인상 깊었던 이유")),
                 List.of(new PersonalRetrospectiveEditResponse.FreeText("자유 서술 제목", "자유 서술 내용")),
@@ -746,7 +759,7 @@ class PersonalRetrospectiveServiceTest {
             List<MeetingMember> meetingMembers = List.of();
             when(topicValidator.getConfirmedTopics(meetingId)).thenReturn(topics);
             when(meetingMemberRepository.findOtherMembersByMeetingId(meetingId, userId)).thenReturn(meetingMembers);
-            when(assembler.assembleEdit(retrospectiveId, changedThoughts, othersPerspectives, freeTexts, topics, meetingMembers))
+            when(assembler.assembleEdit(meeting, retrospectiveId, changedThoughts, othersPerspectives, freeTexts, topics, meetingMembers))
                     .thenReturn(expectedResponse);
 
             // when
@@ -767,7 +780,7 @@ class PersonalRetrospectiveServiceTest {
             verify(freeTextRepository).findByPersonalMeetingRetrospective_Id(retrospectiveId);
             verify(topicValidator).getConfirmedTopics(meetingId);
             verify(meetingMemberRepository).findOtherMembersByMeetingId(meetingId, userId);
-            verify(assembler).assembleEdit(retrospectiveId, changedThoughts, othersPerspectives, freeTexts, topics, meetingMembers);
+            verify(assembler).assembleEdit(meeting, retrospectiveId, changedThoughts, othersPerspectives, freeTexts, topics, meetingMembers);
         }
     }
 
@@ -795,6 +808,7 @@ class PersonalRetrospectiveServiceTest {
 
         PersonalRetrospectiveEditResponse expectedResponse = PersonalRetrospectiveEditResponse.from(
                 retrospectiveId,
+                null,
                 List.of(),
                 List.of(),
                 List.of(),
@@ -816,7 +830,7 @@ class PersonalRetrospectiveServiceTest {
                     .thenReturn(freeTexts);
             when(topicValidator.getConfirmedTopics(meetingId)).thenReturn(topics);
             when(meetingMemberRepository.findOtherMembersByMeetingId(meetingId, userId)).thenReturn(meetingMembers);
-            when(assembler.assembleEdit(retrospectiveId, changedThoughts, othersPerspectives, freeTexts, topics, meetingMembers))
+            when(assembler.assembleEdit(meeting, retrospectiveId, changedThoughts, othersPerspectives, freeTexts, topics, meetingMembers))
                     .thenReturn(expectedResponse);
 
             // when
@@ -1595,6 +1609,7 @@ class PersonalRetrospectiveServiceTest {
 
         PersonalRetrospectiveDetailResponse expectedResponse = PersonalRetrospectiveDetailResponse.from(
                 retrospectiveId,
+                null,
                 List.of(new PersonalRetrospectiveDetailResponse.ChangedThought(10L, "주제 제목", "핵심 쟁점", "사전 의견", "사후 의견")),
                 List.of(new PersonalRetrospectiveDetailResponse.OthersPerspective(10L, 5L, "presigned-url", "다른사용자", "타인 의견", "인상 깊었던 이유")),
                 List.of(new PersonalRetrospectiveDetailResponse.FreeText("자유 서술 제목", "자유 서술 내용"))
@@ -1620,7 +1635,7 @@ class PersonalRetrospectiveServiceTest {
                     .thenReturn(othersPerspectives);
             when(freeTextRepository.findByPersonalMeetingRetrospective_Id(retrospectiveId))
                     .thenReturn(freeTexts);
-            when(assembler.assembleView(eq(retrospectiveId), eq(changedThoughts), eq(othersPerspectives), eq(freeTexts)))
+            when(assembler.assembleView(eq(meeting), eq(retrospectiveId), eq(changedThoughts), eq(othersPerspectives), eq(freeTexts)))
                     .thenReturn(expectedResponse);
 
             // when
@@ -1639,7 +1654,7 @@ class PersonalRetrospectiveServiceTest {
             verify(changedThoughtRepository).findByPersonalMeetingRetrospective(retrospectiveId);
             verify(othersPerspectiveRepository).findByPersonalMeetingRetrospective(retrospectiveId);
             verify(freeTextRepository).findByPersonalMeetingRetrospective_Id(retrospectiveId);
-            verify(assembler).assembleView(eq(retrospectiveId), eq(changedThoughts), eq(othersPerspectives), eq(freeTexts));
+            verify(assembler).assembleView(eq(meeting), eq(retrospectiveId), eq(changedThoughts), eq(othersPerspectives), eq(freeTexts));
         }
     }
 
@@ -1657,6 +1672,7 @@ class PersonalRetrospectiveServiceTest {
 
         PersonalRetrospectiveDetailResponse expectedResponse = PersonalRetrospectiveDetailResponse.from(
                 retrospectiveId,
+                null,
                 List.of(),
                 List.of(),
                 List.of()
@@ -1682,7 +1698,7 @@ class PersonalRetrospectiveServiceTest {
                     .thenReturn(othersPerspectives);
             when(freeTextRepository.findByPersonalMeetingRetrospective_Id(retrospectiveId))
                     .thenReturn(freeTexts);
-            when(assembler.assembleView(eq(retrospectiveId), eq(changedThoughts), eq(othersPerspectives), eq(freeTexts)))
+            when(assembler.assembleView(eq(meeting), eq(retrospectiveId), eq(changedThoughts), eq(othersPerspectives), eq(freeTexts)))
                     .thenReturn(expectedResponse);
 
             // when
@@ -1824,6 +1840,7 @@ class PersonalRetrospectiveServiceTest {
 
         PersonalRetrospectiveDetailResponse expectedResponse = PersonalRetrospectiveDetailResponse.from(
                 retrospectiveId,
+                null,
                 List.of(),
                 List.of(
                         new PersonalRetrospectiveDetailResponse.OthersPerspective(10L, 5L, "presigned-url-1", "사용자1", "타인 의견1", "이유1"),
@@ -1852,7 +1869,7 @@ class PersonalRetrospectiveServiceTest {
                     .thenReturn(othersPerspectives);
             when(freeTextRepository.findByPersonalMeetingRetrospective_Id(retrospectiveId))
                     .thenReturn(freeTexts);
-            when(assembler.assembleView(eq(retrospectiveId), eq(changedThoughts), eq(othersPerspectives), eq(freeTexts)))
+            when(assembler.assembleView(eq(meeting), eq(retrospectiveId), eq(changedThoughts), eq(othersPerspectives), eq(freeTexts)))
                     .thenReturn(expectedResponse);
 
             // when


### PR DESCRIPTION
## PR 요약
> 이 PR이 어떤 변경을 하는지 간단히 설명하고, 체크 표시는 괄호 사이에 소문자 'x'를 삽입하세요.

- [ ] 기능 추가
- [x] 버그 수정
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 기타 (설명)

---

## 이슈 번호
- #341

---

## 주요 변경 사항
> 주요 파일, 로직, 컴포넌트 등을 구체적으로 적어주세요.

- `src/main/java/com/dokdok/retrospective`: +51/-7 (7 files) — 요구사항 반영
- `src/test/java/com/dokdok/retrospective`: +35/-18 (1 files) — 요구사항 반영

---

## 참고 사항
> 리뷰어가 알아야 할 추가 정보, 테스트 방법 등을 작성해주세요.

예:
- 테스트 계정 정보
- 관련 API 엔드포인트
- 로컬 테스트 방법

---
