### PR TITLE
[#400][FIX] 기본 주제 자동 확정 개선

### DIFF
--- a/src/main/java/com/dokdok/meeting/repository/MeetingRepository.java
+++ b/src/main/java/com/dokdok/meeting/repository/MeetingRepository.java
@@ -126,19 +126,46 @@ public interface MeetingRepository extends JpaRepository<Meeting, Long> {
             MeetingStatus meetingStatus
     );
 
-    // Scheduler용: 시작 시간이 지났고 임시저장 사전의견이 있는 CONFIRMED 상태의 Meeting 조회
+    // Scheduler용: 약속 당일이고 임시저장 사전의견이 있는 CONFIRMED 상태의 Meeting 조회
     @Query("""
             SELECT DISTINCT m
             FROM Meeting m
             JOIN FETCH m.book b
             JOIN Topic t ON t.meeting = m
             JOIN TopicAnswer ta ON ta.topic = t
-            WHERE m.meetingStartDate <= :now
+            WHERE m.meetingStartDate >= :dayStart
+            AND m.meetingStartDate < :nextDayStart
             AND m.meetingStatus = :meetingStatus
             AND ta.isSubmitted = false
             """)
-    List<Meeting> findStartedMeetingsWithDraftPreOpinions(
-            @Param("now") LocalDateTime now,
+    List<Meeting> findMeetingsOnDateWithDraftPreOpinions(
+            @Param("dayStart") LocalDateTime dayStart,
+            @Param("nextDayStart") LocalDateTime nextDayStart,
+            @Param("meetingStatus") MeetingStatus meetingStatus
+    );
+
+    // Scheduler용: 시작 24시간 이내이고 확정 주제가 없는 CONFIRMED 상태의 Meeting 조회
+    @Query("""
+            SELECT DISTINCT m
+            FROM Meeting m
+            WHERE m.meetingStartDate <= :deadline
+            AND m.meetingStatus = :meetingStatus
+            AND NOT EXISTS (
+                SELECT 1
+                FROM Topic t
+                WHERE t.meeting = m
+                AND t.topicStatus = com.dokdok.topic.entity.TopicStatus.CONFIRMED
+                AND t.deletedAt IS NULL
+            )
+            AND EXISTS (
+                SELECT 1
+                FROM Topic t
+                WHERE t.meeting = m
+                AND t.deletedAt IS NULL
+            )
+            """)
+    List<Meeting> findMeetingsDueForTopicAutoConfirm(
+            @Param("deadline") LocalDateTime deadline,
             @Param("meetingStatus") MeetingStatus meetingStatus
     );
 

--- a/src/main/java/com/dokdok/meeting/scheduler/MeetingStatusScheduler.java
+++ b/src/main/java/com/dokdok/meeting/scheduler/MeetingStatusScheduler.java
@@ -4,18 +4,22 @@ import com.dokdok.meeting.entity.Meeting;
 import com.dokdok.meeting.entity.MeetingStatus;
 import com.dokdok.meeting.repository.MeetingRepository;
 import com.dokdok.topic.service.PreOpinionAutoShareService;
+import com.dokdok.topic.service.TopicService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
 /**
  * Meeting 상태 자동 업데이트 Scheduler
  * - 매 10분마다 실행
+ * - 약속 시작 24시간 이내에 확정 주제가 없으면 주제를 자동 확정
+ * - 약속 당일에 임시저장 사전의견을 자동 공유
  * - meetingEndDate가 지난 CONFIRMED 상태의 Meeting을 DONE으로 변경
  */
 @Component
@@ -25,6 +29,7 @@ public class MeetingStatusScheduler {
 
     private final MeetingRepository meetingRepository;
     private final PreOpinionAutoShareService preOpinionAutoShareService;
+    private final TopicService topicService;
 
     /**
      * 종료 시간이 지난 모임의 상태를 자동으로 DONE으로 변경
@@ -33,7 +38,8 @@ public class MeetingStatusScheduler {
     @Scheduled(cron = "0 */10 * * * *")
     @Transactional
     public void updateExpiredMeetings() {
-        autoShareStartedMeetings();
+        autoConfirmTopicsDueWithin24Hours();
+        autoShareTodayMeetings();
 
         long startTime = System.currentTimeMillis();
         
@@ -71,13 +77,45 @@ public class MeetingStatusScheduler {
         log.info("[Scheduler] ========================================");
     }
 
-    private void autoShareStartedMeetings() {
-        LocalDateTime now = LocalDateTime.now();
-        List<Meeting> startedMeetings = meetingRepository
-                .findStartedMeetingsWithDraftPreOpinions(now, MeetingStatus.CONFIRMED);
+    private void autoConfirmTopicsDueWithin24Hours() {
+        LocalDateTime deadline = LocalDateTime.now().plusHours(24);
+        List<Meeting> meetings = meetingRepository
+                .findMeetingsDueForTopicAutoConfirm(deadline, MeetingStatus.CONFIRMED);
 
-        if (startedMeetings.isEmpty()) {
-            log.info("[Scheduler] No started meetings for pre-opinion auto share.");
+        if (meetings.isEmpty()) {
+            log.info("[Scheduler] No meetings for topic auto-confirm.");
+            return;
+        }
+
+        int confirmedTopicCount = 0;
+        int confirmedMeetingCount = 0;
+
+        for (Meeting meeting : meetings) {
+            try {
+                TopicService.AutoConfirmResult result = topicService.autoConfirmTopics(meeting);
+                confirmedTopicCount += result.confirmedTopicCount();
+                if (result.confirmedTopicCount() > 0) {
+                    confirmedMeetingCount++;
+                }
+            } catch (Exception e) {
+                log.error("[Scheduler] Failed to auto-confirm topics for meeting {}: {}",
+                        meeting.getId(), e.getMessage());
+            }
+        }
+
+        log.info("[Scheduler] Auto-confirmed topics for {} / {} meetings: topics={}",
+                confirmedMeetingCount, meetings.size(), confirmedTopicCount);
+    }
+
+    private void autoShareTodayMeetings() {
+        LocalDate today = LocalDate.now();
+        LocalDateTime dayStart = today.atStartOfDay();
+        LocalDateTime nextDayStart = today.plusDays(1).atStartOfDay();
+        List<Meeting> todayMeetings = meetingRepository
+                .findMeetingsOnDateWithDraftPreOpinions(dayStart, nextDayStart, MeetingStatus.CONFIRMED);
+
+        if (todayMeetings.isEmpty()) {
+            log.info("[Scheduler] No today's meetings for pre-opinion auto share.");
             return;
         }
 
@@ -85,7 +123,7 @@ public class MeetingStatusScheduler {
         int submittedUserCount = 0;
         int appliedReviewCount = 0;
 
-        for (Meeting meeting : startedMeetings) {
+        for (Meeting meeting : todayMeetings) {
             try {
                 PreOpinionAutoShareService.AutoShareResult result =
                         preOpinionAutoShareService.autoShareDrafts(meeting);
@@ -99,6 +137,6 @@ public class MeetingStatusScheduler {
         }
 
         log.info("[Scheduler] Auto-shared pre-opinions for {} meetings: answers={}, users={}, reviews={}",
-                startedMeetings.size(), submittedAnswerCount, submittedUserCount, appliedReviewCount);
+                todayMeetings.size(), submittedAnswerCount, submittedUserCount, appliedReviewCount);
     }
 }

--- a/src/main/java/com/dokdok/topic/repository/TopicRepository.java
+++ b/src/main/java/com/dokdok/topic/repository/TopicRepository.java
@@ -229,6 +229,18 @@ public interface TopicRepository extends JpaRepository<Topic, Long> {
     );
 
     @Query("""
+            SELECT t
+            FROM Topic t
+            WHERE t.meeting.id = :meetingId
+            AND t.topicStatus = com.dokdok.topic.entity.TopicStatus.PROPOSED
+            AND t.deletedAt IS NULL
+            ORDER BY t.likeCount DESC, t.id ASC
+            """)
+    List<Topic> findAutoConfirmCandidates(
+            @Param("meetingId") Long meetingId
+    );
+
+    @Query("""
             SELECT DISTINCT t.meeting.id
             FROM Topic t
             WHERE t.meeting.id IN :meetingIds

--- a/src/main/java/com/dokdok/topic/service/TopicService.java
+++ b/src/main/java/com/dokdok/topic/service/TopicService.java
@@ -202,6 +202,22 @@ public class TopicService {
         return ConfirmTopicsResponse.from(meetingId, confirmedTopics);
     }
 
+    @Transactional
+    public AutoConfirmResult autoConfirmTopics(Meeting meeting) {
+        List<Topic> topics = topicRepository.findAutoConfirmCandidates(meeting.getId());
+        if (topics.isEmpty()) {
+            return AutoConfirmResult.empty(meeting.getId());
+        }
+
+        int order = 1;
+        for (Topic topic : topics) {
+            topic.updateStatus(TopicStatus.CONFIRMED);
+            topic.updateConfirmOrder(order++);
+        }
+
+        return new AutoConfirmResult(meeting.getId(), topics.size());
+    }
+
     @Transactional(readOnly = true)
     public ConfirmedTopicsResponse getConfirmedTopics(
             Long gatheringId,
@@ -316,5 +332,14 @@ public class TopicService {
         }
 
         return TopicLikeResponse.from(topicId, message, newCount);
+    }
+
+    public record AutoConfirmResult(
+            Long meetingId,
+            int confirmedTopicCount
+    ) {
+        private static AutoConfirmResult empty(Long meetingId) {
+            return new AutoConfirmResult(meetingId, 0);
+        }
     }
 }

--- a/src/test/java/com/dokdok/topic/service/TopicServiceTest.java
+++ b/src/test/java/com/dokdok/topic/service/TopicServiceTest.java
@@ -264,6 +264,52 @@ class TopicServiceTest {
         }
     }
 
+    @Test
+    @DisplayName("자동 확정 대상 주제를 조회된 순서대로 확정한다")
+    void autoConfirmTopics_Success() {
+        Meeting meeting = Meeting.builder()
+                .id(10L)
+                .build();
+        Topic topic1 = Topic.builder()
+                .id(21L)
+                .meeting(meeting)
+                .topicStatus(TopicStatus.PROPOSED)
+                .build();
+        Topic topic2 = Topic.builder()
+                .id(22L)
+                .meeting(meeting)
+                .topicStatus(TopicStatus.PROPOSED)
+                .build();
+
+        given(topicRepository.findAutoConfirmCandidates(meeting.getId()))
+                .willReturn(List.of(topic1, topic2));
+
+        TopicService.AutoConfirmResult result = topicService.autoConfirmTopics(meeting);
+
+        assertThat(result.meetingId()).isEqualTo(meeting.getId());
+        assertThat(result.confirmedTopicCount()).isEqualTo(2);
+        assertThat(topic1.getTopicStatus()).isEqualTo(TopicStatus.CONFIRMED);
+        assertThat(topic1.getConfirmOrder()).isEqualTo(1);
+        assertThat(topic2.getTopicStatus()).isEqualTo(TopicStatus.CONFIRMED);
+        assertThat(topic2.getConfirmOrder()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("자동 확정 대상 주제가 없으면 아무 것도 확정하지 않는다")
+    void autoConfirmTopics_Empty() {
+        Meeting meeting = Meeting.builder()
+                .id(10L)
+                .build();
+
+        given(topicRepository.findAutoConfirmCandidates(meeting.getId()))
+                .willReturn(List.of());
+
+        TopicService.AutoConfirmResult result = topicService.autoConfirmTopics(meeting);
+
+        assertThat(result.meetingId()).isEqualTo(meeting.getId());
+        assertThat(result.confirmedTopicCount()).isZero();
+    }
+
     @Nested
     @DisplayName("getConfirmedTopics - 확정 주제 조회")
     class GetConfirmedTopicsTest {


### PR DESCRIPTION
 ## PR 요약

  > 이 PR이 어떤 변경을 하는지 간단히 설명하고, 체크 표시는 괄호 사이에 소문자 'x'를 삽입하세요.                                                                                                                                        

  - [x] 기능 추가
  - [x] 버그 수정
  - [ ] 코드 리팩토링
  - [ ] 문서 수정
  - [ ] 기타 (설명)

  약속일 24시간 전까지 모임장이 주제를 확정하지 않은 경우, 스케줄러가 자동으로 주제를 확정하도록 개선합니다.

  ———

  ## 이슈 번호

  - #400

  ———

  ## 주요 변경 사항

  > 주요 파일, 로직, 컴포넌트 등을 구체적으로 적어주세요.                                                                                                                                                                               

  - MeetingStatusScheduler: 10분 주기 스케줄러 실행 시 약속 시작 24시간 이내이고 확정 주제가 없는 모임의 주제를 자동 확정하도록 처리 추가
  - MeetingRepository: 자동 확정 대상 모임 조회 쿼리 추가
  - TopicRepository: 자동 확정 대상 주제 조회 쿼리 추가
  - TopicService: 자동 확정 대상 주제를 CONFIRMED 상태로 변경하고 confirmOrder를 부여하는 로직 추가
  - TopicServiceTest: 자동 확정 성공 케이스와 대상 주제가 없는 케이스 테스트 추가

  ———

  ## 참고 사항

  > 리뷰어가 알아야 할 추가 정보, 테스트 방법 등을 작성해주세요.                                                                                                                                                                        

  - 스케줄러는 10분마다 실행됩니다.
  - 자동 확정 대상은 확정된 주제가 없고, 삭제되지 않은 주제가 존재하는 CONFIRMED 상태의 모임입니다.
  - 자동 확정 시 주제는 likeCount DESC, id ASC 순서로 확정됩니다.