### PR TITLE
[#368] 사전의견 임시저장 및 스케쥴링 추가

### DIFF
--- a/src/main/java/com/dokdok/book/dto/response/BookReviewResponse.java
+++ b/src/main/java/com/dokdok/book/dto/response/BookReviewResponse.java
@@ -39,6 +39,16 @@ public record BookReviewResponse(
         );
     }
 
+    public static BookReviewResponse of(
+            Long reviewId,
+            Long bookId,
+            Long userId,
+            BigDecimal rating,
+            List<KeywordInfo> keywords
+    ) {
+        return new BookReviewResponse(reviewId, bookId, userId, rating, keywords);
+    }
+
     @Schema(description = "리뷰 키워드 정보")
     public record KeywordInfo(
             @Schema(description = "키워드 ID", example = "3")

--- a/src/main/java/com/dokdok/meeting/repository/MeetingRepository.java
+++ b/src/main/java/com/dokdok/meeting/repository/MeetingRepository.java
@@ -117,6 +117,22 @@ public interface MeetingRepository extends JpaRepository<Meeting, Long> {
             MeetingStatus meetingStatus
     );
 
+    // Scheduler용: 시작 시간이 지났고 임시저장 사전의견이 있는 CONFIRMED 상태의 Meeting 조회
+    @Query("""
+            SELECT DISTINCT m
+            FROM Meeting m
+            JOIN FETCH m.book b
+            JOIN Topic t ON t.meeting = m
+            JOIN TopicAnswer ta ON ta.topic = t
+            WHERE m.meetingStartDate <= :now
+            AND m.meetingStatus = :meetingStatus
+            AND ta.isSubmitted = false
+            """)
+    List<Meeting> findStartedMeetingsWithDraftPreOpinions(
+            @Param("now") LocalDateTime now,
+            @Param("meetingStatus") MeetingStatus meetingStatus
+    );
+
     Optional<Meeting> findTopByGatheringIdAndBookIdAndMeetingStatusOrderByMeetingStartDateDescIdDesc(
             Long gatheringId,
             Long bookId,

--- a/src/main/java/com/dokdok/meeting/scheduler/MeetingStatusScheduler.java
+++ b/src/main/java/com/dokdok/meeting/scheduler/MeetingStatusScheduler.java
@@ -3,6 +3,7 @@ package com.dokdok.meeting.scheduler;
 import com.dokdok.meeting.entity.Meeting;
 import com.dokdok.meeting.entity.MeetingStatus;
 import com.dokdok.meeting.repository.MeetingRepository;
+import com.dokdok.topic.service.PreOpinionAutoShareService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -23,6 +24,7 @@ import java.util.List;
 public class MeetingStatusScheduler {
 
     private final MeetingRepository meetingRepository;
+    private final PreOpinionAutoShareService preOpinionAutoShareService;
 
     /**
      * 종료 시간이 지난 모임의 상태를 자동으로 DONE으로 변경
@@ -31,6 +33,8 @@ public class MeetingStatusScheduler {
     @Scheduled(cron = "0 */10 * * * *")
     @Transactional
     public void updateExpiredMeetings() {
+        autoShareStartedMeetings();
+
         long startTime = System.currentTimeMillis();
         
         LocalDateTime now = LocalDateTime.now();
@@ -65,5 +69,36 @@ public class MeetingStatusScheduler {
         log.info("[Scheduler] Throughput: {} meetings/sec", 
                  duration > 0 ? (count * 1000.0 / duration) : count);
         log.info("[Scheduler] ========================================");
+    }
+
+    private void autoShareStartedMeetings() {
+        LocalDateTime now = LocalDateTime.now();
+        List<Meeting> startedMeetings = meetingRepository
+                .findStartedMeetingsWithDraftPreOpinions(now, MeetingStatus.CONFIRMED);
+
+        if (startedMeetings.isEmpty()) {
+            log.info("[Scheduler] No started meetings for pre-opinion auto share.");
+            return;
+        }
+
+        int submittedAnswerCount = 0;
+        int submittedUserCount = 0;
+        int appliedReviewCount = 0;
+
+        for (Meeting meeting : startedMeetings) {
+            try {
+                PreOpinionAutoShareService.AutoShareResult result =
+                        preOpinionAutoShareService.autoShareDrafts(meeting);
+                submittedAnswerCount += result.submittedAnswerCount();
+                submittedUserCount += result.submittedUserCount();
+                appliedReviewCount += result.appliedReviewCount();
+            } catch (Exception e) {
+                log.error("[Scheduler] Failed to auto-share pre-opinions for meeting {}: {}",
+                        meeting.getId(), e.getMessage());
+            }
+        }
+
+        log.info("[Scheduler] Auto-shared pre-opinions for {} meetings: answers={}, users={}, reviews={}",
+                startedMeetings.size(), submittedAnswerCount, submittedUserCount, appliedReviewCount);
     }
 }

--- a/src/main/java/com/dokdok/topic/api/TopicAnswerApi.java
+++ b/src/main/java/com/dokdok/topic/api/TopicAnswerApi.java
@@ -31,9 +31,10 @@ public interface TopicAnswerApi {
     @Operation(
             summary = "토픽 답변 일괄 저장 (developer: 양재웅)",
             description = """
-            토픽 답변과 책 평가를 일괄 저장합니다.
+            토픽 답변과 사전의견 전용 책 평가를 임시 저장합니다.
             - 권한: 모임 구성원
             - 제약: 제출 완료된 답변은 수정 불가
+            - 책 평가는 사전의견 작성 화면에만 저장되며, 내 책장 리뷰에는 반영되지 않습니다.
             """,
             parameters = {
                     @Parameter(name = "gatheringId", description = "모임 식별자", in = ParameterIn.PATH, required = true),
@@ -88,6 +89,7 @@ public interface TopicAnswerApi {
             description = """
             현재 로그인 사용자의 사전 의견 작성 화면 정보를 조회합니다.
             - 권한: 모임 구성원
+            - review는 내 책장 리뷰가 아니라 사전의견 전용 책 평가입니다.
             """,
             parameters = {
                     @Parameter(name = "gatheringId", description = "모임 식별자", in = ParameterIn.PATH, required = true),
@@ -129,9 +131,10 @@ public interface TopicAnswerApi {
     @Operation(
             summary = "토픽 답변 일괄 저장 (developer: 양재웅)",
             description = """
-            현재 로그인 사용자의 토픽 답변과 책 평가를 일괄 저장합니다.
+            현재 로그인 사용자의 토픽 답변과 사전의견 전용 책 평가를 임시 저장합니다.
             - 권한: 모임 구성원
             - 제약: 제출 완료된 답변은 수정 불가
+            - 책 평가는 사전의견 작성 화면에만 저장되며, 내 책장 리뷰에는 반영되지 않습니다.
             """,
             parameters = {
                     @Parameter(name = "gatheringId", description = "모임 식별자", in = ParameterIn.PATH, required = true),
@@ -182,11 +185,13 @@ public interface TopicAnswerApi {
     );
 
     @Operation(
-            summary = "토픽 답변 일괄 제출 (developer: 양재웅)",
+            summary = "토픽 답변 일괄 제출/공유 (developer: 양재웅)",
             description = """
-            현재 로그인 사용자의 토픽 답변과 책 평가를 일괄 제출합니다.
+            현재 로그인 사용자의 토픽 답변을 제출하고 책 평가를 공유합니다.
             - 권한: 모임 구성원
             - 제약: 제출 완료된 답변은 재제출 불가
+            - 책 평가는 사전의견 전용 저장소에 저장된 뒤, 실제 내 책장 리뷰에도 반영됩니다.
+            - 응답의 reviewId는 사전의견 전용 책 평가 ID입니다.
             """,
             parameters = {
                     @Parameter(name = "gatheringId", description = "모임 식별자", in = ParameterIn.PATH, required = true),

--- a/src/main/java/com/dokdok/topic/dto/request/TopicAnswerBulkSaveRequest.java
+++ b/src/main/java/com/dokdok/topic/dto/request/TopicAnswerBulkSaveRequest.java
@@ -13,7 +13,7 @@ import java.util.List;
 public record TopicAnswerBulkSaveRequest(
         @NotNull
         @Valid
-        @Schema(description = "책 평가 정보")
+        @Schema(description = "사전의견 전용 책 평가 정보. 저장 시 내 책장 리뷰에는 반영되지 않습니다.")
         BookReviewRequest review,
         @NotEmpty
         @Valid

--- a/src/main/java/com/dokdok/topic/dto/request/TopicAnswerBulkSubmitRequest.java
+++ b/src/main/java/com/dokdok/topic/dto/request/TopicAnswerBulkSubmitRequest.java
@@ -12,7 +12,7 @@ import java.util.List;
 public record TopicAnswerBulkSubmitRequest(
         @NotNull
         @Valid
-        @Schema(description = "책 평가 정보")
+        @Schema(description = "공유할 책 평가 정보. 제출 시 사전의견 전용 저장소와 내 책장 리뷰에 반영됩니다.")
         BookReviewRequest review,
         @NotEmpty
         @Schema(description = "제출할 토픽 ID 목록", example = "[1,2,3]")

--- a/src/main/java/com/dokdok/topic/dto/response/PreOpinionSaveResponse.java
+++ b/src/main/java/com/dokdok/topic/dto/response/PreOpinionSaveResponse.java
@@ -7,7 +7,7 @@ import java.util.List;
 
 @Schema(description = "사전 의견 일괄 저장 응답")
 public record PreOpinionSaveResponse(
-        @Schema(description = "책 평가 응답")
+        @Schema(description = "사전의견 전용 책 평가 응답")
         BookReviewResponse review,
         @Schema(description = "토픽 답변 저장 결과")
         List<TopicAnswerResponse> answers

--- a/src/main/java/com/dokdok/topic/dto/response/PreOpinionSubmitResponse.java
+++ b/src/main/java/com/dokdok/topic/dto/response/PreOpinionSubmitResponse.java
@@ -7,7 +7,7 @@ import java.util.List;
 
 @Schema(description = "사전 의견 일괄 제출 응답")
 public record PreOpinionSubmitResponse(
-        @Schema(description = "책 평가 응답")
+        @Schema(description = "사전의견 전용 책 평가 응답. 책장 리뷰에도 같은 내용이 반영됩니다.")
         BookReviewResponse review,
         @Schema(description = "토픽 답변 제출 결과")
         List<TopicAnswerSubmitResponse> answers

--- a/src/main/java/com/dokdok/topic/dto/response/TopicAnswerDetailResponse.java
+++ b/src/main/java/com/dokdok/topic/dto/response/TopicAnswerDetailResponse.java
@@ -14,7 +14,7 @@ import java.util.List;
 public record TopicAnswerDetailResponse(
         @Schema(description = "책 정보")
         BookInfo book,
-        @Schema(description = "책 평가 정보")
+        @Schema(description = "사전의견 전용 책 평가 정보")
         BookReviewResponse review,
         @Schema(description = "사전 의견 정보")
         PreOpinion preOpinion

--- a/src/main/java/com/dokdok/topic/entity/PreOpinionBookReview.java
+++ b/src/main/java/com/dokdok/topic/entity/PreOpinionBookReview.java
@@ -1,0 +1,133 @@
+package com.dokdok.topic.entity;
+
+import com.dokdok.book.entity.Book;
+import com.dokdok.global.BaseTimeEntity;
+import com.dokdok.keyword.entity.Keyword;
+import com.dokdok.meeting.entity.Meeting;
+import com.dokdok.user.entity.User;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Entity
+@Table(name = "pre_opinion_book_review")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@SuperBuilder
+@SQLDelete(sql = "UPDATE pre_opinion_book_review SET deleted_at = CURRENT_TIMESTAMP WHERE pre_opinion_book_review_id = ?")
+@SQLRestriction("deleted_at IS NULL")
+public class PreOpinionBookReview extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "pre_opinion_book_review_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "meeting_id", nullable = false)
+    private Meeting meeting;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "book_id", nullable = false)
+    private Book book;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(name = "rating", precision = 2, scale = 1)
+    private BigDecimal rating;
+
+    @OneToMany(mappedBy = "preOpinionBookReview", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Builder.Default
+    private List<PreOpinionBookReviewKeyword> keywords = new ArrayList<>();
+
+    public static PreOpinionBookReview create(
+            Meeting meeting,
+            Book book,
+            User user,
+            BigDecimal rating,
+            List<Keyword> keywords
+    ) {
+        PreOpinionBookReview review = PreOpinionBookReview.builder()
+                .meeting(meeting)
+                .book(book)
+                .user(user)
+                .rating(rating)
+                .build();
+        review.replaceKeywords(keywords);
+        return review;
+    }
+
+    public void updateReview(BigDecimal rating, List<Keyword> keywords) {
+        boolean ratingChanged = !Objects.equals(this.rating, rating);
+        boolean keywordsChanged = updateKeywords(keywords);
+
+        if (ratingChanged) {
+            this.rating = rating;
+        }
+
+        if (ratingChanged || keywordsChanged) {
+            this.touch();
+        }
+    }
+
+    public void deleteReview() {
+        this.markDeletedNow();
+    }
+
+    private void replaceKeywords(List<Keyword> keywords) {
+        this.keywords = new ArrayList<>();
+        for (Keyword keyword : keywords) {
+            this.keywords.add(PreOpinionBookReviewKeyword.create(this, keyword));
+        }
+    }
+
+    private boolean updateKeywords(List<Keyword> newKeywords) {
+        Set<Long> newKeywordIds = newKeywords.stream()
+                .map(Keyword::getId)
+                .collect(Collectors.toSet());
+
+        Set<Long> existingKeywordIds = this.keywords.stream()
+                .map(reviewKeyword -> reviewKeyword.getKeyword().getId())
+                .collect(Collectors.toSet());
+
+        boolean hasChanges = !newKeywordIds.equals(existingKeywordIds);
+
+        if (hasChanges) {
+            this.keywords.removeIf(reviewKeyword -> !newKeywordIds.contains(reviewKeyword.getKeyword().getId()));
+
+            for (Keyword keyword : newKeywords) {
+                if (!existingKeywordIds.contains(keyword.getId())) {
+                    this.keywords.add(PreOpinionBookReviewKeyword.create(this, keyword));
+                }
+            }
+        }
+
+        return hasChanges;
+    }
+}

--- a/src/main/java/com/dokdok/topic/entity/PreOpinionBookReviewKeyword.java
+++ b/src/main/java/com/dokdok/topic/entity/PreOpinionBookReviewKeyword.java
@@ -1,0 +1,57 @@
+package com.dokdok.topic.entity;
+
+import com.dokdok.keyword.entity.Keyword;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "pre_opinion_book_review_keyword")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class PreOpinionBookReviewKeyword {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "pre_opinion_book_review_keyword_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "pre_opinion_book_review_id", nullable = false)
+    private PreOpinionBookReview preOpinionBookReview;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "keyword_id", nullable = false)
+    private Keyword keyword;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    public static PreOpinionBookReviewKeyword create(PreOpinionBookReview preOpinionBookReview, Keyword keyword) {
+        return PreOpinionBookReviewKeyword.builder()
+                .preOpinionBookReview(preOpinionBookReview)
+                .keyword(keyword)
+                .build();
+    }
+
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/dokdok/topic/repository/PreOpinionBookReviewRepository.java
+++ b/src/main/java/com/dokdok/topic/repository/PreOpinionBookReviewRepository.java
@@ -1,0 +1,44 @@
+package com.dokdok.topic.repository;
+
+import com.dokdok.topic.entity.PreOpinionBookReview;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface PreOpinionBookReviewRepository extends JpaRepository<PreOpinionBookReview, Long> {
+
+    @Query("""
+            SELECT DISTINCT review
+            FROM PreOpinionBookReview review
+            LEFT JOIN FETCH review.keywords reviewKeyword
+            LEFT JOIN FETCH reviewKeyword.keyword
+            JOIN FETCH review.book
+            JOIN FETCH review.user
+            WHERE review.meeting.id = :meetingId
+            AND review.user.id = :userId
+            """)
+    Optional<PreOpinionBookReview> findByMeetingIdAndUserId(
+            @Param("meetingId") Long meetingId,
+            @Param("userId") Long userId
+    );
+
+    @Query("""
+            SELECT DISTINCT review
+            FROM PreOpinionBookReview review
+            LEFT JOIN FETCH review.keywords reviewKeyword
+            LEFT JOIN FETCH reviewKeyword.keyword
+            JOIN FETCH review.book
+            JOIN FETCH review.user
+            WHERE review.meeting.id = :meetingId
+            AND review.user.id IN :userIds
+            """)
+    List<PreOpinionBookReview> findByMeetingIdAndUserIdIn(
+            @Param("meetingId") Long meetingId,
+            @Param("userIds") List<Long> userIds
+    );
+}

--- a/src/main/java/com/dokdok/topic/repository/PreOpinionBookReviewRepository.java
+++ b/src/main/java/com/dokdok/topic/repository/PreOpinionBookReviewRepository.java
@@ -41,4 +41,15 @@ public interface PreOpinionBookReviewRepository extends JpaRepository<PreOpinion
             @Param("meetingId") Long meetingId,
             @Param("userIds") List<Long> userIds
     );
+
+    @Query("""
+            SELECT DISTINCT review
+            FROM PreOpinionBookReview review
+            LEFT JOIN FETCH review.keywords reviewKeyword
+            LEFT JOIN FETCH reviewKeyword.keyword
+            JOIN FETCH review.book
+            JOIN FETCH review.user
+            WHERE review.meeting.id = :meetingId
+            """)
+    List<PreOpinionBookReview> findByMeetingId(@Param("meetingId") Long meetingId);
 }

--- a/src/main/java/com/dokdok/topic/repository/TopicAnswerRepository.java
+++ b/src/main/java/com/dokdok/topic/repository/TopicAnswerRepository.java
@@ -95,6 +95,16 @@ public interface TopicAnswerRepository extends JpaRepository<TopicAnswer, Long> 
     List<TopicAnswer> findByMeetingId(Long meetingId);
 
     @Query("""
+                    SELECT ta
+                    FROM TopicAnswer ta
+                    JOIN FETCH ta.user u
+                    JOIN FETCH ta.topic t
+                    WHERE t.meeting.id = :meetingId
+                    AND ta.isSubmitted = false
+            """)
+    List<TopicAnswer> findDraftsByMeetingId(@Param("meetingId") Long meetingId);
+
+    @Query("""
         SELECT ta
         FROM TopicAnswer ta
         JOIN FETCH ta.topic t

--- a/src/main/java/com/dokdok/topic/service/PreOpinionAutoShareService.java
+++ b/src/main/java/com/dokdok/topic/service/PreOpinionAutoShareService.java
@@ -1,0 +1,48 @@
+package com.dokdok.topic.service;
+
+import com.dokdok.meeting.entity.Meeting;
+import com.dokdok.topic.entity.TopicAnswer;
+import com.dokdok.topic.repository.TopicAnswerRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class PreOpinionAutoShareService {
+
+    private final TopicAnswerRepository topicAnswerRepository;
+    private final PreOpinionBookReviewService preOpinionBookReviewService;
+
+    @Transactional
+    public AutoShareResult autoShareDrafts(Meeting meeting) {
+        List<TopicAnswer> draftAnswers = topicAnswerRepository.findDraftsByMeetingId(meeting.getId());
+        if (draftAnswers.isEmpty()) {
+            return AutoShareResult.empty(meeting.getId());
+        }
+
+        draftAnswers.forEach(TopicAnswer::submit);
+
+        Set<Long> userIds = draftAnswers.stream()
+                .map(answer -> answer.getUser().getId())
+                .collect(Collectors.toSet());
+        int appliedReviewCount = preOpinionBookReviewService.applyToPersonalBookReviews(meeting.getId(), userIds);
+
+        return new AutoShareResult(meeting.getId(), draftAnswers.size(), userIds.size(), appliedReviewCount);
+    }
+
+    public record AutoShareResult(
+            Long meetingId,
+            int submittedAnswerCount,
+            int submittedUserCount,
+            int appliedReviewCount
+    ) {
+        private static AutoShareResult empty(Long meetingId) {
+            return new AutoShareResult(meetingId, 0, 0, 0);
+        }
+    }
+}

--- a/src/main/java/com/dokdok/topic/service/PreOpinionBookReviewService.java
+++ b/src/main/java/com/dokdok/topic/service/PreOpinionBookReviewService.java
@@ -1,0 +1,114 @@
+package com.dokdok.topic.service;
+
+import com.dokdok.book.dto.request.BookReviewRequest;
+import com.dokdok.book.dto.response.BookReviewResponse;
+import com.dokdok.book.entity.Book;
+import com.dokdok.book.exception.BookErrorCode;
+import com.dokdok.book.exception.BookException;
+import com.dokdok.book.repository.BookReviewRepository;
+import com.dokdok.book.service.BookReviewService;
+import com.dokdok.book.service.BookValidator;
+import com.dokdok.global.util.SecurityUtil;
+import com.dokdok.keyword.entity.Keyword;
+import com.dokdok.keyword.service.KeywordValidator;
+import com.dokdok.meeting.entity.Meeting;
+import com.dokdok.meeting.service.MeetingValidator;
+import com.dokdok.topic.entity.PreOpinionBookReview;
+import com.dokdok.topic.entity.PreOpinionBookReviewKeyword;
+import com.dokdok.topic.repository.PreOpinionBookReviewRepository;
+import com.dokdok.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class PreOpinionBookReviewService {
+
+    private final PreOpinionBookReviewRepository preOpinionBookReviewRepository;
+    private final BookReviewRepository bookReviewRepository;
+    private final BookReviewService bookReviewService;
+    private final MeetingValidator meetingValidator;
+    private final BookValidator bookValidator;
+    private final KeywordValidator keywordValidator;
+
+    @Transactional
+    public BookReviewResponse upsertReview(Long meetingId, BookReviewRequest request) {
+        Long userId = SecurityUtil.getCurrentUserId();
+        User user = SecurityUtil.getCurrentUserEntity();
+
+        Meeting meeting = meetingValidator.findMeetingOrThrow(meetingId);
+        Book book = meeting.getBook();
+        if (book == null) {
+            throw new BookException(BookErrorCode.BOOK_NOT_FOUND);
+        }
+
+        bookValidator.validateRating(request.rating());
+        List<Keyword> keywords = request.keywordIds().stream()
+                .map(keywordValidator::validateAndGetSelectableKeyword)
+                .collect(Collectors.toList());
+
+        PreOpinionBookReview review = preOpinionBookReviewRepository.findByMeetingIdAndUserId(meetingId, userId)
+                .map(existing -> {
+                    existing.updateReview(request.rating(), keywords);
+                    return existing;
+                })
+                .orElseGet(() -> preOpinionBookReviewRepository.save(
+                        PreOpinionBookReview.create(meeting, book, user, request.rating(), keywords)
+                ));
+
+        return toResponse(review);
+    }
+
+    @Transactional(readOnly = true)
+    public BookReviewResponse findMyReview(Long meetingId) {
+        Long userId = SecurityUtil.getCurrentUserId();
+        return preOpinionBookReviewRepository.findByMeetingIdAndUserId(meetingId, userId)
+                .map(this::toResponse)
+                .orElse(null);
+    }
+
+    @Transactional
+    public void deleteMyReview(Long meetingId) {
+        Long userId = SecurityUtil.getCurrentUserId();
+        preOpinionBookReviewRepository.findByMeetingIdAndUserId(meetingId, userId)
+                .ifPresent(PreOpinionBookReview::deleteReview);
+    }
+
+    @Transactional
+    public BookReviewResponse applyToPersonalBookReview(Long meetingId, BookReviewRequest request) {
+        Long userId = SecurityUtil.getCurrentUserId();
+        Meeting meeting = meetingValidator.findMeetingOrThrow(meetingId);
+        Book book = meeting.getBook();
+        if (book == null) {
+            throw new BookException(BookErrorCode.BOOK_NOT_FOUND);
+        }
+
+        boolean exists = bookReviewRepository.findByBookIdAndUserId(book.getId(), userId).isPresent();
+        return exists
+                ? bookReviewService.updateMyReview(book.getId(), request)
+                : bookReviewService.createReview(book.getId(), request);
+    }
+
+    private BookReviewResponse toResponse(PreOpinionBookReview review) {
+        List<BookReviewResponse.KeywordInfo> keywordInfos = review.getKeywords().stream()
+                .map(PreOpinionBookReviewKeyword::getKeyword)
+                .map(keyword -> new BookReviewResponse.KeywordInfo(
+                        keyword.getId(),
+                        keyword.getKeywordName(),
+                        keyword.getKeywordType()
+                ))
+                .toList();
+
+        return BookReviewResponse.of(
+                review.getId(),
+                review.getBook().getId(),
+                review.getUser().getId(),
+                review.getRating(),
+                keywordInfos
+        );
+    }
+}

--- a/src/main/java/com/dokdok/topic/service/PreOpinionBookReviewService.java
+++ b/src/main/java/com/dokdok/topic/service/PreOpinionBookReviewService.java
@@ -3,6 +3,7 @@ package com.dokdok.topic.service;
 import com.dokdok.book.dto.request.BookReviewRequest;
 import com.dokdok.book.dto.response.BookReviewResponse;
 import com.dokdok.book.entity.Book;
+import com.dokdok.book.entity.BookReview;
 import com.dokdok.book.exception.BookErrorCode;
 import com.dokdok.book.exception.BookException;
 import com.dokdok.book.repository.BookReviewRepository;
@@ -22,6 +23,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 @Service
@@ -91,6 +93,42 @@ public class PreOpinionBookReviewService {
         return exists
                 ? bookReviewService.updateMyReview(book.getId(), request)
                 : bookReviewService.createReview(book.getId(), request);
+    }
+
+    @Transactional
+    public int applyToPersonalBookReviews(Long meetingId, Set<Long> userIds) {
+        if (userIds.isEmpty()) {
+            return 0;
+        }
+
+        List<PreOpinionBookReview> reviews = preOpinionBookReviewRepository
+                .findByMeetingIdAndUserIdIn(meetingId, List.copyOf(userIds));
+
+        for (PreOpinionBookReview preOpinionReview : reviews) {
+            applyToPersonalBookReview(preOpinionReview);
+        }
+
+        return reviews.size();
+    }
+
+    private void applyToPersonalBookReview(PreOpinionBookReview preOpinionReview) {
+        List<Keyword> keywords = preOpinionReview.getKeywords().stream()
+                .map(PreOpinionBookReviewKeyword::getKeyword)
+                .toList();
+
+        bookReviewRepository.findByBookIdAndUserId(
+                        preOpinionReview.getBook().getId(),
+                        preOpinionReview.getUser().getId()
+                )
+                .ifPresentOrElse(
+                        existing -> existing.updateReview(preOpinionReview.getRating(), keywords),
+                        () -> bookReviewRepository.save(BookReview.create(
+                                preOpinionReview.getBook(),
+                                preOpinionReview.getUser(),
+                                preOpinionReview.getRating(),
+                                keywords
+                        ))
+                );
     }
 
     private BookReviewResponse toResponse(PreOpinionBookReview review) {

--- a/src/main/java/com/dokdok/topic/service/PreOpinionService.java
+++ b/src/main/java/com/dokdok/topic/service/PreOpinionService.java
@@ -1,9 +1,5 @@
 package com.dokdok.topic.service;
 
-import com.dokdok.book.entity.BookReview;
-import com.dokdok.book.entity.BookReviewKeyword;
-import com.dokdok.book.repository.BookReviewKeywordRepository;
-import com.dokdok.book.repository.BookReviewRepository;
 import com.dokdok.gathering.entity.GatheringMember;
 import com.dokdok.gathering.entity.GatheringRole;
 import com.dokdok.gathering.repository.GatheringMemberRepository;
@@ -16,9 +12,12 @@ import com.dokdok.meeting.service.MeetingValidator;
 import com.dokdok.storage.service.StorageService;
 import com.dokdok.topic.dto.response.PreOpinionResponse;
 import com.dokdok.topic.dto.response.PreOpinionResponse.BookReviewInfo;
+import com.dokdok.topic.entity.PreOpinionBookReview;
+import com.dokdok.topic.entity.PreOpinionBookReviewKeyword;
 import com.dokdok.topic.entity.TopicAnswer;
 import com.dokdok.topic.exception.TopicErrorCode;
 import com.dokdok.topic.exception.TopicException;
+import com.dokdok.topic.repository.PreOpinionBookReviewRepository;
 import com.dokdok.topic.repository.TopicAnswerRepository;
 import com.dokdok.topic.repository.TopicRepository;
 import com.dokdok.user.entity.User;
@@ -41,8 +40,8 @@ public class PreOpinionService {
     private final TopicRepository topicRepository;
     private final MeetingMemberRepository meetingMemberRepository;
     private final TopicAnswerRepository topicAnswerRepository;
-    private final BookReviewRepository bookReviewRepository;
-    private final BookReviewKeywordRepository bookReviewKeywordRepository;
+    private final PreOpinionBookReviewRepository preOpinionBookReviewRepository;
+    private final PreOpinionBookReviewService preOpinionBookReviewService;
     private final StorageService storageService;
 
     @Transactional(readOnly = true)
@@ -72,6 +71,7 @@ public class PreOpinionService {
         List<TopicAnswer> topicAnswers = topicValidator.getTopicAnswers(meetingId, userId);
 
         topicAnswers.forEach(TopicAnswer::softDelete);
+        preOpinionBookReviewService.deleteMyReview(meetingId);
     }
 
     private void validateAccess(Long gatheringId, Long meetingId, Long userId) {
@@ -99,8 +99,7 @@ public class PreOpinionService {
 
     private record PreOpinionMaps(
             Map<Long, GatheringRole> gatheringRoleByUserId,
-            Map<Long, BookReview> bookReviewByUserId,
-            Map<Long, List<BookReviewKeyword>> keywordsByReviewId,
+            Map<Long, PreOpinionBookReview> bookReviewByUserId,
             Map<Long, List<PreOpinionResponse.TopicOpinion>> topicAnswersByUserId
     ) {}
 
@@ -117,19 +116,12 @@ public class PreOpinionService {
                         (existing, replacement) -> existing
                 ));
 
-        Map<Long, BookReview> bookReviewByUserId = bookReviewRepository.findByUserIdIn(userIds, meetingId).stream()
+        Map<Long, PreOpinionBookReview> bookReviewByUserId = preOpinionBookReviewRepository.findByMeetingIdAndUserIdIn(meetingId, userIds).stream()
                 .collect(Collectors.toMap(
                         br -> br.getUser().getId(),
                         br -> br,
                         (existing, replacement) -> existing
                 ));
-
-        List<Long> bookReviewIds = bookReviewByUserId.values().stream()
-                .map(BookReview::getId)
-                .toList();
-        Map<Long, List<BookReviewKeyword>> keywordsByReviewId = bookReviewKeywordRepository
-                .findByBookReviewIds(bookReviewIds).stream()
-                .collect(Collectors.groupingBy(k -> k.getBookReview().getId()));
 
         List<TopicAnswer> allTopicAnswers = topicAnswerRepository.findByMeetingId(meetingId);
 
@@ -146,7 +138,6 @@ public class PreOpinionService {
         return new PreOpinionMaps(
                 gatheringRoleByUserId,
                 bookReviewByUserId,
-                keywordsByReviewId,
                 topicAnswersByUserId
         );
     }
@@ -167,14 +158,15 @@ public class PreOpinionService {
         PreOpinionResponse.MemberInfo memberInfo
                 = PreOpinionResponse.MemberInfo.of(user.getId(), user.getNickname(), presignedUrl, role);
 
-        BookReview review = maps.bookReviewByUserId().get(memberId);
-        BookReviewInfo bookReviewInfo = review != null
-                ? toBookReviewInfo(review, maps.keywordsByReviewId())
+        boolean isSubmitted = maps.topicAnswersByUserId().containsKey(memberId);
+        PreOpinionBookReview review = maps.bookReviewByUserId().get(memberId);
+        BookReviewInfo bookReviewInfo = review != null && isSubmitted
+                ? toBookReviewInfo(review)
                 : null;
 
         List<PreOpinionResponse.TopicOpinion> topicAnswers = maps.topicAnswersByUserId().getOrDefault(memberId, List.of());
 
-        return new PreOpinionResponse.MemberPreOpinion(memberInfo, bookReviewInfo, topicAnswers, maps.topicAnswersByUserId().containsKey(memberId));
+        return new PreOpinionResponse.MemberPreOpinion(memberInfo, bookReviewInfo, topicAnswers, isSubmitted);
     }
 
     /**
@@ -198,17 +190,14 @@ public class PreOpinionService {
      * - 사전의견을 발행하지 않은 사용자는 책 평가도 반환하지 않음
      */
     private BookReviewInfo toBookReviewInfo(
-            BookReview bookReview,
-            Map<Long, List<BookReviewKeyword>> keywordsByReviewId
+            PreOpinionBookReview bookReview
     ) {
-        List<BookReviewKeyword> reviewKeywords =
-                keywordsByReviewId.getOrDefault(bookReview.getId(), List.of());
-
-        List<PreOpinionResponse.KeywordInfo> keywordInfos = reviewKeywords.stream()
-                .map(rk -> PreOpinionResponse.KeywordInfo.of(
-                        rk.getKeyword().getId(),
-                        rk.getKeyword().getKeywordName(),
-                        rk.getKeyword().getKeywordType()
+        List<PreOpinionResponse.KeywordInfo> keywordInfos = bookReview.getKeywords().stream()
+                .map(PreOpinionBookReviewKeyword::getKeyword)
+                .map(keyword -> PreOpinionResponse.KeywordInfo.of(
+                        keyword.getId(),
+                        keyword.getKeywordName(),
+                        keyword.getKeywordType()
                 ))
                 .toList();
 

--- a/src/main/java/com/dokdok/topic/service/TopicAnswerService.java
+++ b/src/main/java/com/dokdok/topic/service/TopicAnswerService.java
@@ -2,10 +2,6 @@ package com.dokdok.topic.service;
 
 import com.dokdok.book.dto.request.BookReviewRequest;
 import com.dokdok.book.dto.response.BookReviewResponse;
-import com.dokdok.book.exception.BookErrorCode;
-import com.dokdok.book.exception.BookException;
-import com.dokdok.book.repository.BookReviewRepository;
-import com.dokdok.book.service.BookReviewService;
 import com.dokdok.gathering.service.GatheringValidator;
 import com.dokdok.global.util.SecurityUtil;
 import com.dokdok.meeting.service.MeetingValidator;
@@ -39,8 +35,7 @@ public class TopicAnswerService {
 
     private final TopicAnswerRepository topicAnswerRepository;
     private final TopicRepository topicRepository;
-    private final BookReviewRepository bookReviewRepository;
-    private final BookReviewService bookReviewService;
+    private final PreOpinionBookReviewService preOpinionBookReviewService;
     private final GatheringValidator gatheringValidator;
     private final MeetingValidator meetingValidator;
 
@@ -89,10 +84,7 @@ public class TopicAnswerService {
         TopicAnswerDetailResponse.BookInfo bookInfo = TopicAnswerDetailResponse.BookInfo.from(meeting.getBook());
         BookReviewResponse reviewResponse = null;
         if (meeting.getBook() != null) {
-            Long bookId = meeting.getBook().getId();
-            reviewResponse = bookReviewRepository.findByBookIdAndUserId(bookId, userId)
-                    .map(BookReviewResponse::from)
-                    .orElse(null);
+            reviewResponse = preOpinionBookReviewService.findMyReview(meetingId);
         }
         TopicAnswerDetailResponse.PreOpinion preOpinion =
                 new TopicAnswerDetailResponse.PreOpinion(latestUpdatedAt, topicInfos);
@@ -204,6 +196,7 @@ public class TopicAnswerService {
         }
 
         BookReviewResponse reviewResponse = upsertReview(meetingId, request.review());
+        preOpinionBookReviewService.applyToPersonalBookReview(meetingId, request.review());
 
         List<TopicAnswerSubmitResponse> responses = topicIds.stream()
                 .map(topicId -> {
@@ -217,17 +210,7 @@ public class TopicAnswerService {
     }
 
     private BookReviewResponse upsertReview(Long meetingId, BookReviewRequest request) {
-        Long userId = SecurityUtil.getCurrentUserId();
-        var meeting = meetingValidator.findMeetingOrThrow(meetingId);
-        Long bookId = meeting.getBook() != null ? meeting.getBook().getId() : null;
-        if (bookId == null) {
-            throw new BookException(BookErrorCode.BOOK_NOT_FOUND);
-        }
-
-        boolean exists = bookReviewRepository.findByBookIdAndUserId(bookId, userId).isPresent();
-        return exists
-                ? bookReviewService.updateMyReview(bookId, request)
-                : bookReviewService.createReview(bookId, request);
+        return preOpinionBookReviewService.upsertReview(meetingId, request);
     }
 
 }

--- a/src/main/resources/data/pre_opinion_book_review.sql
+++ b/src/main/resources/data/pre_opinion_book_review.sql
@@ -1,0 +1,35 @@
+CREATE TABLE IF NOT EXISTS pre_opinion_book_review (
+    pre_opinion_book_review_id BIGSERIAL PRIMARY KEY,
+    meeting_id BIGINT NOT NULL,
+    book_id BIGINT NOT NULL,
+    user_id BIGINT NOT NULL,
+    rating NUMERIC(2, 1),
+    created_at TIMESTAMP,
+    updated_at TIMESTAMP,
+    deleted_at TIMESTAMP,
+    CONSTRAINT fk_pre_opinion_book_review_meeting
+        FOREIGN KEY (meeting_id) REFERENCES meeting (meeting_id),
+    CONSTRAINT fk_pre_opinion_book_review_book
+        FOREIGN KEY (book_id) REFERENCES book (book_id),
+    CONSTRAINT fk_pre_opinion_book_review_user
+        FOREIGN KEY (user_id) REFERENCES users (user_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_pre_opinion_book_review_meeting_user
+    ON pre_opinion_book_review (meeting_id, user_id)
+    WHERE deleted_at IS NULL;
+
+CREATE TABLE IF NOT EXISTS pre_opinion_book_review_keyword (
+    pre_opinion_book_review_keyword_id BIGSERIAL PRIMARY KEY,
+    pre_opinion_book_review_id BIGINT NOT NULL,
+    keyword_id BIGINT NOT NULL,
+    created_at TIMESTAMP NOT NULL,
+    CONSTRAINT fk_pre_opinion_book_review_keyword_review
+        FOREIGN KEY (pre_opinion_book_review_id)
+        REFERENCES pre_opinion_book_review (pre_opinion_book_review_id),
+    CONSTRAINT fk_pre_opinion_book_review_keyword_keyword
+        FOREIGN KEY (keyword_id) REFERENCES keyword (keyword_id)
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_pre_opinion_book_review_keyword
+    ON pre_opinion_book_review_keyword (pre_opinion_book_review_id, keyword_id);

--- a/src/test/java/com/dokdok/topic/service/PreOpinionServiceTest.java
+++ b/src/test/java/com/dokdok/topic/service/PreOpinionServiceTest.java
@@ -44,7 +44,6 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;

--- a/src/test/java/com/dokdok/topic/service/PreOpinionServiceTest.java
+++ b/src/test/java/com/dokdok/topic/service/PreOpinionServiceTest.java
@@ -1,10 +1,7 @@
 package com.dokdok.topic.service;
 
-import com.dokdok.book.entity.BookReview;
-import com.dokdok.book.entity.BookReviewKeyword;
+import com.dokdok.book.entity.Book;
 import com.dokdok.book.entity.KeywordType;
-import com.dokdok.book.repository.BookReviewKeywordRepository;
-import com.dokdok.book.repository.BookReviewRepository;
 import com.dokdok.gathering.entity.GatheringMember;
 import com.dokdok.gathering.entity.GatheringRole;
 import com.dokdok.gathering.repository.GatheringMemberRepository;
@@ -17,11 +14,14 @@ import com.dokdok.meeting.repository.MeetingMemberRepository;
 import com.dokdok.meeting.service.MeetingValidator;
 import com.dokdok.storage.service.StorageService;
 import com.dokdok.topic.dto.response.PreOpinionResponse;
+import com.dokdok.topic.entity.PreOpinionBookReview;
+import com.dokdok.topic.entity.PreOpinionBookReviewKeyword;
 import com.dokdok.topic.entity.Topic;
 import com.dokdok.topic.entity.TopicAnswer;
 import com.dokdok.topic.entity.TopicType;
 import com.dokdok.topic.exception.TopicErrorCode;
 import com.dokdok.topic.exception.TopicException;
+import com.dokdok.topic.repository.PreOpinionBookReviewRepository;
 import com.dokdok.topic.repository.TopicAnswerRepository;
 import com.dokdok.topic.repository.TopicRepository;
 import com.dokdok.user.entity.User;
@@ -76,10 +76,10 @@ class PreOpinionServiceTest {
     private TopicAnswerRepository topicAnswerRepository;
 
     @Mock
-    private BookReviewRepository bookReviewRepository;
+    private PreOpinionBookReviewRepository preOpinionBookReviewRepository;
 
     @Mock
-    private BookReviewKeywordRepository bookReviewKeywordRepository;
+    private PreOpinionBookReviewService preOpinionBookReviewService;
 
     @Mock
     private StorageService storageService;
@@ -169,11 +169,13 @@ class PreOpinionServiceTest {
         return answer;
     }
 
-    private BookReview createBookReview(Long id, User user, BigDecimal rating) {
-        return BookReview.builder()
+    private PreOpinionBookReview createBookReview(Long id, User user, BigDecimal rating) {
+        return PreOpinionBookReview.builder()
                 .id(id)
+                .book(Book.builder().id(10L).build())
                 .user(user)
                 .rating(rating)
+                .keywords(new java.util.ArrayList<>())
                 .build();
     }
 
@@ -186,13 +188,15 @@ class PreOpinionServiceTest {
                 .build();
     }
 
-    private BookReviewKeyword createBookReviewKeyword(Long id, BookReview review, Keyword keyword) {
-        return BookReviewKeyword.builder()
+    private PreOpinionBookReviewKeyword createBookReviewKeyword(Long id, PreOpinionBookReview review, Keyword keyword) {
+        PreOpinionBookReviewKeyword reviewKeyword = PreOpinionBookReviewKeyword.builder()
                 .id(id)
-                .bookReview(review)
+                .preOpinionBookReview(review)
                 .keyword(keyword)
                 .createdAt(LocalDateTime.now())
                 .build();
+        review.getKeywords().add(reviewKeyword);
+        return reviewKeyword;
     }
 
     @Test
@@ -214,7 +218,7 @@ class PreOpinionServiceTest {
                 LocalDateTime.of(2025, 1, 1, 10, 0)
         );
 
-        BookReview review1 = createBookReview(300L, user1, new BigDecimal("4.5"));
+        PreOpinionBookReview review1 = createBookReview(300L, user1, new BigDecimal("4.5"));
 
         GatheringMember gm1 = createGatheringMember(1L, user1, GatheringRole.LEADER);
         GatheringMember gm2 = createGatheringMember(2L, user2, GatheringRole.MEMBER);
@@ -222,8 +226,7 @@ class PreOpinionServiceTest {
         given(topicRepository.findConfirmedTopics(MEETING_ID)).willReturn(List.of(topic));
         given(meetingMemberRepository.findAllByMeetingIdOrderByTopicAnswerDate(MEETING_ID)).willReturn(List.of(mm1, mm2));
         given(gatheringMemberRepository.findAllMembersByGatheringId(GATHERING_ID)).willReturn(List.of(gm1, gm2));
-        given(bookReviewRepository.findByUserIdIn(anyList(), anyLong())).willReturn(List.of(review1));
-        given(bookReviewKeywordRepository.findByBookReviewIds(anyList())).willReturn(List.of());
+        given(preOpinionBookReviewRepository.findByMeetingIdAndUserIdIn(anyLong(), anyList())).willReturn(List.of(review1));
         given(topicAnswerRepository.findByMeetingId(MEETING_ID)).willReturn(List.of(answer1));
         given(storageService.getPresignedProfileImage(anyString())).willReturn(PRESIGNED_URL);
 
@@ -292,8 +295,7 @@ class PreOpinionServiceTest {
         given(meetingMemberRepository.findAllByMeetingIdOrderByTopicAnswerDate(MEETING_ID))
                 .willReturn(List.of(mm1, mm3, mm2));
         given(gatheringMemberRepository.findAllMembersByGatheringId(GATHERING_ID)).willReturn(List.of(gm1, gm2, gm3));
-        given(bookReviewRepository.findByUserIdIn(anyList(), anyLong())).willReturn(List.of());
-        given(bookReviewKeywordRepository.findByBookReviewIds(anyList())).willReturn(List.of());
+        given(preOpinionBookReviewRepository.findByMeetingIdAndUserIdIn(anyLong(), anyList())).willReturn(List.of());
         given(topicAnswerRepository.findByMeetingId(MEETING_ID)).willReturn(List.of(answer1, answer3));
         given(storageService.getPresignedProfileImage(anyString())).willReturn(PRESIGNED_URL);
 
@@ -324,8 +326,7 @@ class PreOpinionServiceTest {
         given(topicRepository.findConfirmedTopics(MEETING_ID)).willReturn(List.of(topic));
         given(meetingMemberRepository.findAllByMeetingIdOrderByTopicAnswerDate(MEETING_ID)).willReturn(List.of(mm1));
         given(gatheringMemberRepository.findAllMembersByGatheringId(GATHERING_ID)).willReturn(List.of(gm1));
-        given(bookReviewRepository.findByUserIdIn(anyList(), anyLong())).willReturn(List.of());
-        given(bookReviewKeywordRepository.findByBookReviewIds(anyList())).willReturn(List.of());
+        given(preOpinionBookReviewRepository.findByMeetingIdAndUserIdIn(anyLong(), anyList())).willReturn(List.of());
         given(topicAnswerRepository.findByMeetingId(MEETING_ID)).willReturn(List.of());
         given(storageService.getPresignedProfileImage(anyString())).willReturn(PRESIGNED_URL);
 
@@ -354,8 +355,7 @@ class PreOpinionServiceTest {
         given(topicRepository.findConfirmedTopics(MEETING_ID)).willReturn(List.of(topic));
         given(meetingMemberRepository.findAllByMeetingIdOrderByTopicAnswerDate(MEETING_ID)).willReturn(List.of(mm1));
         given(gatheringMemberRepository.findAllMembersByGatheringId(GATHERING_ID)).willReturn(List.of(gm1));
-        given(bookReviewRepository.findByUserIdIn(anyList(), anyLong())).willReturn(List.of());
-        given(bookReviewKeywordRepository.findByBookReviewIds(anyList())).willReturn(List.of());
+        given(preOpinionBookReviewRepository.findByMeetingIdAndUserIdIn(anyLong(), anyList())).willReturn(List.of());
         given(topicAnswerRepository.findByMeetingId(MEETING_ID)).willReturn(List.of());
         given(storageService.getPresignedProfileImage(anyString())).willReturn(PRESIGNED_URL);
 
@@ -384,8 +384,7 @@ class PreOpinionServiceTest {
         given(topicRepository.findConfirmedTopics(MEETING_ID)).willReturn(List.of(topic));
         given(meetingMemberRepository.findAllByMeetingIdOrderByTopicAnswerDate(MEETING_ID)).willReturn(List.of(mm1));
         given(gatheringMemberRepository.findAllMembersByGatheringId(GATHERING_ID)).willReturn(List.of(gm1));
-        given(bookReviewRepository.findByUserIdIn(anyList(), anyLong())).willReturn(List.of());
-        given(bookReviewKeywordRepository.findByBookReviewIds(anyList())).willReturn(List.of());
+        given(preOpinionBookReviewRepository.findByMeetingIdAndUserIdIn(anyLong(), anyList())).willReturn(List.of());
         given(topicAnswerRepository.findByMeetingId(MEETING_ID)).willReturn(List.of());
         given(storageService.getPresignedProfileImage(anyString())).willReturn(PRESIGNED_URL);
 
@@ -414,21 +413,20 @@ class PreOpinionServiceTest {
                 LocalDateTime.of(2025, 1, 1, 10, 0)
         );
 
-        BookReview review1 = createBookReview(300L, user1, new BigDecimal("4.0"));
+        PreOpinionBookReview review1 = createBookReview(300L, user1, new BigDecimal("4.0"));
 
         Keyword keyword1 = createKeyword(10L, "판타지", KeywordType.BOOK);
         Keyword keyword2 = createKeyword(20L, "감동적인", KeywordType.IMPRESSION);
 
-        BookReviewKeyword brk1 = createBookReviewKeyword(1L, review1, keyword1);
-        BookReviewKeyword brk2 = createBookReviewKeyword(2L, review1, keyword2);
+        createBookReviewKeyword(1L, review1, keyword1);
+        createBookReviewKeyword(2L, review1, keyword2);
 
         GatheringMember gm1 = createGatheringMember(1L, user1, GatheringRole.MEMBER);
 
         given(topicRepository.findConfirmedTopics(MEETING_ID)).willReturn(List.of(topic));
         given(meetingMemberRepository.findAllByMeetingIdOrderByTopicAnswerDate(MEETING_ID)).willReturn(List.of(mm1));
         given(gatheringMemberRepository.findAllMembersByGatheringId(GATHERING_ID)).willReturn(List.of(gm1));
-        given(bookReviewRepository.findByUserIdIn(anyList(), anyLong())).willReturn(List.of(review1));
-        given(bookReviewKeywordRepository.findByBookReviewIds(List.of(300L))).willReturn(List.of(brk1, brk2));
+        given(preOpinionBookReviewRepository.findByMeetingIdAndUserIdIn(anyLong(), anyList())).willReturn(List.of(review1));
         given(topicAnswerRepository.findByMeetingId(MEETING_ID)).willReturn(List.of(answer1));
         given(storageService.getPresignedProfileImage(anyString())).willReturn(PRESIGNED_URL);
 

--- a/src/test/java/com/dokdok/topic/service/TopicAnswerServiceTest.java
+++ b/src/test/java/com/dokdok/topic/service/TopicAnswerServiceTest.java
@@ -2,10 +2,7 @@ package com.dokdok.topic.service;
 
 import com.dokdok.book.dto.request.BookReviewRequest;
 import com.dokdok.book.dto.response.BookReviewResponse;
-import com.dokdok.book.repository.BookReviewRepository;
-import com.dokdok.book.service.BookReviewService;
 import com.dokdok.gathering.service.GatheringValidator;
-import com.dokdok.meeting.entity.Meeting;
 import com.dokdok.meeting.service.MeetingValidator;
 import com.dokdok.topic.dto.request.TopicAnswerBulkSaveRequest;
 import com.dokdok.topic.dto.request.TopicAnswerBulkSubmitRequest;
@@ -20,7 +17,6 @@ import com.dokdok.user.entity.User;
 import com.dokdok.global.exception.GlobalException;
 import java.util.List;
 import java.math.BigDecimal;
-import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -38,6 +34,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 
@@ -57,10 +54,7 @@ class TopicAnswerServiceTest {
     private MeetingValidator meetingValidator;
 
     @Mock
-    private BookReviewRepository bookReviewRepository;
-
-    @Mock
-    private BookReviewService bookReviewService;
+    private PreOpinionBookReviewService preOpinionBookReviewService;
 
     @InjectMocks
     private TopicAnswerService topicAnswerService;
@@ -106,12 +100,8 @@ class TopicAnswerServiceTest {
                 .willReturn(List.of());
         given(topicAnswerRepository.save(any(TopicAnswer.class)))
                 .willReturn(saved);
-        given(meetingValidator.findMeetingOrThrow(1L))
-                .willReturn(Meeting.builder().book(com.dokdok.book.entity.Book.builder().id(10L).build()).build());
-        given(bookReviewRepository.findByBookIdAndUserId(10L, 1L))
-                .willReturn(Optional.empty());
         BookReviewResponse reviewResponse = new BookReviewResponse(1L, 10L, 1L, BigDecimal.valueOf(4.5), List.of());
-        given(bookReviewService.createReview(eq(10L), any(BookReviewRequest.class)))
+        given(preOpinionBookReviewService.upsertReview(eq(1L), any(BookReviewRequest.class)))
                 .willReturn(reviewResponse);
 
         TopicAnswerBulkSaveRequest request = new TopicAnswerBulkSaveRequest(
@@ -125,6 +115,7 @@ class TopicAnswerServiceTest {
 
         ArgumentCaptor<TopicAnswer> captor = ArgumentCaptor.forClass(TopicAnswer.class);
         verify(topicAnswerRepository).save(captor.capture());
+        verify(preOpinionBookReviewService, never()).applyToPersonalBookReview(eq(1L), any(BookReviewRequest.class));
 
         TopicAnswer captured = captor.getValue();
         assertThat(captured.getTopic()).isEqualTo(topic);
@@ -185,11 +176,7 @@ class TopicAnswerServiceTest {
                 .willReturn(List.of(topic));
         given(topicAnswerRepository.findByMeetingIdUserId(1L, 1L))
                 .willReturn(List.of(answer));
-        given(meetingValidator.findMeetingOrThrow(1L))
-                .willReturn(Meeting.builder().book(com.dokdok.book.entity.Book.builder().id(10L).build()).build());
-        given(bookReviewRepository.findByBookIdAndUserId(10L, 1L))
-                .willReturn(Optional.empty());
-        given(bookReviewService.createReview(eq(10L), any(BookReviewRequest.class)))
+        given(preOpinionBookReviewService.upsertReview(eq(1L), any(BookReviewRequest.class)))
                 .willReturn(new BookReviewResponse(1L, 10L, 1L, BigDecimal.valueOf(4.5), List.of()));
 
         TopicAnswerBulkSaveRequest request = new TopicAnswerBulkSaveRequest(
@@ -202,6 +189,7 @@ class TopicAnswerServiceTest {
         );
 
         assertThat(answer.getContent()).isEqualTo("수정된 내용");
+        verify(preOpinionBookReviewService, never()).applyToPersonalBookReview(eq(1L), any(BookReviewRequest.class));
         assertThat(response.answers()).hasSize(1);
         assertThat(response.answers().get(0).topicId()).isEqualTo(12L);
         assertThat(response.answers().get(0).isSubmitted()).isFalse();
@@ -224,11 +212,7 @@ class TopicAnswerServiceTest {
                 .willReturn(List.of(topic));
         given(topicAnswerRepository.findByMeetingIdUserId(1L, 1L))
                 .willReturn(List.of(answer));
-        given(meetingValidator.findMeetingOrThrow(1L))
-                .willReturn(Meeting.builder().book(com.dokdok.book.entity.Book.builder().id(10L).build()).build());
-        given(bookReviewRepository.findByBookIdAndUserId(10L, 1L))
-                .willReturn(Optional.empty());
-        given(bookReviewService.createReview(eq(10L), any(BookReviewRequest.class)))
+        given(preOpinionBookReviewService.upsertReview(eq(1L), any(BookReviewRequest.class)))
                 .willReturn(new BookReviewResponse(1L, 10L, 1L, BigDecimal.valueOf(4.5), List.of()));
 
         TopicAnswerBulkSaveRequest request = new TopicAnswerBulkSaveRequest(
@@ -258,11 +242,7 @@ class TopicAnswerServiceTest {
                 .willReturn(List.of(topic));
         given(topicAnswerRepository.findByMeetingIdUserId(1L, 1L))
                 .willReturn(List.of(answer));
-        given(meetingValidator.findMeetingOrThrow(1L))
-                .willReturn(Meeting.builder().book(com.dokdok.book.entity.Book.builder().id(10L).build()).build());
-        given(bookReviewRepository.findByBookIdAndUserId(10L, 1L))
-                .willReturn(Optional.empty());
-        given(bookReviewService.createReview(eq(10L), any(BookReviewRequest.class)))
+        given(preOpinionBookReviewService.upsertReview(eq(1L), any(BookReviewRequest.class)))
                 .willReturn(new BookReviewResponse(1L, 10L, 1L, BigDecimal.valueOf(4.5), List.of()));
 
         TopicAnswerBulkSubmitRequest request = new TopicAnswerBulkSubmitRequest(
@@ -272,6 +252,7 @@ class TopicAnswerServiceTest {
         PreOpinionSubmitResponse response =
                 topicAnswerService.submitMyAnswer(1L, 1L, request);
 
+        verify(preOpinionBookReviewService).applyToPersonalBookReview(eq(1L), any(BookReviewRequest.class));
         assertThat(answer.getIsSubmitted()).isTrue();
         assertThat(response.answers()).hasSize(1);
         assertThat(response.answers().get(0).topicId()).isEqualTo(12L);


### PR DESCRIPTION
## PR 요약

  > 이 PR이 어떤 변경을 하는지 간단히 설명하고, 체크 표시는 괄호 사이에 소문자 'x'를 삽입하세요.                                                                                     

  - [x] 기능 추가
  - [x] 버그 수정
  - [ ] 코드 리팩토링
  - [x] 문서 수정
  - [ ] 기타 (설명)

  사전의견 책 평가가 실제 내 책장 리뷰에 즉시 반영되던 문제를 수정했습니다.
  임시저장 시에는 사전의견 전용 테이블에만 저장하고, 공유하기 또는 약속 당일 자동 공유 시 실제 책장 리뷰에 반영되도록 변경했습니다.

  ———

  ## 이슈 번호

  - #368 

  ———

  ## 주요 변경 사항

  > 주요 파일, 로직, 컴포넌트 등을 구체적으로 적어주세요.                                                                                                                            

  - PreOpinionBookReview, PreOpinionBookReviewKeyword: 사전의견 전용 책 평가와 키워드 저장 엔티티 추가
  - PreOpinionBookReviewRepository: 사전의견 전용 책 평가 조회 repository 추가
  - PreOpinionBookReviewService: 사전의견 책 평가 저장/조회 및 실제 book_review 반영 로직 추가
  - TopicAnswerService: 임시저장 시 사전의견 전용 저장소만 사용하고, 제출/공유 시 실제 책장 리뷰에도 반영되도록 변경
  - PreOpinionService: 사전의견 목록 조회 시 기존 book_review가 아닌 사전의견 전용 책 평가를 조회하도록 변경
  - PreOpinionAutoShareService: 약속 시작 시간이 지난 임시저장 사전의견을 자동 공유 처리하는 서비스 추가
  - MeetingStatusScheduler: 기존 약속 종료 상태 변경 스케줄러에 사전의견 자동 공유 처리 추가
  - MeetingRepository, TopicAnswerRepository: 자동 공유 대상 약속 및 임시저장 답변 조회 쿼리 추가
  - TopicAnswerApi 및 관련 DTO Swagger 설명: 임시저장/공유/자동 반영 정책에 맞게 API 문구 수정
  - pre_opinion_book_review.sql: 운영 DB 수동 적용용 사전의견 책 평가 테이블 DDL 추가

  ———

  ## 참고 사항

  > 리뷰어가 알아야 할 추가 정보, 테스트 방법 등을 작성해주세요.                                                                                                                     

  - API 요청/응답 스키마는 기존과 동일하게 유지했습니다.
  - reviewId는 사전의견 저장/조회/제출 응답에서 pre_opinion_book_review_id를 의미합니다.
  - 임시저장 API:
      - POST /api/gatherings/{gatheringId}/meetings/{meetingId}/answers
      - PATCH /api/gatherings/{gatheringId}/meetings/{meetingId}/answers/me
      - 사전의견 전용 테이블에만 저장되며, 내 책장 리뷰에는 반영되지 않습니다.
  - 공유하기 API:
      - PATCH /api/gatherings/{gatheringId}/meetings/{meetingId}/answers/submit
      - 사전의견을 제출 상태로 바꾸고, 책 평가를 실제 book_review에도 반영합니다.
  - 약속 당일 자동 공유:
      - 스케줄러가 시작 시간이 지난 CONFIRMED 약속 중 임시저장 답변이 있는 약속을 찾아 자동 제출 처리합니다.
      - 자동 공유 시에도 사전의견 책 평가가 실제 book_review에 반영됩니다.
  - 운영/ddl-auto: none 환경에서는 src/main/resources/data/pre_opinion_book_review.sql 적용이 필요합니다.

  테스트:

  ./gradlew test
