### PR TITLE
[#387][FEAT] 모임 약속 목록 응답에 사전답변/개인회고 작성 여부 필드 추가

### DIFF
--- a/src/main/java/com/dokdok/meeting/dto/MeetingListItemResponse.java
+++ b/src/main/java/com/dokdok/meeting/dto/MeetingListItemResponse.java
@@ -39,6 +39,12 @@ public record MeetingListItemResponse(
         MeetingMyRole myRole,
 
         @Schema(description = "약속 상태", example = "CONFIRMED")
-        MeetingStatus meetingStatus
+        MeetingStatus meetingStatus,
+
+        @Schema(description = "내가 해당 약속의 사전답변을 제출했는지 여부", example = "true")
+        boolean hasPreOpinion,
+
+        @Schema(description = "내가 해당 약속의 개인 회고를 작성했는지 여부", example = "false")
+        boolean hasPersonalRetrospective
 ) {
 }

--- a/src/main/java/com/dokdok/meeting/service/MeetingService.java
+++ b/src/main/java/com/dokdok/meeting/service/MeetingService.java
@@ -958,6 +958,12 @@ public class MeetingService {
         Set<Long> joinedMeetingIds = new HashSet<>(
                 meetingMemberRepository.findActiveMeetingIdsByUserIdAndGatheringId(userId, gatheringId)
         );
+        Set<Long> preOpinionMeetingIds = new HashSet<>(
+                topicAnswerRepository.findMeetingIdsWithSubmittedAnswers(meetingIds, userId)
+        );
+        Set<Long> retrospectiveMeetingIds = new HashSet<>(
+                personalRetrospectiveRepository.findMeetingIdsWithRetrospective(meetingIds, userId)
+        );
 
         List<MeetingListItemResponse> items = new ArrayList<>();
         for (Meeting meeting : meetings) {
@@ -978,6 +984,8 @@ public class MeetingService {
                     .joined(joined)
                     .myRole(myRole)
                     .meetingStatus(meeting.getMeetingStatus())
+                    .hasPreOpinion(preOpinionMeetingIds.contains(meeting.getId()))
+                    .hasPersonalRetrospective(retrospectiveMeetingIds.contains(meeting.getId()))
                     .build());
         }
         return items;

--- a/src/main/java/com/dokdok/retrospective/repository/PersonalRetrospectiveRepository.java
+++ b/src/main/java/com/dokdok/retrospective/repository/PersonalRetrospectiveRepository.java
@@ -17,6 +17,15 @@ public interface PersonalRetrospectiveRepository extends JpaRepository<PersonalM
 
     boolean existsByMeetingIdAndUserId(Long meetingId, Long userId);
 
+    @Query("""
+            SELECT pmr.meeting.id
+            FROM PersonalMeetingRetrospective pmr
+            WHERE pmr.meeting.id IN :meetingIds
+            AND pmr.user.id = :userId
+            """)
+    List<Long> findMeetingIdsWithRetrospective(@Param("meetingIds") List<Long> meetingIds,
+                                               @Param("userId") Long userId);
+
     Optional<PersonalMeetingRetrospective> findByIdAndUser_Id(Long retrospectiveId, Long userId);
 
     @Query("""

--- a/src/main/java/com/dokdok/topic/repository/TopicAnswerRepository.java
+++ b/src/main/java/com/dokdok/topic/repository/TopicAnswerRepository.java
@@ -35,6 +35,16 @@ public interface TopicAnswerRepository extends JpaRepository<TopicAnswer, Long> 
     boolean existsByMeetingIdAndUserId(@Param("meetingId") Long meetingId,
                                        @Param("userId") Long userId);
 
+    @Query("""
+            SELECT DISTINCT t.meeting.id
+            FROM TopicAnswer ta
+            JOIN ta.topic t
+            WHERE t.meeting.id IN :meetingIds
+            AND ta.user.id = :userId
+            AND ta.isSubmitted = true
+            """)
+    List<Long> findMeetingIdsWithSubmittedAnswers(@Param("meetingIds") List<Long> meetingIds,
+                                                  @Param("userId") Long userId);
 
     @Query("""
                     SELECT ta


### PR DESCRIPTION
## PR 요약

- [x] 기능 추가

---

## 이슈 번호
- #387

---

## 주요 변경 사항

- `MeetingListItemResponse`: 두 개의 boolean 필드 추가
  - `hasPreOpinion`: 내가 해당 약속의 사전답변을 제출했는지 여부
  - `hasPersonalRetrospective`: 내가 해당 약속의 개인 회고를 작성했는지 여부
- `TopicAnswerRepository`: `findMeetingIdsWithSubmittedAnswers` 배치 조회 메서드 추가
  - 약속 ID 목록 + 유저 ID로 사전답변 제출된 약속 ID 목록을 한 번에 조회 (N+1 방지)
- `PersonalRetrospectiveRepository`: `findMeetingIdsWithRetrospective` 배치 조회 메서드 추가
  - 약속 ID 목록 + 유저 ID로 개인 회고 작성된 약속 ID 목록을 한 번에 조회 (N+1 방지)
- `MeetingService.buildMeetingItems`: 위 두 배치 조회 결과를 Set으로 변환 후 각 약속 아이템에 매핑

---

## 참고 사항

- **분기 이동 로직 (프론트 참고)**
  - `hasPreOpinion = true` → 사전답변 조회 페이지로 이동
  - `hasPreOpinion = false` → 사전답변 작성 페이지로 이동
  - `hasPersonalRetrospective = true` → 개인 회고 조회 페이지로 이동
  - `hasPersonalRetrospective = false` → 개인 회고 작성 페이지로 이동
- 배치 쿼리 2번으로 처리하여 약속 목록 크기와 무관하게 쿼리 수 고정
- `GET /api/gatherings/{gatheringId}/meetings` 응답에 적용됨