### PR TITLE
[#444][FIX] 책 평가하기시 최신 데이터로 불러오게 수정

### DIFF
--- a/src/main/java/com/dokdok/book/dto/response/BookReviewResponse.java
+++ b/src/main/java/com/dokdok/book/dto/response/BookReviewResponse.java
@@ -39,7 +39,7 @@ public record BookReviewResponse(
                 review.getUser().getId(),
                 review.getRating(),
                 keywordInfos,
-                review.getCreatedAt()
+                review.getUpdatedAt()
         );
     }
 

--- a/src/test/java/com/dokdok/book/service/BookReviewServiceTest.java
+++ b/src/test/java/com/dokdok/book/service/BookReviewServiceTest.java
@@ -337,7 +337,9 @@ class BookReviewServiceTest {
             when(keywordValidator.validateAndGetSelectableKeyword(5L)).thenReturn(newKeyword);
             when(keywordValidator.validateAndGetSelectableKeyword(8L)).thenReturn(newKeywordSecond);
 
+            LocalDateTime beforeUpdate = LocalDateTime.now();
             BookReviewResponse response = bookReviewService.updateMyReview(1L, request);
+            LocalDateTime afterUpdate = LocalDateTime.now();
 
             assertThat(review.getRating()).isEqualTo(new BigDecimal("3.5"));
             assertThat(review.getKeywords()).hasSize(2);
@@ -346,6 +348,7 @@ class BookReviewServiceTest {
                     new BookReviewResponse.KeywordInfo(8L, "위로", KeywordType.IMPRESSION)
             );
             assertThat(response.reviewId()).isEqualTo(10L);
+            assertThat(response.createdAt()).isBetween(beforeUpdate, afterUpdate);
         }
     }
 


### PR DESCRIPTION
## PR 요약
  > 이 PR이 어떤 변경을 하는지 간단히 설명하고, 체크 표시는 괄호 사이에 소문자 'x'를 삽입하세요.

  - [ ] 기능 추가
  - [x] 버그 수정
  - [ ] 코드 리팩토링
  - [ ] 문서 수정
  - [ ] 기타 (설명)

  책 평가 수정 후 책 상세 메인 화면에서 평가 일자가 최초 작성일로 표시되던 문제를 수정합니다.

  ---

  ## 이슈 번호
  - #444 

  ---

  ## 주요 변경 사항
  > 주요 파일, 로직, 컴포넌트 등을 구체적으로 적어주세요.

  - `BookReviewResponse`: 책 리뷰 응답 날짜를 최초 작성일이 아닌 최신 수정일 기준으로 반환하도록 변경
  - `BookReviewServiceTest`: 책 리뷰 수정 후 응답 날짜가 최신 수정 시각으로 반환되는지 검증 추가

  ---

  ## 참고 사항
  > 리뷰어가 알아야 할 추가 정보, 테스트 방법 등을 작성해주세요.

  - 관련 API 엔드포인트: `GET /api/book/{bookId}/reviews/me`
  - 영향 화면: 책 상세 메인, 지난 평가
  - 로컬 테스트 방법:
    - `./gradlew test --tests com.dokdok.book.service.BookReviewServiceTest`
  - 추가 검증:
    - `./gradlew test --tests com.dokdok.topic.service.TopicAnswerServiceTest --tests com.dokdok.topic.service.TopicServiceTest`
