### PR TITLE
[#351][REFACTOR] 독서기록 타임라인 회고 response에 모임 및 약속ID 필드 추가

### DIFF
--- a/src/main/java/com/dokdok/book/service/ReadingTimelineService.java
+++ b/src/main/java/com/dokdok/book/service/ReadingTimelineService.java
@@ -121,7 +121,7 @@ public class ReadingTimelineService {
         Map<Long, PersonalReadingRecordListResponse> readingRecordMap =
                 fetchReadingRecords(readingRecordIds, personalBookId, userId);
         Map<Long, RetrospectiveRecordResponse> retrospectiveMap =
-                fetchRetrospectives(retrospectiveIds, userId);
+                fetchPersonalRetrospectives(retrospectiveIds, userId);
         Map<Long, RetrospectiveRecordResponse> groupRetrospectiveMap =
                 fetchGroupRetrospectives(groupRetrospectiveMeetingIds);
         Map<Long, ReadingTimelinePreOpinionResponse> preOpinionMap =
@@ -187,82 +187,84 @@ public class ReadingTimelineService {
         return map;
     }
 
-    private Map<Long, RetrospectiveRecordResponse> fetchRetrospectives(
-            List<Long> retrospectiveIds,
-            Long userId
-    ) {
-        if (retrospectiveIds.isEmpty()) {
-            return Map.of();
-        }
-
-        List<PersonalMeetingRetrospective> retrospectives =
-                personalRetrospectiveRepository.findByIdsWithMeeting(retrospectiveIds, userId);
-
-        if (retrospectives.isEmpty()) {
-            return Map.of();
-        }
-
-        List<Long> ids = retrospectives.stream()
-                .map(PersonalMeetingRetrospective::getId)
-                .toList();
-
-        Map<Long, List<ChangedThoughtProjection>> changedThoughtsMap =
-                changedThoughtRepository.findByRetrospectiveIds(ids)
-                        .stream()
-                        .collect(groupingBy(ChangedThoughtProjection::retrospectiveId));
-
-        Map<Long, List<OtherPerspectiveProjection>> othersPerspectivesMap =
-                othersPerspectiveRepository.findByRetrospectiveIds(ids)
-                        .stream()
-                        .collect(groupingBy(OtherPerspectiveProjection::retrospectiveId));
-
-        Map<Long, List<FreeTextProjection>> freeTextsMap =
-                freeTextRepository.findByRetrospectiveIds(ids)
-                        .stream()
-                        .collect(groupingBy(FreeTextProjection::retrospectiveId));
-
-        List<RetrospectiveRecordResponse> responses = personalRetrospectiveAssembler.assembleRecords(
-                retrospectives,
-                changedThoughtsMap,
-                othersPerspectivesMap,
-                freeTextsMap
-        );
-
-        Map<Long, RetrospectiveRecordResponse> map = new HashMap<>();
-        for (RetrospectiveRecordResponse response : responses) {
-            map.put(response.retrospectiveId(), response);
-        }
-        return map;
-    }
-
-    private Map<Long, RetrospectiveRecordResponse> fetchGroupRetrospectives(List<Long> meetingIds) {
-        if (meetingIds.isEmpty()) {
-            return Map.of();
-        }
-
-        List<Meeting> meetings = meetingRepository.findByIdInWithGathering(meetingIds);
-        Map<Long, RetrospectiveRecordResponse> map = new HashMap<>();
-
-        for (Meeting meeting : meetings) {
-            if (!meeting.isRetrospectivePublished() || meeting.getRetrospectivePublishedAt() == null) {
-                continue;
+        private Map<Long, RetrospectiveRecordResponse> fetchPersonalRetrospectives(
+                List<Long> retrospectiveIds,
+                Long userId
+        ) {
+            if (retrospectiveIds.isEmpty()) {
+                return Map.of();
             }
 
-            map.put(
-                    meeting.getId(),
-                    RetrospectiveRecordResponse.of(
-                            meeting.getId(),
-                            meeting.getGathering().getGatheringName(),
-                            ReflectionRecordType.MEETING_RETROSPECTIVE,
-                            meeting.getRetrospectivePublishedAt(),
-                            List.of(),
-                            List.of()
-                    )
+            List<PersonalMeetingRetrospective> retrospectives =
+                    personalRetrospectiveRepository.findByIdsWithMeeting(retrospectiveIds, userId);
+
+            if (retrospectives.isEmpty()) {
+                return Map.of();
+            }
+
+            List<Long> ids = retrospectives.stream()
+                    .map(PersonalMeetingRetrospective::getId)
+                    .toList();
+
+            Map<Long, List<ChangedThoughtProjection>> changedThoughtsMap =
+                    changedThoughtRepository.findByRetrospectiveIds(ids)
+                            .stream()
+                            .collect(groupingBy(ChangedThoughtProjection::retrospectiveId));
+
+            Map<Long, List<OtherPerspectiveProjection>> othersPerspectivesMap =
+                    othersPerspectiveRepository.findByRetrospectiveIds(ids)
+                            .stream()
+                            .collect(groupingBy(OtherPerspectiveProjection::retrospectiveId));
+
+            Map<Long, List<FreeTextProjection>> freeTextsMap =
+                    freeTextRepository.findByRetrospectiveIds(ids)
+                            .stream()
+                            .collect(groupingBy(FreeTextProjection::retrospectiveId));
+
+            List<RetrospectiveRecordResponse> responses = personalRetrospectiveAssembler.assembleRecords(
+                    retrospectives,
+                    changedThoughtsMap,
+                    othersPerspectivesMap,
+                    freeTextsMap
             );
+
+            Map<Long, RetrospectiveRecordResponse> map = new HashMap<>();
+            for (RetrospectiveRecordResponse response : responses) {
+                map.put(response.retrospectiveId(), response);
+            }
+            return map;
         }
 
-        return map;
-    }
+        private Map<Long, RetrospectiveRecordResponse> fetchGroupRetrospectives(List<Long> meetingIds) {
+            if (meetingIds.isEmpty()) {
+                return Map.of();
+            }
+
+            List<Meeting> meetings = meetingRepository.findByIdInWithGathering(meetingIds);
+            Map<Long, RetrospectiveRecordResponse> map = new HashMap<>();
+
+            for (Meeting meeting : meetings) {
+                if (!meeting.isRetrospectivePublished() || meeting.getRetrospectivePublishedAt() == null) {
+                    continue;
+                }
+
+                map.put(
+                        meeting.getId(),
+                        RetrospectiveRecordResponse.of(
+                                meeting.getId(),
+                                meeting.getGathering().getId(),
+                                meeting.getGathering().getGatheringName(),
+                                meeting.getId(),
+                                ReflectionRecordType.MEETING_RETROSPECTIVE,
+                                meeting.getRetrospectivePublishedAt(),
+                                List.of(),
+                                List.of()
+                        )
+                );
+            }
+
+            return map;
+        }
 
     private Map<Long, ReadingTimelinePreOpinionResponse> fetchPreOpinions(
             List<Long> meetingIds,

--- a/src/main/java/com/dokdok/retrospective/dto/response/RetrospectiveRecordResponse.java
+++ b/src/main/java/com/dokdok/retrospective/dto/response/RetrospectiveRecordResponse.java
@@ -13,8 +13,12 @@ import java.util.List;
 public record RetrospectiveRecordResponse(
         @Schema(description = "개인 회고 ID", example = "1")
         Long retrospectiveId,
+        @Schema(description = "모임 ID", example = "1")
+        Long gatheringId,
         @Schema(description = "모임 이름", example = "독서 모임")
         String gatheringName,
+        @Schema(description = "약속 ID", example = "1")
+        Long meetingId,
         @Schema(description = "기록 유형", example = "개인 회고")
         ReflectionRecordType recordType,
         @Schema(description = "작성 일시", example = "2025-02-01T16:30:00")
@@ -91,7 +95,9 @@ public record RetrospectiveRecordResponse(
 
     public static RetrospectiveRecordResponse of(
             Long retrospectiveId,
+            Long gatheringId,
             String gatheringName,
+            Long meetingId,
             ReflectionRecordType recordType,
             LocalDateTime createdAt,
             List<TopicGroup> topicGroups,
@@ -99,7 +105,9 @@ public record RetrospectiveRecordResponse(
     ) {
         return new RetrospectiveRecordResponse(
                 retrospectiveId,
+                gatheringId,
                 gatheringName,
+                meetingId,
                 recordType,
                 createdAt,
                 topicGroups,

--- a/src/main/java/com/dokdok/retrospective/service/PersonalRetrospectiveAssembler.java
+++ b/src/main/java/com/dokdok/retrospective/service/PersonalRetrospectiveAssembler.java
@@ -156,7 +156,9 @@ public class PersonalRetrospectiveAssembler {
 
                     return RetrospectiveRecordResponse.of(
                             retroId,
+                            retrospective.getMeeting().getGathering().getId(),
                             retrospective.getMeeting().getGathering().getGatheringName(),
+                            retrospective.getMeeting().getId(),
                             PERSONAL_RETROSPECTIVE,
                             retrospective.getCreatedAt(),
                             topicGroups,

--- a/src/test/java/com/dokdok/retrospective/service/PersonalRetrospectiveServiceTest.java
+++ b/src/test/java/com/dokdok/retrospective/service/PersonalRetrospectiveServiceTest.java
@@ -1335,7 +1335,8 @@ class PersonalRetrospectiveServiceTest {
                     .thenReturn(List.of());
 
             RetrospectiveRecordResponse recordResponse = RetrospectiveRecordResponse.of(
-                    retrospectiveId, "테스트 모임", ReflectionRecordType.PERSONAL_RETROSPECTIVE, null, List.of(), List.of()
+                    retrospectiveId, gathering.getId(), gathering.getGatheringName(), meeting.getId(),
+                    ReflectionRecordType.PERSONAL_RETROSPECTIVE, null, List.of(), List.of()
             );
             when(assembler.assembleRecords(any(), any(), any(), any()))
                     .thenReturn(List.of(recordResponse));


### PR DESCRIPTION
## PR 요약
> 이 PR이 어떤 변경을 하는지 간단히 설명하고, 체크 표시는 괄호 사이에 소문자 'x'를 삽입하세요.

- [ ] 기능 추가
- [ ] 버그 수정
- [x] 코드 리팩토링
- [ ] 문서 수정
- [ ] 기타 (설명)

---

## 이슈 번호
- #351

---

## 주요 변경 사항
> 주요 파일, 로직, 컴포넌트 등을 구체적으로 적어주세요.

- `src/main/java/com/dokdok/book`: +68/-66 (1 files) — 요구사항 반영
- `src/main/java/com/dokdok/retrospective`: +10/-0 (2 files) — 요구사항 반영
- `src/test/java/com/dokdok/retrospective`: +2/-1 (1 files) — 요구사항 반영

---

## 참고 사항
> 리뷰어가 알아야 할 추가 정보, 테스트 방법 등을 작성해주세요.

예:
- 테스트 계정 정보
- 관련 API 엔드포인트
- 로컬 테스트 방법

---
