### PR TITLE
[#455][FIX] 개인 회고가 책 상세의 회고 기록 목록에 안 보이던 문제 수정

### DIFF
--- a/src/main/java/com/dokdok/retrospective/service/PersonalRetrospectiveService.java
+++ b/src/main/java/com/dokdok/retrospective/service/PersonalRetrospectiveService.java
@@ -1,5 +1,6 @@
 package com.dokdok.retrospective.service;
 
+import com.dokdok.book.entity.PersonalBook;
 import com.dokdok.book.service.BookValidator;
 import com.dokdok.global.response.CursorResponse;
 import com.dokdok.meeting.exception.MeetingErrorCode;
@@ -195,7 +196,8 @@ public class PersonalRetrospectiveService {
     ) {
         Long userId = SecurityUtil.getCurrentUserId();
 
-        bookValidator.validateBook(personalBookId);
+        PersonalBook personalBook = bookValidator.validatePersonalBook(userId, personalBookId);
+        Long bookId = personalBook.getBook().getId();
 
         int fetchSize = pageSize + 1;
         PageRequest pageable = PageRequest.of(0, fetchSize);
@@ -204,14 +206,14 @@ public class PersonalRetrospectiveService {
         Integer totalCount = null;
         if (cursorCreatedAt == null || cursorRetrospectiveId == null) {
             retrospectives = personalRetrospectiveRepository.findRetrospectivesFirstPage(
-                    personalBookId, userId, pageable
+                    bookId, userId, pageable
             );
             totalCount = personalRetrospectiveRepository.countRetrospectivesByBookAndUser(
-                    personalBookId, userId
+                    bookId, userId
             );
         } else {
             retrospectives = personalRetrospectiveRepository.findRetrospectivesAfterCursor(
-                    personalBookId, userId, cursorCreatedAt, cursorRetrospectiveId, pageable
+                    bookId, userId, cursorCreatedAt, cursorRetrospectiveId, pageable
             );
         }
 

--- a/src/test/java/com/dokdok/retrospective/service/PersonalRetrospectiveServiceTest.java
+++ b/src/test/java/com/dokdok/retrospective/service/PersonalRetrospectiveServiceTest.java
@@ -1,5 +1,7 @@
 package com.dokdok.retrospective.service;
 
+import com.dokdok.book.entity.Book;
+import com.dokdok.book.entity.PersonalBook;
 import com.dokdok.book.entity.ReflectionRecordType;
 import com.dokdok.gathering.entity.Gathering;
 import com.dokdok.global.exception.GlobalErrorCode;
@@ -1267,10 +1269,11 @@ class PersonalRetrospectiveServiceTest {
     // ==================== getRetrospectiveRecords 테스트 ====================
 
     @Test
-    @DisplayName("책별 개인 회고 목록을 정상적으로 조회한다 (첫 페이지)")
+    @DisplayName("책별 개인 회고 목록을 정상적으로 조회한다 (첫 페이지) - personalBookId 를 실제 bookId 로 변환해 조회한다")
     void getRetrospectiveRecords_success() {
         // given
-        Long bookId = 1L;
+        Long personalBookId = 7L;   // 책장 항목 PK
+        Long bookId = 1L;           // 실제 도서 PK (personalBookId 와 다름)
         Long userId = 3L;
         Long retrospectiveId = 100L;
         int pageSize = 10;
@@ -1289,6 +1292,16 @@ class PersonalRetrospectiveServiceTest {
                 .id(userId).
                 build();
 
+        Book book = Book.builder()
+                .id(bookId)
+                .build();
+
+        PersonalBook personalBook = PersonalBook.builder()
+                .id(personalBookId)
+                .user(user)
+                .book(book)
+                .build();
+
         PersonalMeetingRetrospective retrospective = PersonalMeetingRetrospective.builder()
                 .id(retrospectiveId)
                 .meeting(meeting)
@@ -1300,7 +1313,7 @@ class PersonalRetrospectiveServiceTest {
         try (MockedStatic<SecurityUtil> securityUtilMock = mockStatic(SecurityUtil.class)) {
             securityUtilMock.when(SecurityUtil::getCurrentUserId).thenReturn(userId);
 
-            doNothing().when(bookValidator).validateBook(bookId);
+            when(bookValidator.validatePersonalBook(userId, personalBookId)).thenReturn(personalBook);
             when(personalRetrospectiveRepository.findRetrospectivesFirstPage(eq(bookId), eq(userId), any()))
                     .thenReturn(retrospectives);
             when(changedThoughtRepository.findByRetrospectiveIds(List.of(retrospectiveId)))
@@ -1319,15 +1332,17 @@ class PersonalRetrospectiveServiceTest {
 
             // when
             CursorResponse<RetrospectiveRecordResponse, RetrospectiveRecordsCursor> response =
-                    personalRetrospectiveService.getRetrospectiveRecords(bookId, pageSize, null, null);
+                    personalRetrospectiveService.getRetrospectiveRecords(personalBookId, pageSize, null, null);
 
             // then
             assertThat(response.items()).hasSize(1);
             assertThat(response.pageSize()).isEqualTo(pageSize);
             assertThat(response.hasNext()).isFalse();
 
-            verify(bookValidator).validateBook(bookId);
+            verify(bookValidator).validatePersonalBook(userId, personalBookId);
+            // personalBookId 가 아니라 변환된 실제 bookId 로 조회해야 한다 (회귀 방지)
             verify(personalRetrospectiveRepository).findRetrospectivesFirstPage(eq(bookId), eq(userId), any());
+            verify(personalRetrospectiveRepository).countRetrospectivesByBookAndUser(bookId, userId);
             verify(changedThoughtRepository).findByRetrospectiveIds(List.of(retrospectiveId));
             verify(othersPerspectiveRepository).findByRetrospectiveIds(List.of(retrospectiveId));
             verify(freeTextRepository).findByRetrospectiveIds(List.of(retrospectiveId));
@@ -1339,27 +1354,36 @@ class PersonalRetrospectiveServiceTest {
     @DisplayName("회고가 없으면 빈 리스트를 반환한다")
     void getRetrospectiveRecords_returnsEmptyList_whenNoRetrospectives() {
         // given
+        Long personalBookId = 7L;
         Long bookId = 1L;
         Long userId = 3L;
         int pageSize = 10;
 
+        User user = User.builder().id(userId).build();
+        Book book = Book.builder().id(bookId).build();
+        PersonalBook personalBook = PersonalBook.builder()
+                .id(personalBookId)
+                .user(user)
+                .book(book)
+                .build();
+
         try (MockedStatic<SecurityUtil> securityUtilMock = mockStatic(SecurityUtil.class)) {
             securityUtilMock.when(SecurityUtil::getCurrentUserId).thenReturn(userId);
 
-            doNothing().when(bookValidator).validateBook(bookId);
+            when(bookValidator.validatePersonalBook(userId, personalBookId)).thenReturn(personalBook);
             when(personalRetrospectiveRepository.findRetrospectivesFirstPage(eq(bookId), eq(userId), any()))
                     .thenReturn(List.of());
 
             // when
             CursorResponse<RetrospectiveRecordResponse, RetrospectiveRecordsCursor> response =
-                    personalRetrospectiveService.getRetrospectiveRecords(bookId, pageSize, null, null);
+                    personalRetrospectiveService.getRetrospectiveRecords(personalBookId, pageSize, null, null);
 
             // then
             assertThat(response.items()).isEmpty();
             assertThat(response.hasNext()).isFalse();
             assertThat(response.nextCursor()).isNull();
 
-            verify(bookValidator).validateBook(bookId);
+            verify(bookValidator).validatePersonalBook(userId, personalBookId);
             verify(personalRetrospectiveRepository).findRetrospectivesFirstPage(eq(bookId), eq(userId), any());
             verify(changedThoughtRepository, never()).findByRetrospectiveIds(any());
             verify(othersPerspectiveRepository, never()).findByRetrospectiveIds(any());
@@ -1368,23 +1392,23 @@ class PersonalRetrospectiveServiceTest {
     }
 
     @Test
-    @DisplayName("책이 존재하지 않으면 예외가 발생한다")
-    void getRetrospectiveRecords_throwsWhenBookNotFound() {
+    @DisplayName("책장에 없는 책이면 예외가 발생한다")
+    void getRetrospectiveRecords_throwsWhenBookNotInShelf() {
         // given
-        Long bookId = 999L;
+        Long personalBookId = 999L;
         Long userId = 3L;
         int pageSize = 10;
 
         try (MockedStatic<SecurityUtil> securityUtilMock = mockStatic(SecurityUtil.class)) {
             securityUtilMock.when(SecurityUtil::getCurrentUserId).thenReturn(userId);
 
-            doThrow(new BookException(BookErrorCode.BOOK_NOT_FOUND))
-                    .when(bookValidator).validateBook(bookId);
+            doThrow(new BookException(BookErrorCode.BOOK_NOT_IN_SHELF))
+                    .when(bookValidator).validatePersonalBook(userId, personalBookId);
 
             // when & then
-            assertThatThrownBy(() -> personalRetrospectiveService.getRetrospectiveRecords(bookId, pageSize, null, null))
+            assertThatThrownBy(() -> personalRetrospectiveService.getRetrospectiveRecords(personalBookId, pageSize, null, null))
                     .isInstanceOf(BookException.class)
-                    .hasFieldOrPropertyWithValue("errorCode", BookErrorCode.BOOK_NOT_FOUND);
+                    .hasFieldOrPropertyWithValue("errorCode", BookErrorCode.BOOK_NOT_IN_SHELF);
 
             verify(personalRetrospectiveRepository, never()).findRetrospectivesFirstPage(any(), any(), any());
         }
@@ -1394,7 +1418,7 @@ class PersonalRetrospectiveServiceTest {
     @DisplayName("인증 정보가 없으면 예외가 발생한다 - 회고 기록 조회")
     void getRetrospectiveRecords_throwsWhenUnauthenticated() {
         // given
-        Long bookId = 1L;
+        Long personalBookId = 7L;
         int pageSize = 10;
 
         try (MockedStatic<SecurityUtil> securityUtilMock = mockStatic(SecurityUtil.class)) {
@@ -1402,11 +1426,11 @@ class PersonalRetrospectiveServiceTest {
                     .thenThrow(new GlobalException(GlobalErrorCode.UNAUTHORIZED));
 
             // when & then
-            assertThatThrownBy(() -> personalRetrospectiveService.getRetrospectiveRecords(bookId, pageSize, null, null))
+            assertThatThrownBy(() -> personalRetrospectiveService.getRetrospectiveRecords(personalBookId, pageSize, null, null))
                     .isInstanceOf(GlobalException.class)
                     .hasFieldOrPropertyWithValue("errorCode", GlobalErrorCode.UNAUTHORIZED);
 
-            verify(bookValidator, never()).validateBook(any());
+            verify(bookValidator, never()).validatePersonalBook(any(), any());
         }
     }
 


### PR DESCRIPTION
## PR 요약
> 책 상세의 "개인 회고 목록"(GET /api/book/{personalBookId}/records/retrospectives)이 항상 비어 있던 버그를 수정합니다. 회고 저장은 정상이었고, 조회 시 personalBookId를 실제 Book.id로 오인해 매칭에 실패한 것이 원인입니다.

- [x] 버그 수정

---

## 이슈 번호
- #455

Closes #455

---

## 주요 변경 사항
- `PersonalRetrospectiveService.getRetrospectiveRecords`: path의 `personalBookId`(책장 항목 PK)를 실제 `Book.id`로 그대로 사용하던 것을, `validatePersonalBook`으로 `PersonalBook`을 조회해 실제 `bookId`로 변환하도록 수정. 회고 조회 쿼리는 `WHERE b.id = :bookId`(실제 도서 PK 기대)라 실데이터에서 `personalBookId != bookId`이면 결과가 항상 비어 있었음. 타임라인 서비스(`getTimeline`)와 동일한 방식으로 정렬하고, 소유자 검증도 함께 수행.
- `PersonalRetrospectiveServiceTest`: 기존 테스트가 입력값을 `bookId`라 부르며 동일 값으로 버그를 가리고 있던 것을, `personalBookId(7L) != bookId(1L)`로 분리해 "변환된 실제 bookId로 조회"하는지 검증하도록 갱신(회귀 방지). 없는 책 케이스는 `BOOK_NOT_IN_SHELF`로 변경.

---

## 참고 사항
- 영향 엔드포인트: `GET /api/book/{personalBookId}/records/retrospectives`
- 동작 변경: 책장에 없는 personalBookId 요청 시 에러코드가 `BOOK_NOT_FOUND` → `BOOK_NOT_IN_SHELF`로 바뀜(타임라인 엔드포인트와 일관).
- 회귀 테스트: `./gradlew test --tests "com.dokdok.retrospective.service.PersonalRetrospectiveServiceTest"` 통과(BUILD SUCCESSFUL).
- 참고: 같은 `WHERE b.id = :bookId` 쿼리를 쓰는 `findByBookAndUser`의 다른 호출부도 실제 bookId를 넘기는지 후속 점검 권장(이번 PR 범위 밖).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
