### PR TITLE
[FIX] 배포 SSH 명령 타임아웃 10분 → 30분 상향

### DIFF
--- a/.github/workflows/dev_cd.yml
+++ b/.github/workflows/dev_cd.yml
@@ -19,6 +19,8 @@ jobs:
           host: ${{ secrets.EC2_HOST }}
           username: ${{ secrets.EC2_USER }}
           key: ${{ secrets.EC2_SSH_KEY }}
+          # 원격에서 docker build(gradle 빌드)가 10분(기본값)을 넘겨 타임아웃나는 것을 방지
+          command_timeout: 30m
           envs: POSTGRES_DB,POSTGRES_USER,POSTGRES_PASSWORD,DB_USERNAME,DB_PASSWORD,KAKAO_CLIENT_ID,KAKAO_CLIENT_SECRET,KAKAO_API_KEY,KAKAO_API_BASE_URL,MINIO_ACCESS_KEY,MINIO_SECRET_KEY,MINIO_EXTERNAL_ENDPOINT,MINIO_BUCKET,MINIO_SERVER_URL
           script: |
             set -e

--- a/.github/workflows/prod_cd.yml
+++ b/.github/workflows/prod_cd.yml
@@ -19,6 +19,8 @@ jobs:
           host: ${{ secrets.EC2_HOST }}
           username: ${{ secrets.EC2_USER }}
           key: ${{ secrets.EC2_SSH_KEY }}
+          # 원격에서 docker build(gradle 빌드)가 10분(기본값)을 넘겨 타임아웃나는 것을 방지
+          command_timeout: 30m
           envs: POSTGRES_DB,POSTGRES_USER,POSTGRES_PASSWORD,DB_USERNAME,DB_PASSWORD,KAKAO_CLIENT_ID,KAKAO_CLIENT_SECRET,KAKAO_API_KEY,KAKAO_API_BASE_URL,MINIO_ACCESS_KEY,MINIO_SECRET_KEY,MINIO_EXTERNAL_ENDPOINT,MINIO_BUCKET,MINIO_SERVER_URL
           script: |
             set -e


### PR DESCRIPTION
## 배경
PR #424 머지 후 dev 배포(`dev_cd.yml`)가 `Run Command Timeout`으로 실패.

## 원인
- 컴파일 오류 아님(`compileJava` 성공, deprecation 경고만).
- 머지 후 EC2 원격에서 `docker compose --profile app up -d --build`(= `./gradlew build`)가 실행되는데, `appleboy/ssh-action`의 기본 `command_timeout`이 **10분**.
- 코드 변경으로 `COPY src` 레이어 캐시가 무효화 → 풀 빌드가 10분을 초과 → 타임아웃(잡 실행시간 10m 3s).
- 즉 src가 바뀌는 모든 배포에서 재발 가능한 인프라 설정 문제.

## 변경
- `dev_cd.yml`, `prod_cd.yml`의 `appleboy/ssh-action`에 `command_timeout: 30m` 추가.

## 참고
- 이 PR이 dev에 머지되면 이후 배포부터 30분 타임아웃이 적용됩니다.
- #424 코드(이미 dev에 있음)는 이 배포로 함께 반영됩니다.