### PR TITLE
[#430][FIX] 내 책장 책 삭제 시 모든 리뷰 삭제

### DIFF
--- a/src/main/java/com/dokdok/book/service/PersonalBookService.java
+++ b/src/main/java/com/dokdok/book/service/PersonalBookService.java
@@ -181,27 +181,29 @@ public class PersonalBookService {
     }
 
     @Transactional
-    public void deleteBook(Long bookId) {
+    public void deleteBook(Long personalBookId) {
         User userEntity = userValidator.findUserOrThrow(SecurityUtil.getCurrentUserId());
 
-        PersonalBook personalBook = bookValidator.validateInBookShelf(userEntity.getId(), bookId);
+        PersonalBook personalBook = bookValidator.validatePersonalBook(userEntity.getId(), personalBookId);
 
         personalBookRepository.delete(personalBook);
+        Long bookId = personalBook.getBook().getId();
         bookReviewRepository.findByBookIdAndUserId(bookId, userEntity.getId())
                 .ifPresent(review -> review.deleteReview());
     }
 
     @Transactional
-    public void deleteBooks(List<Long> bookIds) {
+    public void deleteBooks(List<Long> personalBookIds) {
         User userEntity = userValidator.findUserOrThrow(SecurityUtil.getCurrentUserId());
 
-        List<Long> distinctBookIds = bookIds.stream()
+        List<Long> distinctIds = personalBookIds.stream()
                 .distinct()
                 .toList();
 
-        for (Long bookId : distinctBookIds) {
-            PersonalBook personalBook = bookValidator.validateInBookShelf(userEntity.getId(), bookId);
+        for (Long personalBookId : distinctIds) {
+            PersonalBook personalBook = bookValidator.validatePersonalBook(userEntity.getId(), personalBookId);
             personalBookRepository.delete(personalBook);
+            Long bookId = personalBook.getBook().getId();
             bookReviewRepository.findByBookIdAndUserId(bookId, userEntity.getId())
                     .ifPresent(review -> review.deleteReview());
         }

--- a/src/test/java/com/dokdok/book/service/PersonalBookServiceTest.java
+++ b/src/test/java/com/dokdok/book/service/PersonalBookServiceTest.java
@@ -530,6 +530,7 @@ class PersonalBookServiceTest {
     void deleteBook_Success() {
         // given
         Long userId = 1L;
+        Long personalBookId = 100L;
         Long bookId = 10L;
 
         User user = User.builder()
@@ -547,7 +548,7 @@ class PersonalBookServiceTest {
                 .build();
 
         PersonalBook personalBook = PersonalBook.builder()
-                .id(100L)
+                .id(personalBookId)
                 .user(user)
                 .book(book)
                 .readingStatus(BookReadingStatus.READING)
@@ -555,16 +556,16 @@ class PersonalBookServiceTest {
 
         securityUtilMock.when(SecurityUtil::getCurrentUserId).thenReturn(userId);
         when(userValidator.findUserOrThrow(userId)).thenReturn(user);
-        when(bookValidator.validateInBookShelf(userId, bookId)).thenReturn(personalBook);
+        when(bookValidator.validatePersonalBook(userId, personalBookId)).thenReturn(personalBook);
         when(bookReviewRepository.findByBookIdAndUserId(bookId, userId)).thenReturn(Optional.empty());
 
         // when
-        personalBookService.deleteBook(bookId);
+        personalBookService.deleteBook(personalBookId);
 
         // then
         securityUtilMock.verify(SecurityUtil::getCurrentUserId, times(1));
         verify(userValidator, times(1)).findUserOrThrow(userId);
-        verify(bookValidator, times(1)).validateInBookShelf(userId, bookId);
+        verify(bookValidator, times(1)).validatePersonalBook(userId, personalBookId);
         verify(personalBookRepository, times(1)).delete(personalBook);
     }
 
@@ -573,7 +574,7 @@ class PersonalBookServiceTest {
     void deleteBook_NotFound() {
         // given
         Long userId = 1L;
-        Long bookId = 10L;
+        Long personalBookId = 100L;
 
         User user = User.builder()
                 .id(userId)
@@ -583,17 +584,17 @@ class PersonalBookServiceTest {
 
         securityUtilMock.when(SecurityUtil::getCurrentUserId).thenReturn(userId);
         when(userValidator.findUserOrThrow(userId)).thenReturn(user);
-        when(bookValidator.validateInBookShelf(userId, bookId))
+        when(bookValidator.validatePersonalBook(userId, personalBookId))
                 .thenThrow(new BookException(BookErrorCode.BOOK_NOT_IN_SHELF));
 
         // when & then
-        assertThatThrownBy(() -> personalBookService.deleteBook(bookId))
+        assertThatThrownBy(() -> personalBookService.deleteBook(personalBookId))
                 .isInstanceOf(BookException.class)
                 .hasFieldOrPropertyWithValue("errorCode", BookErrorCode.BOOK_NOT_IN_SHELF);
 
         securityUtilMock.verify(SecurityUtil::getCurrentUserId, times(1));
         verify(userValidator, times(1)).findUserOrThrow(userId);
-        verify(bookValidator, times(1)).validateInBookShelf(userId, bookId);
+        verify(bookValidator, times(1)).validatePersonalBook(userId, personalBookId);
         verify(personalBookRepository, never()).delete(any());
     }
 
@@ -602,7 +603,7 @@ class PersonalBookServiceTest {
     void deleteBooks_Success() {
         // given
         Long userId = 1L;
-        List<Long> bookIds = List.of(10L, 11L);
+        List<Long> personalBookIds = List.of(100L, 101L);
 
         User user = User.builder()
                 .id(userId)
@@ -628,29 +629,29 @@ class PersonalBookServiceTest {
 
         securityUtilMock.when(SecurityUtil::getCurrentUserId).thenReturn(userId);
         when(userValidator.findUserOrThrow(userId)).thenReturn(user);
-        when(bookValidator.validateInBookShelf(userId, 10L)).thenReturn(firstPersonalBook);
-        when(bookValidator.validateInBookShelf(userId, 11L)).thenReturn(secondPersonalBook);
+        when(bookValidator.validatePersonalBook(userId, 100L)).thenReturn(firstPersonalBook);
+        when(bookValidator.validatePersonalBook(userId, 101L)).thenReturn(secondPersonalBook);
         when(bookReviewRepository.findByBookIdAndUserId(10L, userId)).thenReturn(Optional.empty());
         when(bookReviewRepository.findByBookIdAndUserId(11L, userId)).thenReturn(Optional.empty());
 
         // when
-        personalBookService.deleteBooks(bookIds);
+        personalBookService.deleteBooks(personalBookIds);
 
         // then
         securityUtilMock.verify(SecurityUtil::getCurrentUserId, times(1));
         verify(userValidator, times(1)).findUserOrThrow(userId);
-        verify(bookValidator, times(1)).validateInBookShelf(userId, 10L);
-        verify(bookValidator, times(1)).validateInBookShelf(userId, 11L);
+        verify(bookValidator, times(1)).validatePersonalBook(userId, 100L);
+        verify(bookValidator, times(1)).validatePersonalBook(userId, 101L);
         verify(personalBookRepository, times(1)).delete(firstPersonalBook);
         verify(personalBookRepository, times(1)).delete(secondPersonalBook);
     }
 
     @Test
-    @DisplayName("다건 삭제에서 중복 bookId는 한 번만 처리된다")
+    @DisplayName("다건 삭제에서 중복 personalBookId는 한 번만 처리된다")
     void deleteBooks_DeduplicateIds() {
         // given
         Long userId = 1L;
-        List<Long> bookIds = List.of(10L, 10L, 10L);
+        List<Long> personalBookIds = List.of(100L, 100L, 100L);
 
         User user = User.builder()
                 .id(userId)
@@ -668,14 +669,14 @@ class PersonalBookServiceTest {
 
         securityUtilMock.when(SecurityUtil::getCurrentUserId).thenReturn(userId);
         when(userValidator.findUserOrThrow(userId)).thenReturn(user);
-        when(bookValidator.validateInBookShelf(userId, 10L)).thenReturn(personalBook);
+        when(bookValidator.validatePersonalBook(userId, 100L)).thenReturn(personalBook);
         when(bookReviewRepository.findByBookIdAndUserId(10L, userId)).thenReturn(Optional.empty());
 
         // when
-        personalBookService.deleteBooks(bookIds);
+        personalBookService.deleteBooks(personalBookIds);
 
         // then
-        verify(bookValidator, times(1)).validateInBookShelf(userId, 10L);
+        verify(bookValidator, times(1)).validatePersonalBook(userId, 100L);
         verify(personalBookRepository, times(1)).delete(personalBook);
     }
 


### PR DESCRIPTION
## PR 요약
> 이 PR이 어떤 변경을 하는지 간단히 설명하고, 체크 표시는 괄호 사이에 소문자 'x'를 삽입하세요.

- [ ] 기능 추가
- [x] 버그 수정
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 기타 (설명)

---

## 이슈 번호
- #430 

---

## 주요 변경 사항
> 주요 파일, 로직, 컴포넌트 등을 구체적으로 적어주세요.
                                                                                                                                                   
  - PersonalBookService.deleteBook() / deleteBooks(): validateInBookShelf(bookId) → validatePersonalBook(personalBookId)로 교체                                                    
    - PersonalBook을 찾은 후 personalBook.getBook().getId()로 bookId를 꺼내 BookReview 조회에 사용                                                                                 
  - 테스트: 파라미터를 PersonalBook PK(100L, 101L)로 변경하고 mock 검증도 validatePersonalBook으로 업데이트 

---

## 참고 사항
> 리뷰어가 알아야 할 추가 정보, 테스트 방법 등을 작성해주세요.

예:  
- 테스트 계정 정보  
- 관련 API 엔드포인트  
- 로컬 테스트 방법  

---