### PR TITLE
[#451][FIX] canWritePreOpinions 조건 변경

### DIFF
--- a/src/main/java/com/dokdok/topic/service/TopicService.java
+++ b/src/main/java/com/dokdok/topic/service/TopicService.java
@@ -275,10 +275,11 @@ public class TopicService {
             );
         }
         boolean hasConfirmedTopics = confirmedTopicsCount > 0;
+        boolean isMeetingMember = meetingMemberRepository.existsActiveMemberByMeetingIdAndUserId(meetingId, userId);
 
         ConfirmedTopicsResponse.Actions actions = ConfirmedTopicsResponse.Actions.of(
-                hasSubmitted,
-                isMeetingConfirmed && hasConfirmedTopics && !hasSubmitted
+                isMeetingMember && hasSubmitted,
+                isMeetingMember && isMeetingConfirmed && hasConfirmedTopics && !hasSubmitted
         );
 
         CursorResponse<ConfirmedTopicsResponse.ConfirmedTopicDto, ConfirmedTopicsCursor> page =

--- a/src/test/java/com/dokdok/topic/service/TopicServiceTest.java
+++ b/src/test/java/com/dokdok/topic/service/TopicServiceTest.java
@@ -355,6 +355,8 @@ class TopicServiceTest {
                 given(topicAnswerRepository.existsByMeetingIdAndUserId(meetingId, userId))
                         .willReturn(false);
                 given(meetingValidator.findMeetingOrThrow(meetingId)).willReturn(testMeeting);
+                given(meetingMemberRepository.existsActiveMemberByMeetingIdAndUserId(meetingId, userId))
+                        .willReturn(true);
 
                 ConfirmedTopicsResponse response =
                         topicService.getConfirmedTopics(gatheringId, meetingId, pageSize, null, null);
@@ -373,6 +375,50 @@ class TopicServiceTest {
                 verify(gatheringValidator).validateMembership(gatheringId, userId);
                 verify(meetingValidator).validateMeetingInGathering(meetingId, gatheringId);
                 verify(topicRepository).findConfirmedTopicsFirstPage(eq(meetingId), any(Pageable.class));
+            }
+        }
+
+        @Test
+        @DisplayName("약속 참가자가 아니면 사전 의견 작성 액션이 비활성화된다")
+        void getConfirmedTopics_CannotWriteWhenNotMeetingMember() {
+            Long gatheringId = 1L;
+            Long meetingId = 1L;
+            Long userId = 1L;
+            int pageSize = 10;
+
+            Topic topic = Topic.builder()
+                    .id(12L)
+                    .meeting(testMeeting)
+                    .proposedBy(testUser)
+                    .title("첫 번째 주제")
+                    .description("첫 번째 설명")
+                    .topicType(TopicType.DISCUSSION)
+                    .topicStatus(TopicStatus.CONFIRMED)
+                    .confirmOrder(1)
+                    .build();
+
+            try (MockedStatic<SecurityUtil> securityUtilMock = mockStatic(SecurityUtil.class)) {
+                securityUtilMock.when(SecurityUtil::getCurrentUserId).thenReturn(userId);
+
+                doNothing().when(gatheringValidator).validateMembership(gatheringId, userId);
+                doNothing().when(meetingValidator).validateMeetingInGathering(meetingId, gatheringId);
+                given(topicRepository.findConfirmedTopicsFirstPage(eq(meetingId), any(Pageable.class)))
+                        .willReturn(List.of(topic));
+                given(topicRepository.countByMeetingIdAndTopicStatusAndDeletedAtIsNull(meetingId, TopicStatus.CONFIRMED))
+                        .willReturn(1L);
+                given(topicAnswerRepository.existsByMeetingIdAndUserId(meetingId, userId))
+                        .willReturn(false);
+                given(meetingValidator.findMeetingOrThrow(meetingId)).willReturn(testMeeting);
+                given(meetingMemberRepository.existsActiveMemberByMeetingIdAndUserId(meetingId, userId))
+                        .willReturn(false);
+
+                ConfirmedTopicsResponse response =
+                        topicService.getConfirmedTopics(gatheringId, meetingId, pageSize, null, null);
+
+                assertThat(response.actions().canViewPreOpinions()).isFalse();
+                assertThat(response.actions().canWritePreOpinions()).isFalse();
+
+                verify(meetingMemberRepository).existsActiveMemberByMeetingIdAndUserId(meetingId, userId);
             }
         }
 


### PR DESCRIPTION
 ## PR 요약
  > 이 PR이 어떤 변경을 하는지 간단히 설명하고, 체크 표시는 괄호 사이에 소문자 'x'를 삽입하세요.

  - [ ] 기능 추가
  - [x] 버그 수정
  - [ ] 코드 리팩토링
  - [ ] 문서 수정
  - [ ] 기타 (설명)

  확정된 주제 조회 API의 사전의견 액션 값이 약속 참가 여부를 반영하도록 수정합니다.

  ---

  ## 이슈 번호
  - #451 

  ---

  ## 주요 변경 사항
  > 주요 파일, 로직, 컴포넌트 등을 구체적으로 적어주세요.

  - `TopicService`: 확정된 주제 조회 시 약속 참가 여부를 확인해 사전의견 작성/조회 액션을 계산하도록 변경
  - `TopicServiceTest`: 약속 참가자가 아닌 경우 `canWritePreOpinions`가 `false`로 내려가는 테스트 추가

  ---

  ## 참고 사항
  > 리뷰어가 알아야 할 추가 정보, 테스트 방법 등을 작성해주세요.

  - 관련 API 엔드포인트: `GET /api/gatherings/{gatheringId}/meetings/{meetingId}/confirm-topics`
  - 영향 응답 필드:
    - `actions.canViewPreOpinions`
    - `actions.canWritePreOpinions`
  - 로컬 테스트 방법:
    - `./gradlew test --tests com.dokdok.topic.service.TopicServiceTest`
