### PR TITLE
[#380][FIX] 내 책장 personal_book 필드 추가

### DIFF
--- a/src/main/java/com/dokdok/book/dto/response/PersonalBookListResponse.java
+++ b/src/main/java/com/dokdok/book/dto/response/PersonalBookListResponse.java
@@ -12,6 +12,7 @@ import java.util.List;
 
 @Builder
 public record PersonalBookListResponse(
+        Long personalBookId,
         Long bookId,
         String title,
         String publisher,
@@ -25,6 +26,7 @@ public record PersonalBookListResponse(
 
     public static PersonalBookListResponse from(PersonalBook entity) {
         return PersonalBookListResponse.builder()
+                .personalBookId(entity.getId())
                 .bookId(entity.getBook().getId())
                 .title(entity.getBook().getBookName())
                 .publisher(entity.getBook().getPublisher())
@@ -43,6 +45,7 @@ public record PersonalBookListResponse(
 
     public static PersonalBookListResponse from(PersonalBookListProjection projection) {
         return PersonalBookListResponse.builder()
+                .personalBookId(projection.getPersonalBookId())
                 .bookId(projection.getBookId())
                 .title(projection.getTitle())
                 .publisher(projection.getPublisher())

--- a/src/main/java/com/dokdok/book/repository/PersonalBookListProjection.java
+++ b/src/main/java/com/dokdok/book/repository/PersonalBookListProjection.java
@@ -5,6 +5,7 @@ import com.dokdok.book.entity.BookReadingStatus;
 import java.math.BigDecimal;
 
 public interface PersonalBookListProjection {
+    Long getPersonalBookId();
     Long getBookId();
     String getTitle();
     String getPublisher();

--- a/src/main/java/com/dokdok/book/repository/PersonalBookRepository.java
+++ b/src/main/java/com/dokdok/book/repository/PersonalBookRepository.java
@@ -20,6 +20,7 @@ public interface PersonalBookRepository extends JpaRepository<PersonalBook, Long
     @Query(
             value = """
                 select
+                    (array_agg(pb.personal_book_id order by pb.added_at desc, pb.personal_book_id desc))[1] as personalBookId,
                     b.book_id as bookId,
                     b.book_name as title,
                     b.publisher as publisher,
@@ -71,6 +72,7 @@ public interface PersonalBookRepository extends JpaRepository<PersonalBook, Long
     @Query(
             value = """
                 select
+                    (array_agg(pb.personal_book_id order by pb.added_at desc, pb.personal_book_id desc))[1] as personalBookId,
                     b.book_id as bookId,
                     b.book_name as title,
                     b.publisher as publisher,

--- a/src/main/java/com/dokdok/book/service/PersonalBookService.java
+++ b/src/main/java/com/dokdok/book/service/PersonalBookService.java
@@ -325,12 +325,18 @@ public class PersonalBookService {
     }
 
     private record CursorProjection(
+            Long personalBookId,
             Long bookId,
             LocalDateTime addedAt,
             BigDecimal rating
     ) implements PersonalBookListProjection {
         private static CursorProjection of(Long bookId, LocalDateTime addedAt, BigDecimal rating) {
-            return new CursorProjection(bookId, addedAt, rating);
+            return new CursorProjection(null, bookId, addedAt, rating);
+        }
+
+        @Override
+        public Long getPersonalBookId() {
+            return personalBookId;
         }
 
         @Override

--- a/src/test/java/com/dokdok/book/service/PersonalBookServiceTest.java
+++ b/src/test/java/com/dokdok/book/service/PersonalBookServiceTest.java
@@ -766,6 +766,11 @@ class PersonalBookServiceTest {
     ) {
         return new PersonalBookListProjection() {
             @Override
+            public Long getPersonalBookId() {
+                return null;
+            }
+
+            @Override
             public Long getBookId() {
                 return bookId;
             }

--- a/src/test/java/com/dokdok/book/service/PersonalBookServiceTest.java
+++ b/src/test/java/com/dokdok/book/service/PersonalBookServiceTest.java
@@ -287,6 +287,11 @@ class PersonalBookServiceTest {
 
         PersonalBookListProjection projection = new PersonalBookListProjection() {
             @Override
+            public Long getPersonalBookId() {
+                return 20L;
+            }
+
+            @Override
             public Long getBookId() {
                 return book.getId();
             }


### PR DESCRIPTION
## PR 요약
> 이 PR이 어떤 변경을 하는지 간단히 설명하고, 체크 표시는 괄호 사이에 소문자 'x'를 삽입하세요.

- [ ] 기능 추가
- [x] 버그 수정
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 기타 (설명)

---

## 이슈 번호
- #380

---

## 주요 변경 사항
> 주요 파일, 로직, 컴포넌트 등을 구체적으로 적어주세요.

- `PersonalBookListProjection`: getPersonalBookId() 메서드 추가 
- `ersonalBookRepository`:array_agg(pb.personal_book_id...)[1] as personalBookId 추가
- PersonalBookListResponse : personalBookId 필드 추가, 두 from() 메서드에 매핑 추가  
- PersonalBookServiceTest : 테스트 projection에 getPersonalBookId() 구현 추가 

---

## 참고 사항
> 리뷰어가 알아야 할 추가 정보, 테스트 방법 등을 작성해주세요.

예:  
- 테스트 계정 정보  
- 관련 API 엔드포인트  
- 로컬 테스트 방법  

---