### PR TITLE
[FIX] 프로필 이미지 업로드 실패 로그 상향 + StorageService 테스트

### DIFF
--- a/src/main/java/com/dokdok/storage/service/StorageService.java
+++ b/src/main/java/com/dokdok/storage/service/StorageService.java
@@ -57,7 +57,7 @@ public class StorageService {
 
 			return fileName;
 		} catch (Exception e) {
-            log.debug("파일 업로드 실패 {}", e.getMessage());
+            log.error("프로필 이미지 업로드 실패 (object={}): {}", fileName, e.getMessage(), e);
 			throw new StorageException(StorageErrorCode.FILE_UPLOAD_FAILED, e);
 		}
 	}

--- a/src/test/java/com/dokdok/storage/service/StorageServiceTest.java
+++ b/src/test/java/com/dokdok/storage/service/StorageServiceTest.java
@@ -1,0 +1,143 @@
+package com.dokdok.storage.service;
+
+import com.dokdok.global.util.SecurityUtil;
+import com.dokdok.storage.exception.StorageErrorCode;
+import com.dokdok.storage.exception.StorageException;
+import io.minio.BucketExistsArgs;
+import io.minio.MinioClient;
+import io.minio.PutObjectArgs;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+/**
+ * 프로필 이미지 업로드 실패(S001)의 원인을 좁히기 위한 테스트.
+ *
+ * 핵심 증명:
+ *  - S001(FILE_UPLOAD_FAILED)은 파일 검증 실패가 아니라, MinIO 호출
+ *    (putObject / bucketExists)이 예외를 던질 때(=스토리지 연결/인증/권한 문제) 발생한다.
+ *  - 파일 검증 실패는 S001이 아닌 별도 코드(S003/S004)로 구분된다.
+ *  => 따라서 사용자가 받은 S001은 클라이언트/검증 문제가 아니라
+ *     "서버가 MinIO에 올리는 단계"에서 실패했다는 의미임을 증명한다.
+ */
+@ExtendWith(MockitoExtension.class)
+class StorageServiceTest {
+
+    @Mock
+    private MinioClient internalMinioClient;
+
+    @Mock
+    private MinioClient externalMinioClient;
+
+    private StorageService storageService;
+
+    @BeforeEach
+    void setUp() {
+        // 동일 타입 빈 2개라 @InjectMocks 이름 매칭이 불안정 → 생성자로 명확히 주입
+        storageService = new StorageService(internalMinioClient, externalMinioClient);
+        // @Value 로 주입되는 버킷명을 테스트에서 설정 (MinIO Args 빌드 검증 통과용)
+        ReflectionTestUtils.setField(storageService, "bucket", "dokdok-storage");
+    }
+
+    private MultipartFile pngFile() {
+        return new MockMultipartFile(
+                "profileImage", "photo.png", "image/png", new byte[]{1, 2, 3});
+    }
+
+    @Test
+    @DisplayName("MinIO putObject가 실패하면 S001(FILE_UPLOAD_FAILED)로 변환되어 던져진다 - 사용자가 본 에러의 원인")
+    void uploadProfileImage_whenMinioPutObjectFails_throwsS001() throws Exception {
+        // given: 버킷은 존재하지만 업로드(putObject)가 연결 실패 등으로 예외를 던지는 상황
+        lenient().when(internalMinioClient.bucketExists(any(BucketExistsArgs.class))).thenReturn(true);
+        doThrow(new IOException("Connection refused"))
+                .when(internalMinioClient).putObject(any(PutObjectArgs.class));
+
+        try (MockedStatic<SecurityUtil> mock = mockStatic(SecurityUtil.class)) {
+            mock.when(SecurityUtil::getCurrentUserId).thenReturn(1L);
+
+            // when & then
+            assertThatThrownBy(() -> storageService.uploadProfileImage(pngFile()))
+                    .isInstanceOf(StorageException.class)
+                    .extracting(e -> ((StorageException) e).getErrorCode())
+                    .isEqualTo(StorageErrorCode.FILE_UPLOAD_FAILED);
+        }
+    }
+
+    @Test
+    @DisplayName("MinIO 연결 실패로 bucketExists 단계에서 예외가 나도 S001로 던져진다 - 스토리지 접근 자체가 안 되는 경우")
+    void uploadProfileImage_whenMinioUnreachableAtBucketCheck_throwsS001() throws Exception {
+        // given: 스토리지에 아예 접근이 안 되는 상황 (bucketExists에서 예외)
+        given(internalMinioClient.bucketExists(any(BucketExistsArgs.class)))
+                .willThrow(new IOException("Connection refused"));
+
+        try (MockedStatic<SecurityUtil> mock = mockStatic(SecurityUtil.class)) {
+            mock.when(SecurityUtil::getCurrentUserId).thenReturn(1L);
+
+            assertThatThrownBy(() -> storageService.uploadProfileImage(pngFile()))
+                    .isInstanceOf(StorageException.class)
+                    .extracting(e -> ((StorageException) e).getErrorCode())
+                    .isEqualTo(StorageErrorCode.FILE_UPLOAD_FAILED);
+
+            // 업로드까지 가지도 못함
+            verify(internalMinioClient, never()).putObject(any(PutObjectArgs.class));
+        }
+    }
+
+    @Test
+    @DisplayName("지원하지 않는 확장자는 검증 단계에서 S003으로 막히고, MinIO 호출조차 하지 않는다 - S001과 구분됨")
+    void uploadProfileImage_whenInvalidExtension_throwsS003_andNeverCallsMinio() throws Exception {
+        // given: gif (허용: jpg/jpeg/png)
+        MultipartFile gif = new MockMultipartFile(
+                "profileImage", "photo.gif", "image/gif", new byte[]{1, 2, 3});
+
+        // when & then
+        assertThatThrownBy(() -> storageService.uploadProfileImage(gif))
+                .isInstanceOf(StorageException.class)
+                .extracting(e -> ((StorageException) e).getErrorCode())
+                .isEqualTo(StorageErrorCode.INVALID_FILE_TYPE);
+
+        verify(internalMinioClient, never()).bucketExists(any(BucketExistsArgs.class));
+        verify(internalMinioClient, never()).putObject(any(PutObjectArgs.class));
+    }
+
+    @Test
+    @DisplayName("5MB 초과 파일은 검증 단계에서 S004로 막힌다 - S001과 구분됨")
+    void uploadProfileImage_whenFileTooLarge_throwsS004() {
+        // given: 5MB 초과 (.png)
+        byte[] tooLarge = new byte[5 * 1024 * 1024 + 1];
+        MultipartFile bigFile = new MockMultipartFile(
+                "profileImage", "big.png", "image/png", tooLarge);
+
+        // when & then
+        assertThatThrownBy(() -> storageService.uploadProfileImage(bigFile))
+                .isInstanceOf(StorageException.class)
+                .extracting(e -> ((StorageException) e).getErrorCode())
+                .isEqualTo(StorageErrorCode.FILE_SIZE_EXCEEDED);
+    }
+
+    @Test
+    @DisplayName("프로필 이미지가 없으면(null) presigned URL은 null을 반환한다 - 이미지 미설정과 업로드 실패는 별개")
+    void getPresignedProfileImage_whenNull_returnsNull() {
+        assertThat(storageService.getPresignedProfileImage(null)).isNull();
+        assertThat(storageService.getPresignedProfileImage("  ")).isNull();
+    }
+}


### PR DESCRIPTION
## 배경
QA: 프로필 사진 변경이 `{"code":"S001","message":"파일 업로드에 실패했습니다."}`로 실패.
(멤버 관리/각 화면 프로필 이미지가 안 나오는 것도 같은 뿌리일 가능성 — 업로드 실패 시 이미지가 저장되지 않음)

## 진단 (테스트로 증명)
`StorageServiceTest` 추가로 S001의 발생 지점을 명확히 함:
- **MinIO `putObject`/`bucketExists` 호출 실패 → S001** (= 스토리지 연결/인증/권한 문제)
- 확장자 위반은 **S003**, 용량 초과는 **S004** 로 MinIO 호출 전에 구분됨
- 프로필 미설정(null)은 presigned URL `null` 반환(정상)

→ 사용자가 받은 **S001은 파일 검증/프론트 문제가 아니라 "서버가 MinIO에 올리는 단계"에서 실패**했다는 의미. 원인은 MinIO 연결/인증/버킷 권한 영역.

## 변경
- `StorageService.uploadProfileImage` catch 로그: `log.debug` → `log.error`(스택트레이스 포함)
  - 기존엔 운영 로그(INFO)에 실제 MinIO 예외가 안 남아 원인 파악 불가였음
- `StorageServiceTest` 신규 (5 케이스)

## 남은 작업 (환경, 코드 밖)
dev 서버에서 실제 원인 확인 필요:
- MinIO 컨테이너 상태 / 앱→MinIO 네트워크(`MINIO_INTERNAL_ENDPOINT`, `dokdok-shared`)
- access/secret key, 버킷 권한
- 이 PR 머지 후 다음 업로드 실패 시 `log.error` 스택트레이스로 정확한 원인 확인 가능