### PR TITLE
[#364][FIX] 거절된 계정의 모임 재가입요청 로직 수정

### DIFF
--- a/src/main/java/com/dokdok/gathering/entity/GatheringMember.java
+++ b/src/main/java/com/dokdok/gathering/entity/GatheringMember.java
@@ -98,4 +98,9 @@ import java.time.temporal.ChronoUnit;
     public void updateFavorite() {
         this.isFavorite = !isFavorite;
     }
+
+    public void reapplyJoinRequest() {
+        this.memberStatus = GatheringMemberStatus.PENDING;
+        this.joinedAt = null;
+    }
 }

--- a/src/main/java/com/dokdok/gathering/service/GatheringService.java
+++ b/src/main/java/com/dokdok/gathering/service/GatheringService.java
@@ -31,6 +31,7 @@ import java.time.LocalDateTime;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service
@@ -89,12 +90,26 @@ public class GatheringService {
     public GatheringJoinResponse joinGathering(String invitationLink) {
 
         User user = SecurityUtil.getCurrentUserEntity();
-
         Gathering gathering = gatheringValidator.validateInvitationLink(invitationLink);
-        gatheringValidator.validateJoinedGathering(gathering.getId(), user.getId());
+
+        // 기존 멤버십 확인
+        Optional<GatheringMember> existingMember = gatheringMemberRepository.findByGatheringIdAndUserId(gathering.getId(), user.getId());
+
+        if(existingMember.isPresent()) {
+            GatheringMember member = existingMember.get();
+            GatheringMemberStatus status = member.getMemberStatus();
+
+            if(status == GatheringMemberStatus.ACTIVE) {
+                throw new GatheringException(GatheringErrorCode.ALREADY_GATHERING_MEMBER);
+            }else if(status == GatheringMemberStatus.PENDING) {
+                throw new GatheringException(GatheringErrorCode.JOIN_REQUEST_ALREADY_PENDING);
+            }else if(status == GatheringMemberStatus.REJECTED) {
+                member.reapplyJoinRequest();
+                return GatheringJoinResponse.from(member);
+            }
+        }
 
         GatheringMember member = saveGatheringMember(gathering, user, GatheringRole.MEMBER, GatheringMemberStatus.PENDING, null);
-
         return GatheringJoinResponse.from(member);
     }
 

--- a/src/main/java/com/dokdok/gathering/service/GatheringValidator.java
+++ b/src/main/java/com/dokdok/gathering/service/GatheringValidator.java
@@ -93,21 +93,6 @@ public class GatheringValidator {
                 .orElseThrow(() -> new GatheringException(GatheringErrorCode.GATHERING_NOT_FOUND));
     }
 
-    /**
-     * 이미 모임에 가입했거나 가입 신청을 했는지 검증합니다.
-     */
-	public void validateJoinedGathering(Long gatheringId, Long userId) {
-		gatheringMemberRepository
-				.findByGatheringIdAndUserId(gatheringId, userId)
-				.ifPresent(member -> {
-					if (member.getMemberStatus() == GatheringMemberStatus.ACTIVE) {
-						throw new GatheringException(GatheringErrorCode.ALREADY_GATHERING_MEMBER);
-					} else if (member.getMemberStatus() == GatheringMemberStatus.PENDING) {
-						throw new GatheringException(GatheringErrorCode.JOIN_REQUEST_ALREADY_PENDING);
-					}
-				});
-	}
-
 	/**
 	 * 즐겨찾기 된 모임이 4개 이상인지 검증합니다.
 	 */

--- a/src/test/java/com/dokdok/gathering/service/GatheringServiceTest.java
+++ b/src/test/java/com/dokdok/gathering/service/GatheringServiceTest.java
@@ -1036,7 +1036,6 @@ class GatheringServiceTest {
 
 		securityUtilMock.verify(SecurityUtil::getCurrentUserEntity, times(1));
 		verify(gatheringValidator, times(1)).validateInvitationLink(invitationLink);
-		verify(gatheringValidator, times(1)).validateJoinedGathering(1L, 3L);
 		verify(gatheringMemberRepository, times(1)).save(any(GatheringMember.class));
 	}
 
@@ -1058,7 +1057,6 @@ class GatheringServiceTest {
 
 		securityUtilMock.verify(SecurityUtil::getCurrentUserEntity, times(1));
 		verify(gatheringValidator, times(1)).validateInvitationLink(invalidLink);
-		verify(gatheringValidator, times(0)).validateJoinedGathering(any(), any());
 		verify(gatheringMemberRepository, times(0)).save(any());
 	}
 
@@ -1071,8 +1069,8 @@ class GatheringServiceTest {
 		securityUtilMock.when(SecurityUtil::getCurrentUserEntity).thenReturn(member);
 
 		given(gatheringValidator.validateInvitationLink(invitationLink)).willReturn(gathering1);
-		doThrow(new GatheringException(GatheringErrorCode.ALREADY_GATHERING_MEMBER))
-				.when(gatheringValidator).validateJoinedGathering(1L, 2L);
+		given(gatheringMemberRepository.findByGatheringIdAndUserId(1L, 2L))
+				.willReturn(Optional.of(normalMember));
 
 		// when & then
 		assertThatThrownBy(() -> gatheringService.joinGathering(invitationLink))
@@ -1081,7 +1079,6 @@ class GatheringServiceTest {
 
 		securityUtilMock.verify(SecurityUtil::getCurrentUserEntity, times(1));
 		verify(gatheringValidator, times(1)).validateInvitationLink(invitationLink);
-		verify(gatheringValidator, times(1)).validateJoinedGathering(1L, 2L);
 		verify(gatheringMemberRepository, times(0)).save(any());
 	}
 
@@ -1094,8 +1091,8 @@ class GatheringServiceTest {
 		securityUtilMock.when(SecurityUtil::getCurrentUserEntity).thenReturn(pendingUser);
 
 		given(gatheringValidator.validateInvitationLink(invitationLink)).willReturn(gathering1);
-		doThrow(new GatheringException(GatheringErrorCode.JOIN_REQUEST_ALREADY_PENDING))
-				.when(gatheringValidator).validateJoinedGathering(1L, 4L);
+		given(gatheringMemberRepository.findByGatheringIdAndUserId(1L, 4L))
+				.willReturn(Optional.of(pendingMember));
 
 		// when & then
 		assertThatThrownBy(() -> gatheringService.joinGathering(invitationLink))
@@ -1104,7 +1101,6 @@ class GatheringServiceTest {
 
 		securityUtilMock.verify(SecurityUtil::getCurrentUserEntity, times(1));
 		verify(gatheringValidator, times(1)).validateInvitationLink(invitationLink);
-		verify(gatheringValidator, times(1)).validateJoinedGathering(1L, 4L);
 		verify(gatheringMemberRepository, times(0)).save(any());
 	}
 


### PR DESCRIPTION
## PR 요약
> 이 PR이 어떤 변경을 하는지 간단히 설명하고, 체크 표시는 괄호 사이에 소문자 'x'를 삽입하세요.

- [ ] 기능 추가
- [x] 버그 수정
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 기타 (설명)

---

## 이슈 번호
- #364 

---

## 주요 변경 사항
> 주요 파일, 로직, 컴포넌트 등을 구체적으로 적어주세요.

- `GatheringValidator`: 기존 가입 요청 vaildator 삭제
- `GatheringService`: vaildator의 역할을 Service에서 수행하면서 상태가 Reject 이라면 다시 Pending상태로 돌려놓도록 로직수정 (사용자의 상태를 바꾸기때문에 Vaildator가 아닌 Servie로 이동)
- `GatheringMember`: Status를 Reject에서 Pending 상태로 바꾸는 메서드 추가

---

## 참고 사항
> 리뷰어가 알아야 할 추가 정보, 테스트 방법 등을 작성해주세요.

예:  
- 테스트 계정 정보  
- 관련 API 엔드포인트  
- 로컬 테스트 방법  

---