### PR TITLE
[FIX] 독서 타임라인 sort=LATEST/OLDEST 미지원으로 감상 기록 안 보이던 문제 수정

### DIFF
--- a/src/main/java/com/dokdok/book/api/PersonalBookRecordApi.java
+++ b/src/main/java/com/dokdok/book/api/PersonalBookRecordApi.java
@@ -635,7 +635,7 @@ public interface PersonalBookRecordApi {
                     - preOpinionTime: 사전 의견 정렬 기준 (MEETING_START | ANSWER_CREATED, 기본값 ANSWER_CREATED)
                     - gatheringId: 미전달 시 전체 조회, 전달 시 해당 모임의 항목만 조회
                     - recordType: 미전달 시 전체 조회, MEMO/QUOTE 전달 시 독서 기록 유형 필터 (회고/사전의견은 영향 없음)
-                    - sort: DESC(최신순, 기본값) / ASC(오래된순)
+                    - sort: LATEST(최신순, 기본값) / OLDEST(오래된순) — DESC/ASC 도 하위 호환으로 허용
 
                     **사용 방법**
                     - 첫 페이지: `?size=10&preOpinionTime=ANSWER_CREATED`
@@ -696,8 +696,8 @@ public interface PersonalBookRecordApi {
             @RequestParam(required = false) Long gatheringId,
             @Parameter(description = "독서 기록 유형 필터 (MEMO | QUOTE, 미전달 시 전체 조회)")
             @RequestParam(required = false) RecordType recordType,
-            @Parameter(description = "정렬 기준 (DESC: 최신순, ASC: 오래된순)", example = "DESC")
-            @RequestParam(required = false, defaultValue = "DESC") TimelineSortType sort
+            @Parameter(description = "정렬 기준 (LATEST: 최신순, OLDEST: 오래된순 / DESC·ASC 하위 호환)", example = "LATEST")
+            @RequestParam(required = false, defaultValue = "LATEST") TimelineSortType sort
     );
 
     @Operation(

--- a/src/main/java/com/dokdok/book/controller/PersonalBookRecordController.java
+++ b/src/main/java/com/dokdok/book/controller/PersonalBookRecordController.java
@@ -101,7 +101,7 @@ public class PersonalBookRecordController implements PersonalBookRecordApi {
             @RequestParam(required = false, defaultValue = "ANSWER_CREATED") PreOpinionTimeType preOpinionTime,
             @RequestParam(required = false) Long gatheringId,
             @RequestParam(required = false) RecordType recordType,
-            @RequestParam(required = false, defaultValue = "DESC") TimelineSortType sort
+            @RequestParam(required = false, defaultValue = "LATEST") TimelineSortType sort
     ) {
         CursorResponse<ReadingTimelineItem, ReadingTimelineCursor> response =
                 readingTimelineService.getTimeline(

--- a/src/main/java/com/dokdok/book/dto/request/TimelineSortType.java
+++ b/src/main/java/com/dokdok/book/dto/request/TimelineSortType.java
@@ -1,5 +1,13 @@
 package com.dokdok.book.dto.request;
 
 public enum TimelineSortType {
-    DESC, ASC
+    LATEST,   // 최신순(내림차순) — 프런트 기본값
+    OLDEST,   // 오래된순(오름차순)
+    DESC,     // 하위 호환: LATEST 와 동일(최신순)
+    ASC;      // 하위 호환: OLDEST 와 동일(오래된순)
+
+    /** 오름차순(오래된 순) 정렬이면 true */
+    public boolean isAscending() {
+        return this == OLDEST || this == ASC;
+    }
 }

--- a/src/main/java/com/dokdok/book/repository/ReadingTimelineRepository.java
+++ b/src/main/java/com/dokdok/book/repository/ReadingTimelineRepository.java
@@ -31,8 +31,9 @@ public class ReadingTimelineRepository {
             Long cursorSourceId,
             int limit
     ) {
-        String dir = sort == TimelineSortType.ASC ? "ASC" : "DESC";
-        String cursorCompare = sort == TimelineSortType.ASC
+        boolean ascending = sort != null && sort.isAscending();
+        String dir = ascending ? "ASC" : "DESC";
+        String cursorCompare = ascending
                 ? "event_at > :cursorEventAt OR (event_at = :cursorEventAt AND (type_order > :cursorTypeOrder OR (type_order = :cursorTypeOrder AND source_id > :cursorSourceId)))"
                 : "event_at < :cursorEventAt OR (event_at = :cursorEventAt AND (type_order < :cursorTypeOrder OR (type_order = :cursorTypeOrder AND source_id < :cursorSourceId)))";
 

--- a/src/test/java/com/dokdok/book/dto/request/TimelineSortTypeTest.java
+++ b/src/test/java/com/dokdok/book/dto/request/TimelineSortTypeTest.java
@@ -1,0 +1,45 @@
+package com.dokdok.book.dto.request;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * QA: 책 상세 "감상 기록 란"이 안 뜨던 버그 회귀 테스트.
+ * 원인 = FE 가 보내는 sort=LATEST 가 enum 상수에 없어 @RequestParam 바인딩
+ * (Enum.valueOf) 이 실패 → MethodArgumentTypeMismatchException → G003.
+ * 따라서 LATEST/OLDEST 가 유효한 상수여야 하고, 정렬 방향 매핑이 맞아야 한다.
+ */
+class TimelineSortTypeTest {
+
+    @DisplayName("해피: FE 가 보내는 LATEST/OLDEST 가 enum 상수로 바인딩된다 (과거 G003 원인)")
+    @ParameterizedTest
+    @ValueSource(strings = {"LATEST", "OLDEST", "DESC", "ASC"})
+    void valueOf_supportsFrontendAndLegacyTokens(String token) {
+        assertThat(TimelineSortType.valueOf(token)).isNotNull();
+    }
+
+    @DisplayName("해피: 정렬 방향 매핑 - OLDEST/ASC 만 오름차순, LATEST/DESC 는 내림차순")
+    @ParameterizedTest
+    @CsvSource({
+            "LATEST,false",
+            "DESC,false",
+            "OLDEST,true",
+            "ASC,true"
+    })
+    void isAscending_mapsByMeaning(TimelineSortType sort, boolean ascending) {
+        assertThat(sort.isAscending()).isEqualTo(ascending);
+    }
+
+    @DisplayName("더티: 정의되지 않은 토큰은 거부된다 (바인딩 단계에서 G003 으로 처리됨)")
+    @Test
+    void valueOf_rejectsUnknownToken() {
+        assertThatThrownBy(() -> TimelineSortType.valueOf("INVALID"))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+}


### PR DESCRIPTION
## PR 요약
> 책 상세의 "감상 기록 란"이 호출하는 타임라인 API가 sort=LATEST 를 인식하지 못해
> 400(G003)으로 실패, 목록이 비어 "기록이 저장되지 않는 것처럼" 보이던 QA 버그를 수정합니다.
> (저장은 정상이었고, 조회 API의 sort 파라미터 enum 불일치가 원인)

- [x] 버그 수정

---

## 이슈 번호
- 없음

---

## 주요 변경 사항
- `TimelineSortType`: FE가 보내는 `LATEST`/`OLDEST` 값 추가(`DESC`/`ASC` 하위 호환 유지),
  의미 기반 `isAscending()` 헬퍼 추가
- `ReadingTimelineRepository`: 정렬 방향 판정을 `sort == ASC` → `sort.isAscending()`(null-safe)로
  변경해 `OLDEST`도 오름차순으로 매핑
- `PersonalBookRecordController` / `PersonalBookRecordApi`: `sort` 기본값 `DESC`→`LATEST`,
  Swagger 문서 동기화(B14)
- `TimelineSortTypeTest`(신규): 해피(LATEST/OLDEST 바인딩·방향 매핑) + 더티(미정의 토큰 거부)

---

## 참고 사항
- 원인: `GET /api/book/{personalBookId}/records/timeline?sort=LATEST` 의 `sort` 가
  `TimelineSortType`(기존 DESC/ASC만)에 없어 `@RequestParam` 바인딩(Enum.valueOf) 실패
  → `MethodArgumentTypeMismatchException`(G003).
- 하위 호환 유지: `DESC`/`ASC` 도 계속 허용되어 기존 호출 안 깨짐.
- DB 스키마 변경 없음(요청 파라미터 enum이라 영속화 X → CHECK 제약 무관).
- 검증: `compileJava` OK, 신규 회귀 테스트 OK, `com.dokdok.book.*` 전체 테스트 OK.
- 참고(별건): 일반 기록 목록 `GET /{personalBookId}/records` 의 `sort` 는 Spring `Sort.Direction`
  (DESC/ASC)이라, FE가 그쪽에도 `LATEST` 를 보낸다면 동일 이슈가 발생할 수 있어 확인 필요.
