### PR TITLE
[#357][FIX] 내 모임 List에서의 참여 경과일 수정

### DIFF
--- a/src/main/java/com/dokdok/gathering/entity/GatheringMember.java
+++ b/src/main/java/com/dokdok/gathering/entity/GatheringMember.java
@@ -81,7 +81,7 @@ import java.time.temporal.ChronoUnit;
         return (int) ChronoUnit.DAYS.between(
                 this.joinedAt.toLocalDate(),
                 LocalDate.now()
-        );
+        ) + 1;
     }
 
     public void remove() {

--- a/src/test/java/com/dokdok/gathering/service/GatheringServiceTest.java
+++ b/src/test/java/com/dokdok/gathering/service/GatheringServiceTest.java
@@ -335,7 +335,7 @@ class GatheringServiceTest {
 		assertThat(firstGathering.totalMembers()).isEqualTo(1);
 		assertThat(firstGathering.totalMeetings()).isEqualTo(3);
 		assertThat(firstGathering.currentUserRole()).isEqualTo(LEADER);
-		assertThat(firstGathering.daysFromJoined()).isEqualTo(10);
+		assertThat(firstGathering.daysFromJoined()).isEqualTo(11);
 
 		GatheringListItemResponse secondGathering = response.gatherings().get(1);
 		assertThat(secondGathering.gatheringId()).isEqualTo(2L);


### PR DESCRIPTION
## PR 요약
> 이 PR이 어떤 변경을 하는지 간단히 설명하고, 체크 표시는 괄호 사이에 소문자 'x'를 삽입하세요.

- [ ] 기능 추가
- [x] 버그 수정
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 기타 (설명)

---

## 이슈 번호
- #357 

---

## 주요 변경 사항
> 주요 파일, 로직, 컴포넌트 등을 구체적으로 적어주세요.

- `gatheringListItemResponse`: 모임 Detail과 모임 List에서의 참여 경과일 일치하도록 수정 
- `gatheringServiceTest`: 테스트 결과값을 수정  

---

## 참고 사항
> 약속 Count에 대한 이야기도 있었지만 약속 상태에 따른 Count이기 때문에 정상작동중인것으로 판단했습니다.

---