### PR TITLE
[#428][FIX] 주제가 확정된 이후 주제 등록이 가능했던 오류 개선

### DIFF
--- a/src/main/java/com/dokdok/topic/service/TopicService.java
+++ b/src/main/java/com/dokdok/topic/service/TopicService.java
@@ -6,6 +6,8 @@ import com.dokdok.meeting.entity.Meeting;
 import com.dokdok.meeting.entity.MeetingMember;
 import com.dokdok.meeting.entity.MeetingStatus;
 import com.dokdok.global.response.CursorResponse;
+import com.dokdok.meeting.exception.MeetingErrorCode;
+import com.dokdok.meeting.exception.MeetingException;
 import com.dokdok.meeting.repository.MeetingMemberRepository;
 import com.dokdok.meeting.service.MeetingValidator;
 import com.dokdok.topic.dto.request.ConfirmTopicsRequest;
@@ -92,6 +94,9 @@ public class TopicService {
         meetingValidator.validateMeetingStatus(meetingId);
 
         MeetingMember meetingMember = meetingValidator.getMeetingMember(meetingId, userId);
+        if (!topicRepository.canSuggestTopic(meetingId, userId)) {
+            throw new MeetingException(MeetingErrorCode.MEETING_ALREADY_CONFIRMED);
+        }
 
         Meeting meeting = meetingMember.getMeeting();
         User user = meetingMember.getUser();

--- a/src/test/java/com/dokdok/topic/service/TopicServiceTest.java
+++ b/src/test/java/com/dokdok/topic/service/TopicServiceTest.java
@@ -428,6 +428,9 @@ class TopicServiceTest {
             given(meetingValidator.getMeetingMember(meetingId, userId))
                     .willReturn(testMeetingMember);
 
+            given(topicRepository.canSuggestTopic(meetingId, userId))
+                    .willReturn(true);
+
             // Topic 저장 성공
             given(topicRepository.save(any(Topic.class)))
                     .willReturn(testTopic);
@@ -447,7 +450,45 @@ class TopicServiceTest {
             verify(meetingValidator).validateMeetingInGathering(meetingId, gatheringId);
             verify(meetingValidator).validateMeetingStatus(meetingId);
             verify(meetingValidator).getMeetingMember(meetingId, userId);
+            verify(topicRepository).canSuggestTopic(meetingId, userId);
             verify(topicRepository).save(any(Topic.class));
+        }
+    }
+
+    @Test
+    @DisplayName("이미 확정된 주제가 있으면 주제를 생성할 수 없다")
+    void createTopic_ConfirmedTopicExists_ThrowsException() {
+        Long gatheringId = 1L;
+        Long meetingId = 1L;
+        Long userId = 1L;
+
+        try (MockedStatic<SecurityUtil> securityUtilMock = mockStatic(SecurityUtil.class)) {
+            securityUtilMock.when(SecurityUtil::getCurrentUserId)
+                    .thenReturn(userId);
+
+            doNothing().when(gatheringValidator)
+                    .validateGathering(gatheringId);
+
+            doNothing().when(meetingValidator)
+                    .validateMeetingInGathering(meetingId, gatheringId);
+
+            doNothing().when(meetingValidator)
+                    .validateMeetingStatus(meetingId);
+
+            given(meetingValidator.getMeetingMember(meetingId, userId))
+                    .willReturn(testMeetingMember);
+
+            given(topicRepository.canSuggestTopic(meetingId, userId))
+                    .willReturn(false);
+
+            assertThatThrownBy(() ->
+                    topicService.createTopic(gatheringId, meetingId, testRequest))
+                    .isInstanceOf(MeetingException.class)
+                    .hasFieldOrPropertyWithValue("errorCode",
+                            MeetingErrorCode.MEETING_ALREADY_CONFIRMED);
+
+            verify(topicRepository).canSuggestTopic(meetingId, userId);
+            verify(topicRepository, never()).save(any());
         }
     }
 


### PR DESCRIPTION
## PR 요약
  > 이 PR이 어떤 변경을 하는지 간단히 설명하고, 체크 표시는 괄호 사이에 소문자 'x'를 삽입하세요.

  - [ ] 기능 추가
  - [ ] 버그 수정
  - [ ] 코드 리팩토링
  - [ ] 문서 수정
  - [ ] 기타 (설명)

  ---

  ## 이슈 번호
  - #

  ---

  ## 주요 변경 사항
  > 주요 파일, 로직, 컴포넌트 등을 구체적으로 적어주세요.

  - `파일명/모듈명`: 변경 내용 요약
  - `파일명/모듈명`: 수정 이유

  ---

  ## 참고 사항
  > 리뷰어가 알아야 할 추가 정보, 테스트 방법 등을 작성해주세요.

  예:
  - 테스트 계정 정보
  - 관련 API 엔드포인트
  - 로컬 테스트 방법

  --- 이것도


• ## PR 요약
  > 이 PR이 어떤 변경을 하는지 간단히 설명하고, 체크 표시는 괄호 사이에 소문자 'x'를 삽입하세요.

  - [ ] 기능 추가
  - [x] 버그 수정
  - [ ] 코드 리팩토링
  - [ ] 문서 수정
  - [ ] 기타 (설명)

  주제 확정 이후 새로고침하지 않은 기존 화면에서 주제 등록 요청을 보내도 서버에서 등록을 차단하도록 수정합니다.

  ---

  ## 이슈 번호
  - #428 

  ---

  ## 주요 변경 사항
  > 주요 파일, 로직, 컴포넌트 등을 구체적으로 적어주세요.

  - `TopicService`: 주제 생성 시 `canSuggestTopic`을 재검증하여 확정된 주제가 있는 경우 등록을 차단
  - `TopicServiceTest`: 확정된 주제가 있으면 주제 생성이 실패하고 저장 로직이 호출되지 않는 테스트 추가

  ---

  ## 참고 사항
  > 리뷰어가 알아야 할 추가 정보, 테스트 방법 등을 작성해주세요.

  - 관련 API 엔드포인트: `POST /api/gatherings/{gatheringId}/meetings/{meetingId}/topics`
  - 로컬 테스트 방법:
    - `./gradlew test --tests com.dokdok.topic.service.TopicServiceTest`
  - 검증 결과:
    - `TopicServiceTest` 통과