### PR TITLE
[#391][FIX] 모임 책장 조회 시 빈 응답 반환 오류 수정

### DIFF
--- a/src/main/java/com/dokdok/gathering/dto/response/GatheringBookListResponse.java
+++ b/src/main/java/com/dokdok/gathering/dto/response/GatheringBookListResponse.java
@@ -35,4 +35,17 @@ public record GatheringBookListResponse(
                 ratingAverage
         );
     }
+
+    public static GatheringBookListResponse from(
+            Book book,
+            Double ratingAverage
+    ) {
+        return new GatheringBookListResponse(
+                book.getId(),
+                book.getBookName(),
+                book.getAuthor(),
+                book.getThumbnail(),
+                ratingAverage
+        );
+    }
 }

--- a/src/main/java/com/dokdok/gathering/service/GatheringService.java
+++ b/src/main/java/com/dokdok/gathering/service/GatheringService.java
@@ -1,5 +1,6 @@
 package com.dokdok.gathering.service;
 
+import com.dokdok.book.entity.Book;
 import com.dokdok.book.repository.BookReviewRepository;
 import com.dokdok.gathering.dto.request.GatheringCreateRequest;
 import com.dokdok.gathering.dto.request.GatheringUpdateRequest;
@@ -310,31 +311,35 @@ public class GatheringService {
         gatheringValidator.validateMembership(gatheringId, userId);
 
         Pageable pageable = PageRequest.of(page, size);
-        Page<GatheringBook> gatheringBookPage = gatheringBookRepository.findGatheringBooks(gatheringId, pageable);
+        Page<Book> bookPage = meetingRepository.findDistinctBooksByGatheringIdAndStatuses(
+                gatheringId,
+                List.of(MeetingStatus.CONFIRMED, MeetingStatus.DONE),
+                pageable
+        );
 
-        if (gatheringBookPage.isEmpty()) {
+        if (bookPage.isEmpty()) {
             return PageResponse.of(List.of(), 0, page, size);
         }
 
-        List<GatheringBook> gatheringBooks = gatheringBookPage.getContent();
-        Map<Long, Double> ratingMap = getBookRatingMap(gatheringId, gatheringBooks);
+        List<Book> books = bookPage.getContent();
+        Map<Long, Double> ratingMap = getBookRatingMap(gatheringId, books);
 
-        List<GatheringBookListResponse> responses = gatheringBooks.stream()
-                .map(gb -> GatheringBookListResponse.from(gb, ratingMap.get(gb.getBook().getId())))
+        List<GatheringBookListResponse> responses = books.stream()
+                .map(book -> GatheringBookListResponse.from(book, ratingMap.get(book.getId())))
                 .toList();
 
-        return PageResponse.of(responses, gatheringBookPage.getTotalElements(), page, size);
+        return PageResponse.of(responses, bookPage.getTotalElements(), page, size);
     }
 
-    private Map<Long, Double> getBookRatingMap(Long gatheringId, List<GatheringBook> gatheringBooks) {
+    private Map<Long, Double> getBookRatingMap(Long gatheringId, List<Book> books) {
         List<Long> meetingMemberIds = meetingMemberRepository.findByGatheringId(gatheringId);
 
         if (meetingMemberIds.isEmpty()) {
             return Map.of();
         }
 
-        List<Long> bookIds = gatheringBooks.stream()
-                .map(gb -> gb.getBook().getId())
+        List<Long> bookIds = books.stream()
+                .map(Book::getId)
                 .toList();
 
         return bookReviewRepository.findMeetingBookReviews(bookIds, meetingMemberIds).stream()

--- a/src/main/java/com/dokdok/meeting/repository/MeetingRepository.java
+++ b/src/main/java/com/dokdok/meeting/repository/MeetingRepository.java
@@ -156,6 +156,20 @@ public interface MeetingRepository extends JpaRepository<Meeting, Long> {
             """)
     List<Meeting> findByIdInWithGathering(@Param("meetingIds") List<Long> meetingIds);
 
+    @Query("""
+            SELECT DISTINCT m.book
+            FROM Meeting m
+            WHERE m.gathering.id = :gatheringId
+            AND m.meetingStatus IN :meetingStatuses
+            AND m.book IS NOT NULL
+            ORDER BY m.book.id ASC
+            """)
+    Page<com.dokdok.book.entity.Book> findDistinctBooksByGatheringIdAndStatuses(
+            @Param("gatheringId") Long gatheringId,
+            @Param("meetingStatuses") List<MeetingStatus> meetingStatuses,
+            Pageable pageable
+    );
+
     /**
      * 여러 모임의 완료된 미팅 수를 한번에 조회
      */

--- a/src/test/java/com/dokdok/gathering/service/GatheringServiceTest.java
+++ b/src/test/java/com/dokdok/gathering/service/GatheringServiceTest.java
@@ -1302,20 +1302,8 @@ class GatheringServiceTest {
 				.isbn("978-0134757599")
 				.build();
 
-		GatheringBook gatheringBook1 = GatheringBook.builder()
-				.id(1L)
-				.gathering(gathering1)
-				.book(book1)
-				.build();
-
-		GatheringBook gatheringBook2 = GatheringBook.builder()
-				.id(2L)
-				.gathering(gathering1)
-				.book(book2)
-				.build();
-
-		List<GatheringBook> gatheringBooks = List.of(gatheringBook1, gatheringBook2);
-		Page<GatheringBook> gatheringBookPage = new PageImpl<>(gatheringBooks, PageRequest.of(page, size), 2);
+		List<Book> books = List.of(book1, book2);
+		Page<Book> bookPage = new PageImpl<>(books, PageRequest.of(page, size), 2);
 
 		List<Long> meetingMemberIds = List.of(1L, 2L, 3L);
 		List<BookRatingAverage> ratingAverages = List.of(
@@ -1324,8 +1312,8 @@ class GatheringServiceTest {
 		);
 
 		securityUtilMock.when(SecurityUtil::getCurrentUserId).thenReturn(userId);
-		given(gatheringBookRepository.findGatheringBooks(eq(gatheringId), any(Pageable.class)))
-				.willReturn(gatheringBookPage);
+		given(meetingRepository.findDistinctBooksByGatheringIdAndStatuses(eq(gatheringId), any(), any(Pageable.class)))
+				.willReturn(bookPage);
 		given(meetingMemberRepository.findByGatheringId(gatheringId)).willReturn(meetingMemberIds);
 		given(bookReviewRepository.findMeetingBookReviews(List.of(1L, 2L), meetingMemberIds))
 				.willReturn(ratingAverages);
@@ -1364,10 +1352,10 @@ class GatheringServiceTest {
 		int page = 0;
 		int size = 10;
 
-		Page<GatheringBook> emptyPage = new PageImpl<>(List.of(), PageRequest.of(page, size), 0);
+		Page<Book> emptyPage = new PageImpl<>(List.of(), PageRequest.of(page, size), 0);
 
 		securityUtilMock.when(SecurityUtil::getCurrentUserId).thenReturn(userId);
-		given(gatheringBookRepository.findGatheringBooks(eq(gatheringId), any(Pageable.class)))
+		given(meetingRepository.findDistinctBooksByGatheringIdAndStatuses(eq(gatheringId), any(), any(Pageable.class)))
 				.willReturn(emptyPage);
 
 		// when
@@ -1403,18 +1391,11 @@ class GatheringServiceTest {
 				.isbn("978-0132350884")
 				.build();
 
-		GatheringBook gatheringBook1 = GatheringBook.builder()
-				.id(1L)
-				.gathering(gathering1)
-				.book(book1)
-				.build();
-
-		List<GatheringBook> gatheringBooks = List.of(gatheringBook1);
-		Page<GatheringBook> gatheringBookPage = new PageImpl<>(gatheringBooks, PageRequest.of(page, size), 1);
+		Page<Book> bookPage = new PageImpl<>(List.of(book1), PageRequest.of(page, size), 1);
 
 		securityUtilMock.when(SecurityUtil::getCurrentUserId).thenReturn(userId);
-		given(gatheringBookRepository.findGatheringBooks(eq(gatheringId), any(Pageable.class)))
-				.willReturn(gatheringBookPage);
+		given(meetingRepository.findDistinctBooksByGatheringIdAndStatuses(eq(gatheringId), any(), any(Pageable.class)))
+				.willReturn(bookPage);
 		given(meetingMemberRepository.findByGatheringId(gatheringId)).willReturn(List.of());
 
 		// when


### PR DESCRIPTION
## PR 요약

- [x] 버그 수정

---

## 이슈 번호
- #391

---

## 주요 변경 사항

- `MeetingRepository`: `findDistinctBooksByGatheringIdAndStatuses` 신규 쿼리 추가
  - `gathering_id` + 약속 상태(CONFIRMED/DONE)로 중복 제거된 책 목록 조회
- `GatheringService.getGatheringBooks()`: `GatheringBookRepository` 대신 `MeetingRepository`를 통해 책 조회하도록 변경
- `GatheringBookListResponse`: `Book` 객체를 직접 받는 `from(Book, Double)` 팩토리 메서드 추가
- `GatheringServiceTest`: 변경된 조회 방식에 맞게 mock 수정

---

## 참고 사항

- **원인**: `gathering_book` 테이블에 데이터를 INSERT하는 코드가 프로젝트 전체에 존재하지 않아 항상 빈 응답 반환
- **해결 방향**: `Meeting`이 `gathering_id`와 `book_id`를 모두 알고 있으므로 `Meeting → Book` 경로로 직접 조회
  - `GatheringBook`을 거칠 필요 없이 `Meeting`에서 DISTINCT 조회로 해결
  - 기존 DONE 약속 데이터도 별도 마이그레이션 없이 즉시 반영
- `GatheringBook` 엔티티/레포지토리는 현재 미사용 상태로, 별도 PR에서 정리 예정