### PR TITLE
[#345][REFACTOR] 약속 상세 응답 테스트 코드 변경, 약속 상세 응답 추가

### DIFF
--- a/src/main/java/com/dokdok/meeting/api/MeetingApi.java
+++ b/src/main/java/com/dokdok/meeting/api/MeetingApi.java
@@ -89,6 +89,8 @@ public interface MeetingApi {
                                             }
                                           ]
                                         },
+                                        "retrospectiveStatus": "AI_SUMMARY_COMPLETED",
+                                        "personalRetrospectiveWritten": true,
                                         "actionState": {
                                           "type": "CAN_EDIT",
                                           "buttonLabel": "수정하기",

--- a/src/main/java/com/dokdok/meeting/dto/MeetingDetailResponse.java
+++ b/src/main/java/com/dokdok/meeting/dto/MeetingDetailResponse.java
@@ -51,6 +51,12 @@ public record MeetingDetailResponse(
         @Schema(description = "참가자 정보")
         ParticipantsInfo participants,
 
+        @Schema(description = "약속 회고 상태", example = "AI_SUMMARY_COMPLETED")
+        MeetingRetrospectiveStatus retrospectiveStatus,
+
+        @Schema(description = "개인 회고 작성 여부", example = "true")
+        Boolean personalRetrospectiveWritten,
+
         @Schema(description = "화면 버튼 상태")
         ActionState actionState
 ) {
@@ -61,6 +67,8 @@ public record MeetingDetailResponse(
             Long requestUserId,
             Boolean confirmedTopic,
             LocalDateTime confirmedTopicDate,
+            MeetingRetrospectiveStatus retrospectiveStatus,
+            Boolean personalRetrospectiveWritten,
             Map<Long, String> profileImageUrlMap
     ) {
         List<MeetingMember> safeMembers = meetingMembers == null ? Collections.emptyList() : meetingMembers;
@@ -100,6 +108,8 @@ public record MeetingDetailResponse(
                 ScheduleInfo.from(meeting.getMeetingStartDate(), meeting.getMeetingEndDate()),
                 MeetingLocationDto.from(meeting.getLocation()),
                 participantsInfo,
+                retrospectiveStatus,
+                personalRetrospectiveWritten,
                 actionState
         );
     }

--- a/src/main/java/com/dokdok/meeting/dto/MeetingRetrospectiveStatus.java
+++ b/src/main/java/com/dokdok/meeting/dto/MeetingRetrospectiveStatus.java
@@ -1,0 +1,13 @@
+package com.dokdok.meeting.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "약속 회고 상태")
+public enum MeetingRetrospectiveStatus {
+    @Schema(description = "회고 생성 전")
+    NOT_CREATED,
+    @Schema(description = "AI 요약 완료")
+    AI_SUMMARY_COMPLETED,
+    @Schema(description = "최종 생성 완료")
+    FINAL_PUBLISHED
+}

--- a/src/main/java/com/dokdok/meeting/service/MeetingService.java
+++ b/src/main/java/com/dokdok/meeting/service/MeetingService.java
@@ -25,6 +25,8 @@ import com.dokdok.meeting.exception.MeetingErrorCode;
 import com.dokdok.meeting.exception.MeetingException;
 import com.dokdok.meeting.repository.MeetingMemberRepository;
 import com.dokdok.meeting.repository.MeetingRepository;
+import com.dokdok.retrospective.repository.PersonalRetrospectiveRepository;
+import com.dokdok.retrospective.repository.TopicRetrospectiveSummaryRepository;
 import com.dokdok.topic.entity.Topic;
 import com.dokdok.topic.entity.TopicStatus;
 import com.dokdok.topic.entity.TopicType;
@@ -62,6 +64,8 @@ public class MeetingService {
     private final BookValidator bookValidator;
     private final UserValidator userValidator;
     private final PersonalBookService personalBookService;
+    private final TopicRetrospectiveSummaryRepository topicRetrospectiveSummaryRepository;
+    private final PersonalRetrospectiveRepository personalRetrospectiveRepository;
 
     /**
      * 특정 약속의 정보를 확인할 수 있다. 모임에 속한 사용자만 조회 가능
@@ -86,14 +90,46 @@ public class MeetingService {
         );
         boolean confirmedTopic = confirmedTopicDate != null;
 
+        MeetingRetrospectiveStatus retrospectiveStatus = resolveMeetingRetrospectiveStatus(meetingId, meeting);
+
+        // 개인 회고 작성 여부
+        boolean personalRetrospectiveWritten = personalRetrospectiveRepository
+                .existsByMeetingIdAndUserId(meetingId, userId);
+
         return MeetingDetailResponse.from(
                 meeting,
                 meetingMembers,
                 userId,
                 confirmedTopic,
                 confirmedTopicDate,
+                retrospectiveStatus,
+                personalRetrospectiveWritten,
                 profileImageUrlMap
         );
+    }
+
+    /**
+     * 약속 회고 상태를 계산한다: FINAL_PUBLISHED > AI_SUMMARY_COMPLETED > NOT_CREATED 순으로 판단.
+     *   - FINAL_PUBLISHED: meeting.isRetrospectivePublished()가 true
+     *   - AI_SUMMARY_COMPLETED: 확정 토픽이 있고, 해당 토픽 중 하나라도 TopicRetrospectiveSummary가 존재
+     *   - NOT_CREATED: 위 두 조건 모두 불충족
+     **/
+    private MeetingRetrospectiveStatus resolveMeetingRetrospectiveStatus(Long meetingId, Meeting meeting) {
+        if (meeting.isRetrospectivePublished()) {
+            return MeetingRetrospectiveStatus.FINAL_PUBLISHED;
+        }
+
+        List<Long> topicIds = topicRepository.findConfirmedTopics(meetingId).stream()
+                .map(Topic::getId)
+                .toList();
+        if (topicIds.isEmpty()) {
+            return MeetingRetrospectiveStatus.NOT_CREATED;
+        }
+
+        boolean hasSummary = !topicRetrospectiveSummaryRepository.findAllByTopicIdIn(topicIds).isEmpty();
+        return hasSummary
+                ? MeetingRetrospectiveStatus.AI_SUMMARY_COMPLETED
+                : MeetingRetrospectiveStatus.NOT_CREATED;
     }
 
     /**

--- a/src/test/java/com/dokdok/meeting/service/MeetingServiceTest.java
+++ b/src/test/java/com/dokdok/meeting/service/MeetingServiceTest.java
@@ -22,6 +22,8 @@ import com.dokdok.meeting.exception.MeetingErrorCode;
 import com.dokdok.meeting.exception.MeetingException;
 import com.dokdok.meeting.repository.MeetingMemberRepository;
 import com.dokdok.meeting.repository.MeetingRepository;
+import com.dokdok.retrospective.repository.PersonalRetrospectiveRepository;
+import com.dokdok.retrospective.repository.TopicRetrospectiveSummaryRepository;
 import com.dokdok.topic.entity.TopicStatus;
 import com.dokdok.topic.entity.TopicType;
 import com.dokdok.topic.repository.TopicAnswerRepository;
@@ -49,6 +51,7 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
 
@@ -100,6 +103,12 @@ class MeetingServiceTest {
     @Mock
     private PersonalBookService personalBookService;
 
+    @Mock
+    private TopicRetrospectiveSummaryRepository topicRetrospectiveSummaryRepository;
+
+    @Mock
+    private PersonalRetrospectiveRepository personalRetrospectiveRepository;
+
     private Meeting meeting;
     private Long meetingId;
     private Gathering gathering;
@@ -128,6 +137,12 @@ class MeetingServiceTest {
                 .gathering(gathering)
                 .book(sampleBook())
                 .build();
+
+        lenient().when(topicRepository.findConfirmedTopics(anyLong())).thenReturn(List.of());
+        lenient().when(topicRetrospectiveSummaryRepository.findAllByTopicIdIn(any()))
+                .thenReturn(List.of());
+        lenient().when(personalRetrospectiveRepository.existsByMeetingIdAndUserId(eq(meetingId), any()))
+                .thenReturn(false);
     }
 
     private Book sampleBook() {


### PR DESCRIPTION
## PR 요약
> 이 PR이 어떤 변경을 하는지 간단히 설명하고, 체크 표시는 괄호 사이에 소문자 'x'를 삽입하세요.

- [ ] 기능 추가
- [ ] 버그 수정
- [x] 코드 리팩토링
- [ ] 문서 수정
- [ ] 기타 (설명)

---

## 이슈 번호
- #345

---

## 주요 변경 사항
> 주요 파일, 로직, 컴포넌트 등을 구체적으로 적어주세요.

  - 메인 내 약속 “완료(DONE)” 탭에서 개인 회고 작성 완료 약속을 제외하도록 필터링/카운트 로직 수정.
  - 메인 내 약속 리스트 응답에 사전 의견 템플릿 확정 여부(preOpinionTemplateConfirmed) 추가.
  - 관련 테스트/예시 응답 업데이트.

---

## 참고 사항
> 리뷰어가 알아야 할 추가 정보, 테스트 방법 등을 작성해주세요.

예:
- 테스트 계정 정보
- 관련 API 엔드포인트
- 로컬 테스트 방법

---
