### PR TITLE
[CHORE] CD에서 EC2 빌드 제거하고 GHCR 이미지 pull 방식으로 전환

### DIFF
--- a/.github/workflows/dev_cd.yml
+++ b/.github/workflows/dev_cd.yml
@@ -3,8 +3,17 @@ on:
     branches: [ "dev" ]
     types: [ closed ]
 
+permissions:
+  contents: read
+  packages: write   # GITHUB_TOKEN 으로 GHCR push
+
+env:
+  IMAGE: ghcr.io/fc-de/dokdok-server
+
 jobs:
-  deploy:
+  # 1) 빌드는 빈약한 EC2 가 아니라 GitHub 러너(7GB RAM)에서 수행하고
+  #    완성된 이미지를 GHCR 에 push 한다. EC2 는 더 이상 빌드하지 않는다.
+  build-and-push:
     if: >
       github.event.pull_request.merged == true &&
       github.event.pull_request.base.ref == 'dev'
@@ -13,14 +22,40 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: |
+            ${{ env.IMAGE }}:dev
+            ${{ env.IMAGE }}:dev-${{ github.sha }}
+          # 의존성 레이어 캐시를 GitHub Actions 캐시에 저장 → build.gradle 안 바뀌면 재다운로드 없음
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  # 2) EC2 는 SSH 로 들어가 새 이미지를 pull 해서 띄우기만 한다 (--build 없음).
+  deploy:
+    needs: build-and-push
+    runs-on: ubuntu-latest
+    steps:
       - name: SSH to EC2 and deploy
         uses: appleboy/ssh-action@v1.2.0
         with:
           host: ${{ secrets.EC2_HOST }}
           username: ${{ secrets.EC2_USER }}
           key: ${{ secrets.EC2_SSH_KEY }}
-          # 원격에서 docker build(gradle 빌드)가 10분(기본값)을 넘겨 타임아웃나는 것을 방지
-          command_timeout: 30m
+          command_timeout: 10m
           envs: POSTGRES_DB,POSTGRES_USER,POSTGRES_PASSWORD,DB_USERNAME,DB_PASSWORD,KAKAO_CLIENT_ID,KAKAO_CLIENT_SECRET,KAKAO_API_KEY,KAKAO_API_BASE_URL,MINIO_ACCESS_KEY,MINIO_SECRET_KEY,MINIO_EXTERNAL_ENDPOINT,MINIO_BUCKET,MINIO_SERVER_URL
           script: |
             set -e
@@ -52,7 +87,10 @@ jobs:
             MINIO_SERVER_URL=${MINIO_SERVER_URL}
             EOF
 
-            docker compose --profile app up -d --build app
+            # 러너가 GHCR 에 올린 최신 이미지를 받아 교체 (EC2 빌드 없음)
+            docker compose --profile app pull app
+            docker compose --profile app up -d app
+            docker image prune -f
             docker compose ps
         env:
           POSTGRES_DB: ${{ secrets.DEV_POSTGRES_DB }}

--- a/.github/workflows/prod_cd.yml
+++ b/.github/workflows/prod_cd.yml
@@ -3,8 +3,16 @@ on:
     branches: [ "main" ]
     types: [ closed ]
 
+permissions:
+  contents: read
+  packages: write   # GITHUB_TOKEN 으로 GHCR push
+
+env:
+  IMAGE: ghcr.io/fc-de/dokdok-server
+
 jobs:
-  deploy:
+  # 1) 러너에서 이미지 빌드 → GHCR push (EC2 는 빌드하지 않음)
+  build-and-push:
     if: >
       github.event.pull_request.merged == true &&
       github.event.pull_request.base.ref == 'main'
@@ -13,14 +21,39 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: |
+            ${{ env.IMAGE }}:prod
+            ${{ env.IMAGE }}:prod-${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  # 2) EC2 는 새 이미지를 pull 해서 띄우기만 한다 (--build 없음)
+  deploy:
+    needs: build-and-push
+    runs-on: ubuntu-latest
+    steps:
       - name: SSH to EC2 and deploy
         uses: appleboy/ssh-action@v1.2.0
         with:
           host: ${{ secrets.EC2_HOST }}
           username: ${{ secrets.EC2_USER }}
           key: ${{ secrets.EC2_SSH_KEY }}
-          # 원격에서 docker build(gradle 빌드)가 10분(기본값)을 넘겨 타임아웃나는 것을 방지
-          command_timeout: 30m
+          command_timeout: 10m
           envs: POSTGRES_DB,POSTGRES_USER,POSTGRES_PASSWORD,DB_USERNAME,DB_PASSWORD,KAKAO_CLIENT_ID,KAKAO_CLIENT_SECRET,KAKAO_API_KEY,KAKAO_API_BASE_URL,MINIO_ACCESS_KEY,MINIO_SECRET_KEY,MINIO_EXTERNAL_ENDPOINT,MINIO_BUCKET,MINIO_SERVER_URL
           script: |
             set -e
@@ -52,7 +85,9 @@ jobs:
             MINIO_SERVER_URL=${MINIO_SERVER_URL}
             EOF
 
-            docker compose --profile app up -d --build app
+            docker compose --profile app pull app
+            docker compose --profile app up -d app
+            docker image prune -f
             docker compose ps
         env:
           POSTGRES_DB: ${{ secrets.PROD_POSTGRES_DB }}

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,9 +1,9 @@
 services:
   app:
     profiles: ["app"]
-    build:
-      context: .
-      dockerfile: Dockerfile
+    # 러너(GitHub Actions)가 GHCR 에 올린 이미지를 받아 띄운다. EC2 빌드 없음.
+    # 태그는 프로필별로 분기: dev → :dev, prod → :prod (CD 워크플로가 동일 태그로 push)
+    image: ghcr.io/fc-de/dokdok-server:${SPRING_PROFILE:-dev}
     container_name: dokdok-${SPRING_PROFILE:-dev}-app
     environment:
       TZ: Asia/Seoul


### PR DESCRIPTION
## PR 요약
> 빈약한 EC2(1.9GB)에서 매 배포마다 Gradle 멀티스테이지 빌드를 돌려 swap 쓰래싱으로
> CD가 5분→20분까지 느려지던 문제를, 빌드를 GitHub 러너로 옮기고 EC2는 GHCR 이미지를
> pull 해서 띄우기만 하도록 전환했습니다.

- [x] 기타 (CI/CD 설정 변경 — 빌드 파이프라인 구조 개선)

---

## 이슈 번호
- 없음

---

## 주요 변경 사항
- `.github/workflows/dev_cd.yml`, `prod_cd.yml`: `ubuntu-latest` 러너에서 이미지 빌드 →
  `ghcr.io/fc-de/dokdok-server:{dev,prod}` push (`GITHUB_TOKEN`, GHA 캐시로 의존성 레이어 캐싱).
  EC2 SSH 스텝은 `docker compose pull` + `up -d`로 교체(`--build` 제거). `command_timeout` 30m→10m.
- `compose.yaml`: `app` 서비스 `build:` → `image: ghcr.io/fc-de/dokdok-server:${SPRING_PROFILE:-dev}`
  (dev/prod 동일 compose, 프로필로 태그 분기).

---

## 참고 사항
- **운영 선행조건(완료):** GHCR 패키지가 private 이라 EC2에서 최초 1회 `docker login ghcr.io`
  (`read:packages` PAT) 필요 → 이미 적용함(`Login Succeeded`). dev/prod 동일 호스트라 1회로 커버.
- 머지 시 동작: 러너가 이미지 빌드·push → EC2가 pull·재기동(빌드 없음). 첫 배포에서 GHCR에
  이미지가 생성됨.
- 검증: 머지 후 `build-and-push` 잡 성공 + EC2 `docker compose ps`로 app 기동, `docker images`에
  `ghcr.io/...:dev` 확인.
