### PR TITLE
[#385][FEAT] 홈화면 책 탭 카운트 API 추가 및 내 약속 upcoming 카운트 범위 수정

### DIFF
--- a/src/main/java/com/dokdok/book/api/BookApi.java
+++ b/src/main/java/com/dokdok/book/api/BookApi.java
@@ -873,4 +873,41 @@ public interface BookApi {
             @Parameter(description = "내 책장 항목 ID (personal_book PK)", required = true, example = "100")
             @RequestParam Long personalBookId
     );
+
+    @Operation(
+            summary = "홈화면 읽고 있는 책 탭 카운트 조회",
+            description = """
+            로그인 사용자의 전체 책장 탭 카운트를 조회합니다.
+            - 전체(all): 읽는 중 + 읽기 전 + 완독
+            - 약속 전(before): 읽는 중 + 읽기 전 (미완료 상태)
+            - 약속 후(after): 완독 상태
+            - all = before + after 항상 보장
+            """
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "탭 카운트 조회 성공",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = BookReadingTabCountsResponse.class),
+                            examples = @io.swagger.v3.oas.annotations.media.ExampleObject(value = """
+                                    {
+                                      "code": "SUCCESS",
+                                      "message": "읽고 있는 책 탭 카운트 조회 성공",
+                                      "data": {
+                                        "all": 5,
+                                        "before": 3,
+                                        "after": 2
+                                      }
+                                    }
+                                    """))
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 오류",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            examples = @io.swagger.v3.oas.annotations.media.ExampleObject(value = """
+                                    {"code": "E000", "message": "서버 에러가 발생했습니다. 담당자에게 문의 바랍니다.", "data": null}
+                                    """)))
+    })
+    @GetMapping("/reading/tab-counts")
+    ResponseEntity<ApiResponse<BookReadingTabCountsResponse>> getBookReadingTabCounts();
 }

--- a/src/main/java/com/dokdok/book/controller/BookController.java
+++ b/src/main/java/com/dokdok/book/controller/BookController.java
@@ -113,4 +113,10 @@ public class BookController implements BookApi {
         PersonalBookDetailResponse personalBook = personalBookService.updateReadingStatus(personalBookId);
         return ApiResponse.success(personalBook, "읽는 상태 업데이트 성공");
     }
+
+    @Override
+    @GetMapping("/reading/tab-counts")
+    public ResponseEntity<ApiResponse<BookReadingTabCountsResponse>> getBookReadingTabCounts() {
+        return ApiResponse.success(personalBookService.getBookReadingTabCounts(), "읽고 있는 책 탭 카운트 조회 성공");
+    }
 }

--- a/src/main/java/com/dokdok/book/dto/response/BookReadingTabCountsResponse.java
+++ b/src/main/java/com/dokdok/book/dto/response/BookReadingTabCountsResponse.java
@@ -1,0 +1,18 @@
+package com.dokdok.book.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+@Schema(description = "홈화면 읽고 있는 책 탭별 카운트 응답")
+@Builder
+public record BookReadingTabCountsResponse(
+        @Schema(description = "전체 책 수 (읽는 중 + 읽기 전 + 완독)", example = "5")
+        long all,
+
+        @Schema(description = "약속 전 책 수 (읽는 중 + 읽기 전)", example = "3")
+        long before,
+
+        @Schema(description = "약속 후 책 수 (완독)", example = "2")
+        long after
+) {
+}

--- a/src/main/java/com/dokdok/book/service/PersonalBookService.java
+++ b/src/main/java/com/dokdok/book/service/PersonalBookService.java
@@ -4,6 +4,7 @@ import com.dokdok.book.dto.request.BookCreateRequest;
 import com.dokdok.book.dto.request.PersonalBookSortBy;
 import com.dokdok.book.dto.request.PersonalBookSortOrder;
 import com.dokdok.book.dto.response.BookListCursor;
+import com.dokdok.book.dto.response.BookReadingTabCountsResponse;
 import com.dokdok.book.dto.response.PersonalBookCursorPageResponse;
 import com.dokdok.book.dto.response.PersonalBookCreateResponse;
 import com.dokdok.book.dto.response.PersonalBookDetailResponse;
@@ -194,6 +195,18 @@ public class PersonalBookService {
             PersonalBook personalBook = bookValidator.validateInBookShelf(userEntity.getId(), bookId);
             personalBookRepository.delete(personalBook);
         }
+    }
+
+    public BookReadingTabCountsResponse getBookReadingTabCounts() {
+        Long userId = SecurityUtil.getCurrentUserId();
+        PersonalBookStatusCountsResponse counts = buildStatusCounts(userId, null);
+        long before = counts.reading() + counts.pending();
+        long after = counts.completed();
+        return BookReadingTabCountsResponse.builder()
+                .all(counts.total())
+                .before(before)
+                .after(after)
+                .build();
     }
 
     /**

--- a/src/main/java/com/dokdok/meeting/api/MyMeetingListApi.java
+++ b/src/main/java/com/dokdok/meeting/api/MyMeetingListApi.java
@@ -99,7 +99,7 @@ public interface MyMeetingListApi {
             description = """
             로그인 사용자의 내 약속 탭 카운트를 조회합니다.
             - 전체: 확정된 약속 + 완료된 약속
-            - 다가오는 약속: 3일 이내 시작하는 확정된 약속
+            - 다가오는 약속: 확정된 약속 전체 (all = upcoming + done 보장)
             - 완료된 약속: 종료된 약속
             """
     )

--- a/src/main/java/com/dokdok/meeting/dto/MyMeetingTabCountsResponse.java
+++ b/src/main/java/com/dokdok/meeting/dto/MyMeetingTabCountsResponse.java
@@ -9,7 +9,7 @@ public record MyMeetingTabCountsResponse(
         @Schema(description = "전체 약속 수", example = "10")
         int all,
 
-        @Schema(description = "다가오는 약속 수 (3일 이내)", example = "2")
+        @Schema(description = "다가오는 약속 수 (확정된 약속 전체)", example = "2")
         int upcoming,
 
         @Schema(description = "완료된 약속 수", example = "5")

--- a/src/main/java/com/dokdok/meeting/service/MeetingService.java
+++ b/src/main/java/com/dokdok/meeting/service/MeetingService.java
@@ -806,17 +806,14 @@ public class MeetingService {
     @Transactional(readOnly = true)
     public MyMeetingTabCountsResponse getMyMeetingTabCounts() {
         Long userId = SecurityUtil.getCurrentUserId();
-        LocalDateTime now = LocalDateTime.now();
 
         int allCount = meetingMemberRepository.countMyMeetingsByStatuses(
                 userId,
                 List.of(MeetingStatus.CONFIRMED, MeetingStatus.DONE)
         );
-        int upcomingCount = meetingMemberRepository.countMyUpcomingMeetings(
+        int upcomingCount = meetingMemberRepository.countMyMeetingsByStatus(
                 userId,
-                MeetingStatus.CONFIRMED,
-                now,
-                now.plusDays(3)
+                MeetingStatus.CONFIRMED
         );
         int doneCount = meetingMemberRepository.countMyMeetingsByStatusWithoutPersonalRetrospective(
                 userId,

--- a/src/test/java/com/dokdok/meeting/service/MeetingServiceTest.java
+++ b/src/test/java/com/dokdok/meeting/service/MeetingServiceTest.java
@@ -1779,11 +1779,9 @@ class MeetingServiceTest {
                 userId,
                 List.of(MeetingStatus.CONFIRMED, MeetingStatus.DONE)
         )).willReturn(5);
-        given(meetingMemberRepository.countMyUpcomingMeetings(
-                eq(userId),
-                eq(MeetingStatus.CONFIRMED),
-                any(),
-                any()
+        given(meetingMemberRepository.countMyMeetingsByStatus(
+                userId,
+                MeetingStatus.CONFIRMED
         )).willReturn(2);
         given(meetingMemberRepository.countMyMeetingsByStatusWithoutPersonalRetrospective(
                 userId,


### PR DESCRIPTION
## PR 요약

- [x] 기능 추가
- [x] 버그 수정

---

## 이슈 번호
- #385

---

## 주요 변경 사항

- `GET /api/book/reading/tab-counts` (신규): 홈화면 읽고 있는 책 탭 카운트 조회 API 추가
  - `all` = 전체 (READING + PENDING + COMPLETED)
  - `before` = 약속 전 (READING + PENDING)
  - `after` = 약속 후 (COMPLETED)
  - `all = before + after` 항상 보장
- `MeetingService.getMyMeetingTabCounts()`: `upcoming` 카운트 범위를 3일 이내 → 확정된 약속 전체로 변경
  - 기존: `countMyUpcomingMeetings(now, now+3days)` → 3일 이내만 카운트
  - 변경: `countMyMeetingsByStatus(CONFIRMED)` → 전체 확정 약속 카운트
  - `all = upcoming + done` 항상 보장
- `BookReadingTabCountsResponse`: 신규 응답 DTO 추가
- `MyMeetingTabCountsResponse`: `upcoming` 필드 설명 업데이트

---

## 참고 사항

- **책 탭 카운트 로직**
  - `before (약속 전)` = READING + PENDING: 아직 완독하지 않은 책
  - `after (약속 후)` = COMPLETED: 완독한 책
  - `all` = total (세 상태 합계)
- **약속 upcoming 변경 배경**
  - 기존 3일 이내 필터로 인해 `all > upcoming + done` 불일치 발생
  - 탭 배지 카운트와 탭 클릭 시 보이는 목록 수가 일치하지 않는 문제 해결
- 기존 `countMyUpcomingMeetings` (3일 이내 필터)는 `getMyMeetingList` 목록 조회에서는 그대로 사용 중