### PR TITLE
[#393][FEAT] 책 목록 응답에 약속 진행 상태 필드 추가 및 필터 파라미터 추가

### DIFF
--- a/src/main/java/com/dokdok/book/api/BookApi.java
+++ b/src/main/java/com/dokdok/book/api/BookApi.java
@@ -347,7 +347,9 @@ public interface BookApi {
             @Parameter(description = "커서 - 마지막 아이템 bookId (cursorAddedAt과 함께 전달)")
             @RequestParam(required = false) Long cursorBookId,
             @Parameter(description = "한 페이지당 아이템 수", example = "10")
-            @RequestParam(required = false) Integer size
+            @RequestParam(required = false) Integer size,
+            @Parameter(description = "약속 진행 상태 필터 (BEFORE: 약속 전, AFTER: 약속 후)", example = "BEFORE")
+            @RequestParam(required = false) com.dokdok.book.entity.BookMeetingProgressStatus meetingProgressStatus
     );
 
     @Operation(

--- a/src/main/java/com/dokdok/book/controller/BookController.java
+++ b/src/main/java/com/dokdok/book/controller/BookController.java
@@ -6,6 +6,7 @@ import com.dokdok.book.dto.request.BookCreateRequest;
 import com.dokdok.book.dto.request.PersonalBookSortBy;
 import com.dokdok.book.dto.request.PersonalBookSortOrder;
 import com.dokdok.book.dto.response.*;
+import com.dokdok.book.entity.BookMeetingProgressStatus;
 import com.dokdok.book.entity.BookReadingStatus;
 import com.dokdok.book.service.BookService;
 import com.dokdok.book.service.PersonalBookService;
@@ -60,7 +61,8 @@ public class BookController implements BookApi {
             @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
             OffsetDateTime cursorAddedAt,
             @RequestParam(required = false) Long cursorBookId,
-            @RequestParam(required = false) Integer size
+            @RequestParam(required = false) Integer size,
+            @RequestParam(required = false) BookMeetingProgressStatus meetingProgressStatus
     ) {
         PersonalBookCursorPageResponse response = personalBookService
                 .getPersonalBookListCursor(
@@ -73,7 +75,8 @@ public class BookController implements BookApi {
                         cursorRating,
                         cursorAddedAt,
                         cursorBookId,
-                        size
+                        size,
+                        meetingProgressStatus
                 );
         return ApiResponse.success(response, "책 리스트 조회 성공");
     }

--- a/src/main/java/com/dokdok/book/dto/response/PersonalBookListResponse.java
+++ b/src/main/java/com/dokdok/book/dto/response/PersonalBookListResponse.java
@@ -1,5 +1,6 @@
 package com.dokdok.book.dto.response;
 
+import com.dokdok.book.entity.BookMeetingProgressStatus;
 import com.dokdok.book.entity.BookReadingStatus;
 import com.dokdok.book.entity.PersonalBook;
 import com.dokdok.book.repository.PersonalBookListProjection;
@@ -20,7 +21,8 @@ public record PersonalBookListResponse(
         BookReadingStatus bookReadingStatus,
         String thumbnail,
         BigDecimal rating,
-        List<PersonalBookGatheringResponse> gatherings
+        List<PersonalBookGatheringResponse> gatherings,
+        BookMeetingProgressStatus meetingProgressStatus
 ) {
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
@@ -54,7 +56,17 @@ public record PersonalBookListResponse(
                 .thumbnail(projection.getThumbnail())
                 .rating(projection.getRating())
                 .gatherings(parseGatherings(projection.getGatherings()))
+                .meetingProgressStatus(parseMeetingProgressStatus(projection.getMeetingProgressStatus()))
                 .build();
+    }
+
+    private static BookMeetingProgressStatus parseMeetingProgressStatus(String value) {
+        if (value == null) return null;
+        try {
+            return BookMeetingProgressStatus.valueOf(value);
+        } catch (IllegalArgumentException e) {
+            return null;
+        }
     }
 
     private static List<PersonalBookGatheringResponse> parseGatherings(String gatheringsJson) {

--- a/src/main/java/com/dokdok/book/entity/BookMeetingProgressStatus.java
+++ b/src/main/java/com/dokdok/book/entity/BookMeetingProgressStatus.java
@@ -1,0 +1,9 @@
+package com.dokdok.book.entity;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "책의 약속 진행 상태")
+public enum BookMeetingProgressStatus {
+    BEFORE,
+    AFTER
+}

--- a/src/main/java/com/dokdok/book/repository/PersonalBookListProjection.java
+++ b/src/main/java/com/dokdok/book/repository/PersonalBookListProjection.java
@@ -15,4 +15,5 @@ public interface PersonalBookListProjection {
     BigDecimal getRating();
     String getGatherings();
     java.time.LocalDateTime getAddedAt();
+    String getMeetingProgressStatus();
 }

--- a/src/main/java/com/dokdok/book/repository/PersonalBookRepository.java
+++ b/src/main/java/com/dokdok/book/repository/PersonalBookRepository.java
@@ -33,7 +33,26 @@ public interface PersonalBookRepository extends JpaRepository<PersonalBook, Long
                             filter (where g.gathering_id is not null),
                         '[]'::json
                     )::text as gatherings,
-                    max(pb.added_at) as addedAt
+                    max(pb.added_at) as addedAt,
+                    (
+                        select
+                            case
+                                when bool_or(m.meeting_status = 'CONFIRMED') then 'BEFORE'
+                                when count(m.meeting_id) > 0 and bool_and(m.meeting_status = 'DONE') then 'AFTER'
+                                else null
+                            end
+                        from meeting m
+                        where m.book_id = b.book_id
+                            and m.deleted_at is null
+                            and (:gatheringId is null or m.gathering_id = :gatheringId)
+                            and m.gathering_id in (
+                                select pb2.gathering_id from personal_book pb2
+                                where pb2.book_id = b.book_id
+                                    and pb2.user_id = :userId
+                                    and pb2.deleted_at is null
+                                    and pb2.gathering_id is not null
+                            )
+                    ) as meetingProgressStatus
                 from personal_book pb
                 join book b on pb.book_id = b.book_id
                 left join gathering g
@@ -85,7 +104,26 @@ public interface PersonalBookRepository extends JpaRepository<PersonalBook, Long
                             filter (where g.gathering_id is not null),
                         '[]'::json
                     )::text as gatherings,
-                    max(pb.added_at) as addedAt
+                    max(pb.added_at) as addedAt,
+                    (
+                        select
+                            case
+                                when bool_or(m.meeting_status = 'CONFIRMED') then 'BEFORE'
+                                when count(m.meeting_id) > 0 and bool_and(m.meeting_status = 'DONE') then 'AFTER'
+                                else null
+                            end
+                        from meeting m
+                        where m.book_id = b.book_id
+                            and m.deleted_at is null
+                            and (:gatheringId is null or m.gathering_id = :gatheringId)
+                            and m.gathering_id in (
+                                select pb2.gathering_id from personal_book pb2
+                                where pb2.book_id = b.book_id
+                                    and pb2.user_id = :userId
+                                    and pb2.deleted_at is null
+                                    and pb2.gathering_id is not null
+                            )
+                    ) as meetingProgressStatus
                 from personal_book pb
                 join book b on pb.book_id = b.book_id
                 left join gathering g

--- a/src/main/java/com/dokdok/book/service/PersonalBookService.java
+++ b/src/main/java/com/dokdok/book/service/PersonalBookService.java
@@ -5,6 +5,7 @@ import com.dokdok.book.dto.request.PersonalBookSortBy;
 import com.dokdok.book.dto.request.PersonalBookSortOrder;
 import com.dokdok.book.dto.response.BookListCursor;
 import com.dokdok.book.dto.response.BookReadingTabCountsResponse;
+import com.dokdok.book.entity.BookMeetingProgressStatus;
 import com.dokdok.book.dto.response.PersonalBookCursorPageResponse;
 import com.dokdok.book.dto.response.PersonalBookCreateResponse;
 import com.dokdok.book.dto.response.PersonalBookDetailResponse;
@@ -115,7 +116,8 @@ public class PersonalBookService {
             BigDecimal cursorRating,
             OffsetDateTime cursorAddedAt,
             Long cursorBookId,
-            Integer size
+            Integer size,
+            BookMeetingProgressStatus meetingProgressStatus
     ) {
         User userEntity = userValidator.findUserOrThrow(SecurityUtil.getCurrentUserId());
         String readingStatus = bookReadingStatus != null ? bookReadingStatus.name() : null;
@@ -133,6 +135,8 @@ public class PersonalBookService {
                 )
                 .stream()
                 .filter(item -> isWithinRatingRange(item.getRating(), minRating, maxRating))
+                .filter(item -> meetingProgressStatus == null
+                        || meetingProgressStatus.name().equals(item.getMeetingProgressStatus()))
                 .toList();
 
         List<PersonalBookListProjection> sorted = filtered.stream()
@@ -394,6 +398,11 @@ public class PersonalBookService {
 
         @Override
         public String getGatherings() {
+            return null;
+        }
+
+        @Override
+        public String getMeetingProgressStatus() {
             return null;
         }
     }

--- a/src/test/java/com/dokdok/book/service/PersonalBookServiceTest.java
+++ b/src/test/java/com/dokdok/book/service/PersonalBookServiceTest.java
@@ -335,6 +335,11 @@ class PersonalBookServiceTest {
             public LocalDateTime getAddedAt() {
                 return addedAt;
             }
+
+            @Override
+            public String getMeetingProgressStatus() {
+                return null;
+            }
         };
 
         Page<PersonalBookListProjection> page = new PageImpl<>(List.of(projection), pageable, 1);
@@ -700,7 +705,8 @@ class PersonalBookServiceTest {
                 null,
                 null,
                 null,
-                10
+                10,
+                null
         );
 
         // then
@@ -747,7 +753,8 @@ class PersonalBookServiceTest {
                 new BigDecimal("4.0"),
                 OffsetDateTime.of(secondAddedAt, ZoneOffset.UTC),
                 20L,
-                10
+                10,
+                null
         );
 
         // then
@@ -813,6 +820,11 @@ class PersonalBookServiceTest {
             @Override
             public LocalDateTime getAddedAt() {
                 return addedAt;
+            }
+
+            @Override
+            public String getMeetingProgressStatus() {
+                return null;
             }
         };
     }


### PR DESCRIPTION
## PR 요약

- [x] 기능 추가

---

## 이슈 번호
- #393

---

## 주요 변경 사항

- `BookMeetingProgressStatus` enum 추가 (`BEFORE`, `AFTER`)
- `PersonalBookListProjection`: `getMeetingProgressStatus()` 메서드 추가
- `PersonalBookRepository`: 두 native SQL 쿼리에 `meetingProgressStatus` 서브쿼리 추가
  - CONFIRMED 약속이 하나라도 있으면 → `BEFORE`
  - 약속이 있고 전부 DONE이면 → `AFTER`
  - 약속 없으면 → `null`
- `PersonalBookListResponse`: `meetingProgressStatus` 필드 추가
- `PersonalBookService.getPersonalBookListCursor()`: `meetingProgressStatus` 필터 파라미터 추가
- `GET /api/book`: `meetingProgressStatus` 쿼리 파라미터 추가 (BEFORE / AFTER)

---

## 참고 사항

- **필터 사용 예시**
  - `GET /api/book?readingStatus=READING&meetingProgressStatus=BEFORE` → 약속 전 책만 조회
  - `GET /api/book?readingStatus=READING&meetingProgressStatus=AFTER` → 약속 후 책만 조회
  - 파라미터 미전달 시 전체 반환
- 필터링은 기존 rating 필터와 동일하게 Java에서 처리 (전체 조회 후 필터)