### PR TITLE
[#373][FEAT] 약속 승인/취소/거절 검증 추가

### DIFF
--- a/docs/ErrorCode.md
+++ b/docs/ErrorCode.md
@@ -130,6 +130,10 @@
 | M017 | MEETING_UPDATE_NOT_ALLOWED | 약속 시작 24시간 이내에는 수정할 수 없습니다. | 400 |
 | M018 | MEETING_NOT_CONFIRMED | 약속이 확정된 경우에만 주제를 제안할 수 있습니다. | 400 |
 | M019 | MEETING_DATE_REQUIRED | 약속 시작/종료 일시는 필수입니다. | 400 |
+| M020 | MEETING_JOIN_REQUIRES_CONFIRMED | 확정된 약속만 참가 신청할 수 있습니다. | 400 |
+| M021 | MEETING_JOIN_TIME_CONFLICT | 동일 시간대의 다른 약속에 이미 참가 중입니다. | 400 |
+| M022 | MEETING_CREATE_NOT_ALLOWED | 약속 시작 24시간 이내의 일정은 신청할 수 없습니다. | 400 |
+| M023 | MEETING_CONFIRM_NOT_ALLOWED | 약속 시작 24시간 이내의 일정은 승인할 수 없습니다. | 400 |
 
 ---
 

--- a/src/main/java/com/dokdok/meeting/exception/MeetingErrorCode.java
+++ b/src/main/java/com/dokdok/meeting/exception/MeetingErrorCode.java
@@ -30,6 +30,8 @@ public enum MeetingErrorCode implements BaseErrorCode {
     MEETING_DATE_REQUIRED("M019", "약속 시작/종료 일시는 필수입니다.", HttpStatus.BAD_REQUEST),
     MEETING_JOIN_REQUIRES_CONFIRMED("M020", "확정된 약속만 참가 신청할 수 있습니다.", HttpStatus.BAD_REQUEST),
     MEETING_JOIN_TIME_CONFLICT("M021", "동일 시간대의 다른 약속에 이미 참가 중입니다.", HttpStatus.BAD_REQUEST),
+    MEETING_CREATE_NOT_ALLOWED("M022", "약속 시작 24시간 이내의 일정은 신청할 수 없습니다.", HttpStatus.BAD_REQUEST),
+    MEETING_CONFIRM_NOT_ALLOWED("M023", "약속 시작 24시간 이내의 일정은 승인할 수 없습니다.", HttpStatus.BAD_REQUEST),
 
     INVALID_MAX_PARTICIPANTS("M013", "최대 참가 인원은 1명 이상이어야 하며, 모임 전체 인원을 초과할 수 없습니다.", HttpStatus.BAD_REQUEST),
     MAX_PARTICIPANTS_LESS_THAN_CURRENT("M014", "현재 참가 확정된 인원 수보다 적게 수정할 수 없습니다.", HttpStatus.BAD_REQUEST);

--- a/src/main/java/com/dokdok/meeting/service/MeetingService.java
+++ b/src/main/java/com/dokdok/meeting/service/MeetingService.java
@@ -187,6 +187,7 @@ public class MeetingService {
         }
 
         validateMeetingDatesRequired(request.meetingStartDate(), request.meetingEndDate());
+        validateCreatableMeetingStartDate(request.meetingStartDate());
 
         // 최대 참가 인원 검증
         validateMaxParticipants(maxParticipants, gathering.getId());
@@ -271,6 +272,9 @@ public class MeetingService {
         if (startDate == null || endDate == null) {
             throw new MeetingException(MeetingErrorCode.MEETING_DATE_REQUIRED,
                     "약속 시작/종료 일시는 필수입니다.");
+        }
+        if (startDate.isBefore(LocalDateTime.now().plusHours(24))) {
+            throw new MeetingException(MeetingErrorCode.MEETING_CONFIRM_NOT_ALLOWED);
         }
         boolean hasOverlappingMeeting = meetingRepository.existsOverlappingMeeting(
                 gatheringId,
@@ -618,6 +622,15 @@ public class MeetingService {
                     MeetingErrorCode.MEETING_DATE_REQUIRED,
                     "약속 시작/종료 일시는 필수입니다."
             );
+        }
+    }
+
+    /**
+     * 약속 시작 24시간 이내 일정은 신청 불가
+     */
+    private void validateCreatableMeetingStartDate(LocalDateTime startDate) {
+        if (startDate != null && startDate.isBefore(LocalDateTime.now().plusHours(24))) {
+            throw new MeetingException(MeetingErrorCode.MEETING_CREATE_NOT_ALLOWED);
         }
     }
 

--- a/src/test/java/com/dokdok/meeting/service/MeetingServiceTest.java
+++ b/src/test/java/com/dokdok/meeting/service/MeetingServiceTest.java
@@ -418,8 +418,8 @@ class MeetingServiceTest {
         MeetingCreateRequest.BookInfo bookInfo = new MeetingCreateRequest.BookInfo(
                 title, authors, publisher, isbn, thumbnail
         );
-        LocalDateTime startDate = LocalDateTime.of(2024, 1, 20, 20, 0);
-        LocalDateTime endDate = LocalDateTime.of(2024, 1, 20, 22, 0);
+        LocalDateTime startDate = LocalDateTime.now().plusDays(3);
+        LocalDateTime endDate = startDate.plusHours(2);
         int memberCount = 5;
         MeetingCreateRequest request = MeetingCreateRequest.builder()
                 .gatheringId(gatheringId)
@@ -529,8 +529,8 @@ class MeetingServiceTest {
         String publisher = "publisher";
         String isbn = "9781234567890";
         String thumbnail = "https://example.com/thumb.jpg";
-        LocalDateTime startDate = LocalDateTime.of(2024, 1, 20, 20, 0);
-        LocalDateTime endDate = LocalDateTime.of(2024, 1, 20, 22, 0);
+        LocalDateTime startDate = LocalDateTime.now().plusDays(3);
+        LocalDateTime endDate = startDate.plusHours(2);
         MeetingCreateRequest.BookInfo bookInfo = new MeetingCreateRequest.BookInfo(
                 title, authors, publisher, isbn, thumbnail
         );
@@ -591,6 +591,44 @@ class MeetingServiceTest {
             // then
             assertThat(response.meetingId()).isEqualTo(25L);
             assertThat(response.book().bookName()).isEqualTo(title);
+        }
+    }
+
+    @DisplayName("약속 시작 24시간 이내 일정은 생성 신청할 수 없다.")
+    @Test
+    void givenMeetingWithin24Hours_whenCreateMeeting_thenThrowException() {
+        // given
+        Long gatheringId = 3L;
+        Long userId = 7L;
+        MeetingCreateRequest.BookInfo bookInfo = new MeetingCreateRequest.BookInfo(
+                "book", "author", "publisher", "9781234567890", "https://example.com/thumb.jpg"
+        );
+        MeetingCreateRequest request = MeetingCreateRequest.builder()
+                .gatheringId(gatheringId)
+                .book(bookInfo)
+                .meetingStartDate(LocalDateTime.now().plusHours(23))
+                .meetingEndDate(LocalDateTime.now().plusHours(25))
+                .build();
+        given(gatheringRepository.findById(gatheringId))
+                .willReturn(Optional.of(Gathering.builder()
+                        .id(gatheringId)
+                        .gatheringName("gathering")
+                        .invitationLink("link")
+                        .build()));
+        given(bookRepository.findByIsbn(bookInfo.isbn()))
+                .willReturn(Optional.of(sampleBook()));
+        given(userValidator.findUserOrThrow(userId))
+                .willReturn(User.builder().id(userId).nickname("leader").build());
+
+        try (MockedStatic<SecurityUtil> securityUtilMock = mockStatic(SecurityUtil.class)) {
+            securityUtilMock.when(SecurityUtil::getCurrentUserId).thenReturn(userId);
+
+            // when + then
+            assertThatThrownBy(() -> meetingService.createMeeting(request))
+                    .isInstanceOf(MeetingException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(MeetingErrorCode.MEETING_CREATE_NOT_ALLOWED);
+            verify(meetingRepository, never()).save(any());
         }
     }
 
@@ -655,6 +693,36 @@ class MeetingServiceTest {
                     .isInstanceOf(MeetingException.class)
                     .extracting("errorCode")
                     .isEqualTo(MeetingErrorCode.INVALID_MEETING_STATUS_CHANGE);
+        }
+    }
+
+    @DisplayName("약속 시작 24시간 이내의 확정 대기 약속은 승인할 수 없다.")
+    @Test
+    void givenPendingMeetingWithin24Hours_whenConfirm_thenThrowMeetingException() {
+        // given
+        Long meetingId = 1L;
+        Long gatheringLeaderId = 10L;
+        Meeting pendingMeeting = Meeting.builder()
+                .id(meetingId)
+                .meetingName("Meeting 1")
+                .meetingStatus(MeetingStatus.PENDING)
+                .meetingStartDate(LocalDateTime.now().plusHours(23))
+                .meetingEndDate(LocalDateTime.now().plusHours(25))
+                .meetingLeader(leader)
+                .gathering(gathering)
+                .build();
+        given(meetingValidator.findMeetingOrThrow(meetingId)).willReturn(pendingMeeting);
+
+        try (MockedStatic<SecurityUtil> securityUtilMock = mockStatic(SecurityUtil.class)) {
+            securityUtilMock.when(SecurityUtil::getCurrentUserId).thenReturn(gatheringLeaderId);
+
+            // when + then
+            assertThatThrownBy(() -> meetingService.confirmMeeting(meetingId))
+                    .isInstanceOf(MeetingException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(MeetingErrorCode.MEETING_CONFIRM_NOT_ALLOWED);
+            verify(meetingRepository, never()).existsOverlappingMeeting(any(), any(), any(), any(), any());
+            verify(meetingMemberRepository, never()).save(any());
         }
     }
 


### PR DESCRIPTION
## PR 요약
> 이 PR이 어떤 변경을 하는지 간단히 설명하고, 체크 표시는 괄호 사이에 소문자 'x'를 삽입하세요.

- [x] 기능 추가
- [ ] 버그 수정
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 기타 (설명)

---

## 이슈 번호
- #373

---

## 주요 변경 사항
> 주요 파일, 로직, 컴포넌트 등을 구체적으로 적어주세요.
- `meeting/MeetingService`: 약속 시작 24시간 이내 일정은 신규 신청 자체를 차단하도록 생성 검증 추가
- `meeting/MeetingService`: `PENDING` 약속이 24시간 이내로 들어간 경우 승인 차단, 거절은 허용하도록 정책 보강
- `meeting/MeetingService`: 거절은 `PENDING` 상태에서만 가능하도록 서버 검증 추가
- `meeting/MeetingService`: 약속 참가 신청 시 대상 약속이 `CONFIRMED`인지 검증 추가
- `meeting/MeetingService`: 다른 모임 포함 동일 시간대의 다른 확정 약속에 이미 참가 중인지 검증 추가
- `meeting/MeetingMemberRepository`: 사용자 기준 시간 중복 참가 여부 조회 쿼리 추가
- `meeting/MeetingErrorCode`: 참가 상태/시간 중복, 24시간 내 생성/승인 제한 검증용 에러 코드(`M020`~`M023`) 추가
- `meeting/MeetingServiceTest`: 24시간 내 생성 차단, 24시간 내 승인 차단, 24시간 내 거절 허용, 미확정 약속 참가 차단, 동일 시간 중복 참가 차단 테스트 추가

- QA 이슈 대응
- 약속 시작 24시간 이내 일정은 신규 신청을 막고, 이미 신청된 `PENDING` 약속이 24시간 이내로 들어간 경우 승인만 차단하고 거절은 허용하도록 정책을 정리했습니다.
- 확정 대기 약속 거절 시 서버 에러 대신 정상 거절 또는 상태 전이 예외가 내려오도록 서버 검증을 보강했습니다.
- 다른 모임의 동일 시간대 약속 중복 참가가 가능하던 문제를 서버에서 차단하도록 수정했습니다.



---

## 참고 사항
> 리뷰어가 알아야 할 추가 정보, 테스트 방법 등을 작성해주세요.

예:
- 테스트 계정 정보
- 관련 API 엔드포인트
- 로컬 테스트 방법

---
