### PR TITLE
[#370][FIX] 참가 중인 약속이 있으면 약속 참가 불가 로직

### DIFF
--- a/src/main/java/com/dokdok/meeting/exception/MeetingErrorCode.java
+++ b/src/main/java/com/dokdok/meeting/exception/MeetingErrorCode.java
@@ -28,6 +28,8 @@ public enum MeetingErrorCode implements BaseErrorCode {
     MEETING_UPDATE_NOT_ALLOWED("M017", "약속 시작 24시간 이내에는 수정할 수 없습니다.", HttpStatus.BAD_REQUEST),
     MEETING_NOT_CONFIRMED("M018", "약속이 확정된 경우에만 주제를 제안할 수 있습니다.", HttpStatus.BAD_REQUEST),
     MEETING_DATE_REQUIRED("M019", "약속 시작/종료 일시는 필수입니다.", HttpStatus.BAD_REQUEST),
+    MEETING_JOIN_REQUIRES_CONFIRMED("M020", "확정된 약속만 참가 신청할 수 있습니다.", HttpStatus.BAD_REQUEST),
+    MEETING_JOIN_TIME_CONFLICT("M021", "동일 시간대의 다른 약속에 이미 참가 중입니다.", HttpStatus.BAD_REQUEST),
 
     INVALID_MAX_PARTICIPANTS("M013", "최대 참가 인원은 1명 이상이어야 하며, 모임 전체 인원을 초과할 수 없습니다.", HttpStatus.BAD_REQUEST),
     MAX_PARTICIPANTS_LESS_THAN_CURRENT("M014", "현재 참가 확정된 인원 수보다 적게 수정할 수 없습니다.", HttpStatus.BAD_REQUEST);

--- a/src/main/java/com/dokdok/meeting/repository/MeetingMemberRepository.java
+++ b/src/main/java/com/dokdok/meeting/repository/MeetingMemberRepository.java
@@ -83,6 +83,25 @@ public interface MeetingMemberRepository extends JpaRepository<MeetingMember, Lo
             @Param("userId") Long userId
     );
 
+    @Query("""
+            SELECT COUNT(mm) > 0
+            FROM MeetingMember mm
+            JOIN mm.meeting m
+            WHERE mm.user.id = :userId
+            AND mm.canceledAt IS NULL
+            AND m.id <> :meetingId
+            AND m.meetingStatus = :meetingStatus
+            AND m.meetingStartDate < :endDate
+            AND m.meetingEndDate > :startDate
+            """)
+    boolean existsOverlappingConfirmedMeetingByUserId(
+            @Param("userId") Long userId,
+            @Param("meetingId") Long meetingId,
+            @Param("meetingStatus") MeetingStatus meetingStatus,
+            @Param("startDate") LocalDateTime startDate,
+            @Param("endDate") LocalDateTime endDate
+    );
+
     boolean existsByMeetingIdAndUserId(Long meetingId, Long userId);
 
     @Query("""

--- a/src/main/java/com/dokdok/meeting/service/MeetingService.java
+++ b/src/main/java/com/dokdok/meeting/service/MeetingService.java
@@ -235,6 +235,7 @@ public class MeetingService {
         // 모임장만 거절 가능
         gatheringValidator.validateLeader(meeting.getGathering().getId(), userId);
 
+        validateRejectable(meeting);
         meeting.changeStatus(MeetingStatus.REJECTED);
 
         return MeetingStatusResponse.from(meeting);
@@ -285,6 +286,18 @@ public class MeetingService {
     }
 
     /**
+     * 신청된 약속만 거절 가능하다.
+     */
+    private void validateRejectable(Meeting meeting) {
+        if (meeting.getMeetingStatus() != MeetingStatus.PENDING) {
+            throw new MeetingException(
+                    MeetingErrorCode.INVALID_MEETING_STATUS_CHANGE,
+                    "신청된 약속만 거절할 수 있습니다."
+            );
+        }
+    }
+
+    /**
      * 약속장을 미팅 멤버로 포함하고 역할을 LEADER로 설정한다.
      */
     private void ensureLeaderMember(Meeting meeting) {
@@ -317,7 +330,9 @@ public class MeetingService {
 
         Meeting meeting = meetingValidator.findMeetingOrThrow(meetingId);
 
+        validateJoinableStatus(meeting);
         validateJoinableMeetingStartDate(meeting);
+        validateNoOverlappingJoinedMeeting(meeting, userId);
 
         gatheringValidator.validateMembership(meeting.getGathering().getId(), userId);
 
@@ -545,6 +560,36 @@ public class MeetingService {
         if (meetingStartDate != null
                 && meetingStartDate.isBefore(LocalDateTime.now().plusHours(24))) {
             throw new MeetingException(MeetingErrorCode.MEETING_JOIN_NOT_ALLOWED);
+        }
+    }
+
+    /**
+     * 확정된 약속만 참가 신청 가능
+     */
+    private void validateJoinableStatus(Meeting meeting) {
+        if (meeting.getMeetingStatus() != MeetingStatus.CONFIRMED) {
+            throw new MeetingException(MeetingErrorCode.MEETING_JOIN_REQUIRES_CONFIRMED);
+        }
+    }
+
+    /**
+     * 동일 시간대의 다른 확정 약속에 이미 참가 중이면 참가 신청 불가
+     */
+    private void validateNoOverlappingJoinedMeeting(Meeting meeting, Long userId) {
+        LocalDateTime meetingStartDate = meeting.getMeetingStartDate();
+        LocalDateTime meetingEndDate = meeting.getMeetingEndDate();
+
+        validateMeetingDatesRequired(meetingStartDate, meetingEndDate);
+
+        boolean hasOverlappingMeeting = meetingMemberRepository.existsOverlappingConfirmedMeetingByUserId(
+                userId,
+                meeting.getId(),
+                MeetingStatus.CONFIRMED,
+                meetingStartDate,
+                meetingEndDate
+        );
+        if (hasOverlappingMeeting) {
+            throw new MeetingException(MeetingErrorCode.MEETING_JOIN_TIME_CONFLICT);
         }
     }
 

--- a/src/test/java/com/dokdok/meeting/service/MeetingServiceTest.java
+++ b/src/test/java/com/dokdok/meeting/service/MeetingServiceTest.java
@@ -714,6 +714,66 @@ class MeetingServiceTest {
         }
     }
 
+    @DisplayName("확정 대기 약속은 정상적으로 거절된다.")
+    @Test
+    void givenPendingMeeting_whenReject_thenMeetingStatusChangesToRejected() {
+        // given
+        Long meetingId = 1L;
+        Long gatheringLeaderId = 10L;
+        Meeting pendingMeeting = Meeting.builder()
+                .id(meetingId)
+                .meetingName("Meeting 1")
+                .meetingStatus(MeetingStatus.PENDING)
+                .meetingStartDate(LocalDateTime.now().plusDays(2))
+                .meetingEndDate(LocalDateTime.now().plusDays(2).plusHours(1))
+                .gathering(gathering)
+                .meetingLeader(leader)
+                .build();
+        given(meetingValidator.findMeetingOrThrow(meetingId)).willReturn(pendingMeeting);
+
+        try (MockedStatic<SecurityUtil> securityUtilMock = mockStatic(SecurityUtil.class)) {
+            securityUtilMock.when(SecurityUtil::getCurrentUserId).thenReturn(gatheringLeaderId);
+
+            // when
+            MeetingStatusResponse response = meetingService.rejectMeeting(meetingId);
+
+            // then
+            assertThat(response.meetingId()).isEqualTo(meetingId);
+            assertThat(response.meetingStatus()).isEqualTo(MeetingStatus.REJECTED);
+            assertThat(response.confirmedAt()).isNull();
+        }
+    }
+
+    @DisplayName("약속 시작 24시간 이내의 확정 대기 약속도 서버 에러 없이 거절된다.")
+    @Test
+    void givenPendingMeetingWithin24Hours_whenReject_thenMeetingStatusChangesToRejected() {
+        // given
+        Long meetingId = 1L;
+        Long gatheringLeaderId = 10L;
+        Meeting pendingMeeting = Meeting.builder()
+                .id(meetingId)
+                .meetingName("Meeting 1")
+                .meetingStatus(MeetingStatus.PENDING)
+                .meetingStartDate(LocalDateTime.now().plusHours(23))
+                .meetingEndDate(LocalDateTime.now().plusHours(24))
+                .gathering(gathering)
+                .meetingLeader(leader)
+                .build();
+        given(meetingValidator.findMeetingOrThrow(meetingId)).willReturn(pendingMeeting);
+
+        try (MockedStatic<SecurityUtil> securityUtilMock = mockStatic(SecurityUtil.class)) {
+            securityUtilMock.when(SecurityUtil::getCurrentUserId).thenReturn(gatheringLeaderId);
+
+            // when
+            MeetingStatusResponse response = meetingService.rejectMeeting(meetingId);
+
+            // then
+            assertThat(response.meetingId()).isEqualTo(meetingId);
+            assertThat(response.meetingStatus()).isEqualTo(MeetingStatus.REJECTED);
+            assertThat(response.confirmedAt()).isNull();
+        }
+    }
+
     @DisplayName("확정된 약속은 거절할 수 없다.")
     @Test
     void givenConfirmedMeeting_whenReject_thenThrowMeetingException() {
@@ -748,6 +808,9 @@ class MeetingServiceTest {
         Long userId = 7L;
         Meeting meeting = Meeting.builder()
                 .id(meetingId)
+                .meetingStatus(MeetingStatus.CONFIRMED)
+                .meetingStartDate(LocalDateTime.now().plusDays(3))
+                .meetingEndDate(LocalDateTime.now().plusDays(3).plusHours(2))
                 .gathering(Gathering.builder()
                         .id(1L)
                         .gatheringName("gathering")
@@ -762,6 +825,13 @@ class MeetingServiceTest {
 
         given(meetingValidator.findMeetingOrThrow(meetingId))
                 .willReturn(meeting);
+        given(meetingMemberRepository.existsOverlappingConfirmedMeetingByUserId(
+                userId,
+                meetingId,
+                MeetingStatus.CONFIRMED,
+                meeting.getMeetingStartDate(),
+                meeting.getMeetingEndDate()
+        )).willReturn(false);
         given(meetingMemberRepository.findAnyByMeetingIdAndUserId(meetingId, userId))
                 .willReturn(Optional.empty());
         given(userValidator.findUserOrThrow(userId))
@@ -789,6 +859,9 @@ class MeetingServiceTest {
         Long userId = 7L;
         Meeting meeting = Meeting.builder()
                 .id(meetingId)
+                .meetingStatus(MeetingStatus.CONFIRMED)
+                .meetingStartDate(LocalDateTime.now().plusDays(3))
+                .meetingEndDate(LocalDateTime.now().plusDays(3).plusHours(2))
                 .gathering(Gathering.builder()
                         .id(1L)
                         .gatheringName("gathering")
@@ -799,6 +872,13 @@ class MeetingServiceTest {
 
         given(meetingValidator.findMeetingOrThrow(meetingId))
                 .willReturn(meeting);
+        given(meetingMemberRepository.existsOverlappingConfirmedMeetingByUserId(
+                userId,
+                meetingId,
+                MeetingStatus.CONFIRMED,
+                meeting.getMeetingStartDate(),
+                meeting.getMeetingEndDate()
+        )).willReturn(false);
         given(meetingMemberRepository.findAnyByMeetingIdAndUserId(meetingId, userId))
                 .willReturn(Optional.of(MeetingMember.builder()
                         .meeting(meeting)
@@ -829,6 +909,9 @@ class MeetingServiceTest {
         Integer maxParticipants = 5;
         Meeting meeting = Meeting.builder()
                 .id(meetingId)
+                .meetingStatus(MeetingStatus.CONFIRMED)
+                .meetingStartDate(LocalDateTime.now().plusDays(3))
+                .meetingEndDate(LocalDateTime.now().plusDays(3).plusHours(2))
                 .maxParticipants(maxParticipants)
                 .gathering(Gathering.builder()
                         .id(1L)
@@ -845,6 +928,13 @@ class MeetingServiceTest {
 
         given(meetingValidator.findMeetingOrThrow(meetingId))
                 .willReturn(meeting);
+        given(meetingMemberRepository.existsOverlappingConfirmedMeetingByUserId(
+                userId,
+                meetingId,
+                MeetingStatus.CONFIRMED,
+                meeting.getMeetingStartDate(),
+                meeting.getMeetingEndDate()
+        )).willReturn(false);
         given(meetingMemberRepository.findAnyByMeetingIdAndUserId(meetingId, userId))
                 .willReturn(Optional.of(canceledMember));
 
@@ -871,6 +961,9 @@ class MeetingServiceTest {
         Long userId = 7L;
         Meeting meeting = Meeting.builder()
                 .id(meetingId)
+                .meetingStatus(MeetingStatus.CONFIRMED)
+                .meetingStartDate(LocalDateTime.now().plusDays(3))
+                .meetingEndDate(LocalDateTime.now().plusDays(3).plusHours(2))
                 .gathering(Gathering.builder()
                         .id(1L)
                         .gatheringName("gathering")
@@ -881,6 +974,13 @@ class MeetingServiceTest {
 
         given(meetingValidator.findMeetingOrThrow(meetingId))
                 .willReturn(meeting);
+        given(meetingMemberRepository.existsOverlappingConfirmedMeetingByUserId(
+                userId,
+                meetingId,
+                MeetingStatus.CONFIRMED,
+                meeting.getMeetingStartDate(),
+                meeting.getMeetingEndDate()
+        )).willReturn(false);
         doThrow(new GatheringException(GatheringErrorCode.NOT_GATHERING_MEMBER))
                 .when(gatheringValidator).validateMembership(meeting.getGathering().getId(), userId);
 
@@ -903,6 +1003,9 @@ class MeetingServiceTest {
         Long userId = 7L;
         Meeting meeting = Meeting.builder()
                 .id(meetingId)
+                .meetingStatus(MeetingStatus.CONFIRMED)
+                .meetingStartDate(LocalDateTime.now().plusDays(3))
+                .meetingEndDate(LocalDateTime.now().plusDays(3).plusHours(2))
                 .maxParticipants(2)
                 .gathering(Gathering.builder()
                         .id(1L)
@@ -914,6 +1017,13 @@ class MeetingServiceTest {
 
         given(meetingValidator.findMeetingOrThrow(meetingId))
                 .willReturn(meeting);
+        given(meetingMemberRepository.existsOverlappingConfirmedMeetingByUserId(
+                userId,
+                meetingId,
+                MeetingStatus.CONFIRMED,
+                meeting.getMeetingStartDate(),
+                meeting.getMeetingEndDate()
+        )).willReturn(false);
         given(meetingMemberRepository.findAnyByMeetingIdAndUserId(meetingId, userId))
                 .willReturn(Optional.empty());
         doThrow(new MeetingException(MeetingErrorCode.MEETING_FULL))
@@ -938,7 +1048,9 @@ class MeetingServiceTest {
         Long userId = 7L;
         Meeting meeting = Meeting.builder()
                 .id(meetingId)
+                .meetingStatus(MeetingStatus.CONFIRMED)
                 .meetingStartDate(LocalDateTime.now().plusHours(1))
+                .meetingEndDate(LocalDateTime.now().plusHours(2))
                 .gathering(Gathering.builder()
                         .id(1L)
                         .gatheringName("gathering")
@@ -961,6 +1073,80 @@ class MeetingServiceTest {
             verify(gatheringValidator, never()).validateMembership(any(), any());
             verify(meetingValidator, never()).validateCapacity(any(), any());
             verify(userValidator, never()).findUserOrThrow(any());
+            verify(meetingMemberRepository, never()).save(any());
+        }
+    }
+
+    @DisplayName("확정되지 않은 약속은 참가 신청할 수 없다.")
+    @Test
+    void givenPendingMeeting_whenJoinMeeting_thenThrowException() {
+        Long meetingId = 3L;
+        Long userId = 7L;
+        Meeting meeting = Meeting.builder()
+                .id(meetingId)
+                .meetingStatus(MeetingStatus.PENDING)
+                .meetingStartDate(LocalDateTime.now().plusDays(3))
+                .meetingEndDate(LocalDateTime.now().plusDays(3).plusHours(2))
+                .gathering(Gathering.builder()
+                        .id(1L)
+                        .gatheringName("gathering")
+                        .invitationLink("link")
+                        .build())
+                .book(sampleBook())
+                .build();
+
+        given(meetingValidator.findMeetingOrThrow(meetingId)).willReturn(meeting);
+
+        try (MockedStatic<SecurityUtil> securityUtilMock = mockStatic(SecurityUtil.class)) {
+            securityUtilMock.when(SecurityUtil::getCurrentUserId).thenReturn(userId);
+
+            assertThatThrownBy(() -> meetingService.joinMeeting(meetingId))
+                    .isInstanceOf(MeetingException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(MeetingErrorCode.MEETING_JOIN_REQUIRES_CONFIRMED);
+            verify(gatheringValidator, never()).validateMembership(any(), any());
+            verify(meetingMemberRepository, never()).findAnyByMeetingIdAndUserId(any(), any());
+            verify(meetingValidator, never()).validateCapacity(any(), any());
+        }
+    }
+
+    @DisplayName("동일 시간대의 다른 확정 약속에 이미 참가 중이면 참가 신청에 실패한다.")
+    @Test
+    void givenOverlappingMeetingJoined_whenJoinMeeting_thenThrowException() {
+        Long meetingId = 3L;
+        Long userId = 7L;
+        Meeting meeting = Meeting.builder()
+                .id(meetingId)
+                .meetingStatus(MeetingStatus.CONFIRMED)
+                .meetingStartDate(LocalDateTime.now().plusDays(3))
+                .meetingEndDate(LocalDateTime.now().plusDays(3).plusHours(2))
+                .gathering(Gathering.builder()
+                        .id(1L)
+                        .gatheringName("gathering")
+                        .invitationLink("link")
+                        .build())
+                .book(sampleBook())
+                .build();
+
+        given(meetingValidator.findMeetingOrThrow(meetingId)).willReturn(meeting);
+        given(meetingMemberRepository.existsOverlappingConfirmedMeetingByUserId(
+                userId,
+                meetingId,
+                MeetingStatus.CONFIRMED,
+                meeting.getMeetingStartDate(),
+                meeting.getMeetingEndDate()
+        )).willReturn(true);
+
+        try (MockedStatic<SecurityUtil> securityUtilMock = mockStatic(SecurityUtil.class)) {
+            securityUtilMock.when(SecurityUtil::getCurrentUserId).thenReturn(userId);
+
+            assertThatThrownBy(() -> meetingService.joinMeeting(meetingId))
+                    .isInstanceOf(MeetingException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(MeetingErrorCode.MEETING_JOIN_TIME_CONFLICT);
+            verify(gatheringValidator, never()).validateMembership(any(), any());
+            verify(meetingMemberRepository, never()).findAnyByMeetingIdAndUserId(any(), any());
+            verify(meetingValidator, never()).validateCapacity(any(), any());
             verify(meetingMemberRepository, never()).save(any());
         }
     }


### PR DESCRIPTION
## PR 요약
> 이 PR이 어떤 변경을 하는지 간단히 설명하고, 체크 표시는 괄호 사이에 소문자 'x'를 삽입하세요.

- [ ] 기능 추가
- [x] 버그 수정
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 기타 (설명)

---

## 이슈 번호
- #370

---

## 주요 변경 사항
> 주요 파일, 로직, 컴포넌트 등을 구체적으로 적어주세요.
- `meeting/MeetingService`: 거절은 `PENDING` 상태에서만 가능하도록 서버 검증 추가
- `meeting/MeetingService`: 약속 참가 신청 시 대상 약속이 `CONFIRMED`인지 검증 추가
- `meeting/MeetingService`: 다른 모임 포함 동일 시간대의 다른 확정 약속에 이미 참가 중인지 검증 추가
- `meeting/MeetingMemberRepository`: 사용자 기준 시간 중복 참가 여부 조회 쿼리 추가
- `meeting/MeetingErrorCode`: 참가 상태/시간 중복 검증용 에러 코드(`M020`, `M021`) 추가
- `meeting/MeetingServiceTest`: 거절 성공, 24시간 이내 거절 성공, 미확정 약속 참가 차단, 동일 시간 중복 참가 차단 테스트 추가

---

## 참고 사항
> 리뷰어가 알아야 할 추가 정보, 테스트 방법 등을 작성해주세요.

예:
- 테스트 계정 정보
- 관련 API 엔드포인트
- 로컬 테스트 방법

---
