### PR TITLE
[#389][FIX] 모임별 약속 탭 카운트 및 전체 목록 조회 오류 수정

### DIFF
--- a/src/main/java/com/dokdok/meeting/dto/MeetingTabCountsResponse.java
+++ b/src/main/java/com/dokdok/meeting/dto/MeetingTabCountsResponse.java
@@ -6,16 +6,16 @@ import lombok.Builder;
 @Schema(description = "약속 탭별 카운트 응답")
 @Builder
 public record MeetingTabCountsResponse(
-        @Schema(description = "전체 확정된 약속 수", example = "10")
+        @Schema(description = "전체 약속 수 (확정 + 완료)", example = "10")
         int all,
 
-        @Schema(description = "다가오는 약속 수 (3일 이내)", example = "2")
+        @Schema(description = "예정된 약속 수 (확정된 약속 전체)", example = "2")
         int upcoming,
 
         @Schema(description = "완료된 약속 수", example = "5")
         int done,
 
-        @Schema(description = "내가 참여한 완료 약속 수", example = "3")
+        @Schema(description = "내가 참여한 약속 수 (전체 상태)", example = "3")
         int joined
 ) {
 }

--- a/src/main/java/com/dokdok/meeting/repository/MeetingMemberRepository.java
+++ b/src/main/java/com/dokdok/meeting/repository/MeetingMemberRepository.java
@@ -134,6 +134,18 @@ public interface MeetingMemberRepository extends JpaRepository<MeetingMember, Lo
             JOIN mm.meeting m
             WHERE mm.user.id = :userId
             AND mm.canceledAt IS NULL
+            AND m.gathering.id = :gatheringId
+            """)
+    int countMeetingsByUserIdAndGatheringId(
+            @Param("userId") Long userId,
+            @Param("gatheringId") Long gatheringId
+    );
+
+    @Query("""
+            SELECT count(mm) FROM MeetingMember mm
+            JOIN mm.meeting m
+            WHERE mm.user.id = :userId
+            AND mm.canceledAt IS NULL
             AND m.meetingStatus IN :meetingStatuses
             """)
     int countMyMeetingsByStatuses(

--- a/src/main/java/com/dokdok/meeting/repository/MeetingRepository.java
+++ b/src/main/java/com/dokdok/meeting/repository/MeetingRepository.java
@@ -40,10 +40,19 @@ public interface MeetingRepository extends JpaRepository<Meeting, Long> {
 
     int countByGatheringIdAndMeetingStatus(Long gatheringId, MeetingStatus meetingStatus);
 
+    int countByGatheringIdAndMeetingStatusIn(Long gatheringId, List<MeetingStatus> meetingStatuses);
+
     @EntityGraph(attributePaths = {"book"})
     Page<Meeting> findByGatheringIdAndMeetingStatus(
             Long gatheringId,
             MeetingStatus meetingStatus,
+            Pageable pageable
+    );
+
+    @EntityGraph(attributePaths = {"book"})
+    Page<Meeting> findByGatheringIdAndMeetingStatusIn(
+            Long gatheringId,
+            List<MeetingStatus> meetingStatuses,
             Pageable pageable
     );
 

--- a/src/main/java/com/dokdok/meeting/service/MeetingService.java
+++ b/src/main/java/com/dokdok/meeting/service/MeetingService.java
@@ -672,23 +672,12 @@ public class MeetingService {
         gatheringValidator.validateMembership(gatheringId, userId);
 
         int allCount = meetingRepository
-                .countByGatheringIdAndMeetingStatus(gatheringId, MeetingStatus.CONFIRMED);
+                .countByGatheringIdAndMeetingStatusIn(gatheringId, List.of(MeetingStatus.CONFIRMED, MeetingStatus.DONE));
         int doneCount = meetingRepository
                 .countByGatheringIdAndMeetingStatus(gatheringId, MeetingStatus.DONE);
-
-        LocalDateTime now = LocalDateTime.now();
-        int upcomingCount = meetingRepository.countUpcomingMeetings(
-                gatheringId,
-                MeetingStatus.CONFIRMED,
-                now,
-                now.plusDays(3)
-        );
-
-        int joinedCount = meetingMemberRepository.countMeetingsByUserIdAndStatus(
-                userId,
-                gatheringId,
-                MeetingStatus.DONE
-        );
+        int upcomingCount = meetingRepository
+                .countByGatheringIdAndMeetingStatus(gatheringId, MeetingStatus.CONFIRMED);
+        int joinedCount = meetingMemberRepository.countMeetingsByUserIdAndGatheringId(userId, gatheringId);
 
         return MeetingTabCountsResponse.builder()
                 .all(allCount)
@@ -835,9 +824,9 @@ public class MeetingService {
             Pageable pageable,
             Long userId
     ) {
-        Page<Meeting> meetingPage = meetingRepository.findByGatheringIdAndMeetingStatus(
+        Page<Meeting> meetingPage = meetingRepository.findByGatheringIdAndMeetingStatusIn(
                 gatheringId,
-                MeetingStatus.CONFIRMED,
+                List.of(MeetingStatus.CONFIRMED, MeetingStatus.DONE),
                 pageable
         );
         return buildMeetingPageResponse(meetingPage, userId, gatheringId);
@@ -851,12 +840,9 @@ public class MeetingService {
             Pageable pageable,
             Long userId
     ) {
-        LocalDateTime now = LocalDateTime.now();
-        Page<Meeting> meetingPage = meetingRepository.findByGatheringIdAndMeetingStatusAndMeetingStartDateBetween(
+        Page<Meeting> meetingPage = meetingRepository.findByGatheringIdAndMeetingStatus(
                 gatheringId,
                 MeetingStatus.CONFIRMED,
-                now,
-                now.plusDays(3),
                 pageable
         );
         return buildMeetingPageResponse(meetingPage, userId, gatheringId);

--- a/src/test/java/com/dokdok/meeting/service/MeetingServiceTest.java
+++ b/src/test/java/com/dokdok/meeting/service/MeetingServiceTest.java
@@ -1503,9 +1503,9 @@ class MeetingServiceTest {
 
         List<Meeting> meetings = List.of(meeting1, meeting2);
         Page<Meeting> meetingPage = new PageImpl<>(meetings, pageable, meetings.size());
-        given(meetingRepository.findByGatheringIdAndMeetingStatus(
+        given(meetingRepository.findByGatheringIdAndMeetingStatusIn(
                 eq(gatheringId),
-                eq(MeetingStatus.CONFIRMED),
+                eq(List.of(MeetingStatus.CONFIRMED, MeetingStatus.DONE)),
                 any()
         )).willReturn(meetingPage);
         given(topicRepository.findTopicTypesByMeetingIds(List.of(1L, 2L)))
@@ -1516,6 +1516,10 @@ class MeetingServiceTest {
                 ));
         given(meetingMemberRepository.findActiveMeetingIdsByUserIdAndGatheringId(userId, gatheringId))
                 .willReturn(List.of(1L));
+        given(topicAnswerRepository.findMeetingIdsWithSubmittedAnswers(List.of(1L, 2L), userId))
+                .willReturn(List.of());
+        given(personalRetrospectiveRepository.findMeetingIdsWithRetrospective(List.of(1L, 2L), userId))
+                .willReturn(List.of());
 
         try (MockedStatic<SecurityUtil> mock = mockStatic(SecurityUtil.class)) {
             mock.when(SecurityUtil::getCurrentUserId).thenReturn(userId);
@@ -1653,14 +1657,15 @@ class MeetingServiceTest {
         // given
         Long gatheringId = 100L;
         Long userId = 55L;
-        given(meetingRepository.countByGatheringIdAndMeetingStatus(gatheringId, MeetingStatus.CONFIRMED))
-                .willReturn(3);
+        given(meetingRepository.countByGatheringIdAndMeetingStatusIn(
+                gatheringId, List.of(MeetingStatus.CONFIRMED, MeetingStatus.DONE)))
+                .willReturn(5);
         given(meetingRepository.countByGatheringIdAndMeetingStatus(gatheringId, MeetingStatus.DONE))
                 .willReturn(2);
-        given(meetingRepository.countUpcomingMeetings(eq(gatheringId), eq(MeetingStatus.CONFIRMED), any(), any()))
-                .willReturn(1);
-        given(meetingMemberRepository.countMeetingsByUserIdAndStatus(userId, gatheringId, MeetingStatus.DONE))
-                .willReturn(1);
+        given(meetingRepository.countByGatheringIdAndMeetingStatus(gatheringId, MeetingStatus.CONFIRMED))
+                .willReturn(3);
+        given(meetingMemberRepository.countMeetingsByUserIdAndGatheringId(userId, gatheringId))
+                .willReturn(4);
 
         try (MockedStatic<SecurityUtil> mock = mockStatic(SecurityUtil.class)) {
             mock.when(SecurityUtil::getCurrentUserId).thenReturn(userId);
@@ -1669,16 +1674,10 @@ class MeetingServiceTest {
             MeetingTabCountsResponse response = meetingService.getMeetingTabCounts(gatheringId);
 
             // then
-            assertThat(response.all()).isEqualTo(3);
-            assertThat(response.upcoming()).isEqualTo(1);
+            assertThat(response.all()).isEqualTo(5);
+            assertThat(response.upcoming()).isEqualTo(3);
             assertThat(response.done()).isEqualTo(2);
-            assertThat(response.joined()).isEqualTo(1);
-            verify(meetingRepository).countUpcomingMeetings(
-                    eq(gatheringId),
-                    eq(MeetingStatus.CONFIRMED),
-                    any(LocalDateTime.class),
-                    any(LocalDateTime.class)
-            );
+            assertThat(response.joined()).isEqualTo(4);
         }
     }
 


### PR DESCRIPTION
## PR 요약

- [x] 버그 수정

---

## 이슈 번호
- #389

---

## 주요 변경 사항

- `getMeetingTabCounts()`: 탭 카운트 3개 수정
  - `all`: CONFIRMED만 → CONFIRMED + DONE 합산 (`countByGatheringIdAndMeetingStatusIn` 신규 추가)
  - `upcoming`: 3일 이내 제한 제거 → 전체 CONFIRMED 수 (`countByGatheringIdAndMeetingStatus(CONFIRMED)`)
  - `joined`: DONE 참여만 → 전체 상태 참여 수 (`countMeetingsByUserIdAndGatheringId` 신규 추가)
- `getAllMeetingsPage()`: `filter=ALL` 시 CONFIRMED만 → CONFIRMED + DONE 반환 (`findByGatheringIdAndMeetingStatusIn` 신규 추가)
- `getUpcomingMeetingsPage()`: 3일 이내 제한 제거 → 전체 CONFIRMED 반환 (기존 `findByGatheringIdAndMeetingStatus` 재활용)
- `MeetingServiceTest`: 변경된 로직에 맞게 mock 및 검증 업데이트

---

## 참고 사항

- **수정 전 문제**: `all=0, done=8, joined=8` → `all < joined` 논리 불일치
- **수정 후 보장**: `all = upcoming + done`, `joined ≤ all`
- 3개 이슈 동시 해결:
  1. 참여 약속 카운트 불일치 (`all < joined`)
  2. 탭 카운트와 실제 목록 수 불일치 (upcoming 3일 필터)
  3. ALL 탭에서 종료 약속 누락 (`filter=ALL` CONFIRMED만 반환)