### PR TITLE
[#442][FIX] 사전의견 빈 토픽 제출 허용

### DIFF
--- a/src/main/java/com/dokdok/topic/dto/request/TopicAnswerBulkSubmitRequest.java
+++ b/src/main/java/com/dokdok/topic/dto/request/TopicAnswerBulkSubmitRequest.java
@@ -3,7 +3,6 @@ package com.dokdok.topic.dto.request;
 import com.dokdok.book.dto.request.BookReviewRequest;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 
 import java.util.List;
@@ -14,8 +13,7 @@ public record TopicAnswerBulkSubmitRequest(
         @Valid
         @Schema(description = "공유할 책 평가 정보. 제출 시 사전의견 전용 저장소와 내 책장 리뷰에 반영됩니다.")
         BookReviewRequest review,
-        @NotEmpty
-        @Schema(description = "제출할 토픽 ID 목록", example = "[1,2,3]")
+        @Schema(description = "제출할 토픽 ID 목록 (빈 사전답변 제출 허용)", example = "[1,2,3]")
         List<@NotNull Long> topicIds
 ) {
 }

--- a/src/main/java/com/dokdok/topic/service/TopicAnswerService.java
+++ b/src/main/java/com/dokdok/topic/service/TopicAnswerService.java
@@ -177,7 +177,7 @@ public class TopicAnswerService {
         meetingValidator.validateMeetingInGathering(meetingId, gatheringId);
         meetingValidator.validateMeetingMember(meetingId, userId);
 
-        List<Long> topicIds = request.topicIds();
+        List<Long> topicIds = request.topicIds() != null ? request.topicIds() : List.of();
         List<Topic> topics = topicRepository.findAllByIdInAndMeetingId(topicIds, meetingId);
         if (topics.size() != topicIds.size()) {
             throw new TopicException(TopicErrorCode.TOPIC_NOT_FOUND);

--- a/src/test/java/com/dokdok/topic/service/TopicAnswerServiceTest.java
+++ b/src/test/java/com/dokdok/topic/service/TopicAnswerServiceTest.java
@@ -260,6 +260,49 @@ class TopicAnswerServiceTest {
     }
 
     @Test
+    @DisplayName("빈 토픽 목록으로도 제출(공유)할 수 있다")
+    void submitMyAnswer_allowsEmptyTopicIds() {
+        given(topicRepository.findAllByIdInAndMeetingId(List.of(), 1L))
+                .willReturn(List.of());
+        given(topicAnswerRepository.findByMeetingIdUserId(1L, 1L))
+                .willReturn(List.of());
+        given(preOpinionBookReviewService.upsertReview(eq(1L), any(BookReviewRequest.class)))
+                .willReturn(new BookReviewResponse(1L, 10L, 1L, BigDecimal.valueOf(4.5), List.of(), null));
+
+        TopicAnswerBulkSubmitRequest request = new TopicAnswerBulkSubmitRequest(
+                new BookReviewRequest(BigDecimal.valueOf(4.5), List.of(1L)),
+                List.of()
+        );
+        PreOpinionSubmitResponse response =
+                topicAnswerService.submitMyAnswer(1L, 1L, request);
+
+        verify(preOpinionBookReviewService).applyToPersonalBookReview(eq(1L), any(BookReviewRequest.class));
+        verify(topicAnswerRepository, never()).save(any(TopicAnswer.class));
+        assertThat(response.review().reviewId()).isEqualTo(1L);
+        assertThat(response.answers()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("토픽 목록이 null이어도 제출(공유)할 수 있다")
+    void submitMyAnswer_allowsNullTopicIds() {
+        given(topicRepository.findAllByIdInAndMeetingId(List.of(), 1L))
+                .willReturn(List.of());
+        given(topicAnswerRepository.findByMeetingIdUserId(1L, 1L))
+                .willReturn(List.of());
+        given(preOpinionBookReviewService.upsertReview(eq(1L), any(BookReviewRequest.class)))
+                .willReturn(new BookReviewResponse(1L, 10L, 1L, BigDecimal.valueOf(4.5), List.of(), null));
+
+        TopicAnswerBulkSubmitRequest request = new TopicAnswerBulkSubmitRequest(
+                new BookReviewRequest(BigDecimal.valueOf(4.5), List.of(1L)),
+                null
+        );
+        PreOpinionSubmitResponse response =
+                topicAnswerService.submitMyAnswer(1L, 1L, request);
+
+        assertThat(response.answers()).isEmpty();
+    }
+
+    @Test
     @DisplayName("이미 제출된 답변은 다시 제출할 수 없다")
     void submitMyAnswer_throwsWhenAlreadySubmitted() {
         Topic topic = Topic.builder().id(12L).build();


### PR DESCRIPTION
## PR 요약
> 사전의견 공유하기(제출) 시 선택된 토픽이 없으면 G002 "비어 있을 수 없습니다" 오류로 제출이 불가하던 문제를 수정합니다. 커밋 6f3d7c8(빈 사전답변 제출 가능) 의도에 맞춰 제약을 정리합니다.

- [ ] 기능 추가
- [x] 버그 수정
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 기타 (설명)

---

## 이슈 번호
- #442

Closes #442

---

## 주요 변경 사항
- `TopicAnswerBulkSubmitRequest`: `topicIds`의 `@NotEmpty` 제거 — 빈 토픽 목록 제출 허용 (보고된 G002의 직접 원인)
- `TopicAnswerService.submitAnswersBulk`: `topicIds` null-safe 처리 (FE가 null 전송 시 NPE 방지, save 경로와 동일 패턴)
- `TopicAnswerServiceTest`: 빈 리스트/null 제출 정상 동작 케이스 2건 추가

---

## 참고 사항
- 재현: 약속 생성 후 사전의견 작성 → 공유하기 시 G002 발생 → 본 수정으로 빈 토픽도 제출 가능
- 책 평가(`review`/`keywordIds`)는 기존대로 필수 유지 — 커밋 의도가 "토픽 답변"에 한정되어 범위에서 제외. 책평가를 선택값으로 전환할지는 별도 기획 결정 필요.
- 테스트: `./gradlew test --tests "com.dokdok.topic.service.TopicAnswerServiceTest"` 통과
