### PR TITLE
[#457][FIX] 책 상세 독서모임 필터에 무관한 모임이 뜨던 문제 수정

### DIFF
--- a/src/main/java/com/dokdok/book/repository/PersonalBookRepository.java
+++ b/src/main/java/com/dokdok/book/repository/PersonalBookRepository.java
@@ -184,16 +184,16 @@ public interface PersonalBookRepository extends JpaRepository<PersonalBook, Long
 
     @Query(value = """
             SELECT DISTINCT g.gathering_id AS gatheringId, g.gathering_name AS gatheringName
-            FROM personal_book pb
-            JOIN gathering g ON pb.gathering_id = g.gathering_id
-            WHERE pb.user_id = :userId
-              AND pb.deleted_at IS NULL
+            FROM meeting m
+            JOIN gathering g ON g.gathering_id = m.gathering_id
+            JOIN meeting_member mm ON mm.meeting_id = m.meeting_id AND mm.user_id = :userId
+            WHERE m.book_id = :bookId
+              AND m.deleted_at IS NULL
               AND g.deleted_at IS NULL
-              AND pb.personal_book_id = :personalBookId
             """, nativeQuery = true)
     List<PersonalBookGatheringProjection> findActiveGatheringsWithMeetingsByUserAndBook(
             @Param("userId") Long userId,
-            @Param("personalBookId") Long personalBookId
+            @Param("bookId") Long bookId
     );
 
 }

--- a/src/main/java/com/dokdok/book/service/PersonalReadingRecordService.java
+++ b/src/main/java/com/dokdok/book/service/PersonalReadingRecordService.java
@@ -224,8 +224,9 @@ public class PersonalReadingRecordService {
     public List<PersonalBookGatheringResponse> getGatheringsForBook(Long personalBookId) {
         Long userId = SecurityUtil.getCurrentUserId();
         PersonalBook personalBook = bookValidator.validatePersonalBook(userId, personalBookId);
+        Long bookId = personalBook.getBook().getId();
         return personalBookRepository
-                .findActiveGatheringsWithMeetingsByUserAndBook(userId, personalBookId)
+                .findActiveGatheringsWithMeetingsByUserAndBook(userId, bookId)
                 .stream()
                 .map(p -> new PersonalBookGatheringResponse(p.getGatheringId(), p.getGatheringName()))
                 .toList();

--- a/src/test/java/com/dokdok/book/repository/PersonalBookRepositoryGatheringFilterTest.java
+++ b/src/test/java/com/dokdok/book/repository/PersonalBookRepositoryGatheringFilterTest.java
@@ -1,0 +1,168 @@
+package com.dokdok.book.repository;
+
+import com.dokdok.book.entity.Book;
+import com.dokdok.gathering.entity.Gathering;
+import com.dokdok.meeting.entity.Meeting;
+import com.dokdok.meeting.entity.MeetingMember;
+import com.dokdok.meeting.entity.MeetingStatus;
+import com.dokdok.user.entity.User;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.boot.jpa.test.autoconfigure.TestEntityManager;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * QA: "모임에 없는 책인데 필터링 버튼이 있음" 회귀 테스트.
+ *
+ * 책 상세의 독서모임 필터 목록(GET /api/book/{personalBookId}/gatherings)은
+ * "그 책으로 약속(meeting)이 잡혔고, 그 약속에 내가 참여한" 모임만 나와야 한다.
+ * 과거 구현은 personal_book.gathering_id 만 봐서 책과 무관한 모임이 노출됐다.
+ * PersonalBookRepository.findActiveGatheringsWithMeetingsByUserAndBook 를 실제 DB로 검증한다.
+ */
+@DataJpaTest
+@ActiveProfiles("test")
+class PersonalBookRepositoryGatheringFilterTest {
+
+    @Autowired
+    private PersonalBookRepository personalBookRepository;
+
+    @Autowired
+    private TestEntityManager em;
+
+    @Test
+    @DisplayName("그 책으로 약속이 잡힌, 내가 참여한 모임만 반환한다 (다른 책 모임은 제외)")
+    void returnsOnlyGatheringsWhereBookIsUsedAndUserIsMember() {
+        // given
+        User user = persistUser("회원");
+
+        Book targetBook = persistBook("모순");
+        Book otherBook = persistBook("관련없는책");
+
+        // 대상 책으로 약속이 잡힌 모임 (내가 참여) → 포함되어야 함
+        Gathering targetGathering = persistGathering(user, "2차QA모임");
+        Meeting targetMeeting = persistMeeting(targetGathering, targetBook);
+        persistMember(targetMeeting, user);
+
+        // 다른 책으로 약속이 잡힌 모임 (내가 참여) → 제외되어야 함
+        Gathering otherGathering = persistGathering(user, "다른모임");
+        Meeting otherMeeting = persistMeeting(otherGathering, otherBook);
+        persistMember(otherMeeting, user);
+
+        em.flush();
+        em.clear();
+
+        // when
+        List<PersonalBookGatheringProjection> result =
+                personalBookRepository.findActiveGatheringsWithMeetingsByUserAndBook(
+                        user.getId(), targetBook.getId());
+
+        // then
+        assertThat(result)
+                .extracting(PersonalBookGatheringProjection::getGatheringName)
+                .containsExactly("2차QA모임");
+    }
+
+    @Test
+    @DisplayName("그 책으로 약속이 있어도 내가 참여하지 않은 모임은 제외한다")
+    void excludesGatheringWhereUserIsNotMeetingMember() {
+        // given
+        User user = persistUser("회원");
+        User other = persistUser("남");
+
+        Book book = persistBook("모순");
+
+        Gathering gathering = persistGathering(other, "내가없는모임");
+        Meeting meeting = persistMeeting(gathering, book);
+        persistMember(meeting, other); // 다른 사람만 참여
+
+        em.flush();
+        em.clear();
+
+        // when
+        List<PersonalBookGatheringProjection> result =
+                personalBookRepository.findActiveGatheringsWithMeetingsByUserAndBook(
+                        user.getId(), book.getId());
+
+        // then
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("같은 모임에서 같은 책으로 약속이 여러 개여도 중복 없이 한 번만 반환한다")
+    void deduplicatesSameGathering() {
+        // given
+        User user = persistUser("회원");
+        Book book = persistBook("모순");
+
+        Gathering gathering = persistGathering(user, "2차QA모임");
+        Meeting m1 = persistMeeting(gathering, book);
+        Meeting m2 = persistMeeting(gathering, book);
+        persistMember(m1, user);
+        persistMember(m2, user);
+
+        em.flush();
+        em.clear();
+
+        // when
+        List<PersonalBookGatheringProjection> result =
+                personalBookRepository.findActiveGatheringsWithMeetingsByUserAndBook(
+                        user.getId(), book.getId());
+
+        // then
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getGatheringName()).isEqualTo("2차QA모임");
+    }
+
+    private User persistUser(String name) {
+        return em.persist(User.builder()
+                .userName(name)
+                .nickname(name)
+                .userEmail(name + System.nanoTime() + "@test.com")
+                .kakaoId(System.nanoTime())
+                .build());
+    }
+
+    private Gathering persistGathering(User leader, String name) {
+        return em.persist(Gathering.builder()
+                .gatheringLeader(leader)
+                .gatheringName(name)
+                .invitationLink("invite-" + System.nanoTime())
+                .build());
+    }
+
+    private Book persistBook(String name) {
+        return em.persist(Book.builder()
+                .bookName(name)
+                .author("저자")
+                .publisher("출판사")
+                .isbn("978-" + System.nanoTime())
+                .build());
+    }
+
+    private Meeting persistMeeting(Gathering gathering, Book book) {
+        return em.persist(Meeting.builder()
+                .gathering(gathering)
+                .book(book)
+                .meetingName("테스트 약속")
+                .meetingStatus(MeetingStatus.CONFIRMED)
+                .meetingStartDate(LocalDateTime.of(2026, 1, 1, 19, 0))
+                .meetingEndDate(LocalDateTime.of(2026, 1, 1, 21, 0))
+                .build());
+    }
+
+    private void persistMember(Meeting meeting, User user) {
+        em.persist(MeetingMember.builder()
+                .meeting(meeting)
+                .user(user)
+                .joinedAt(LocalDateTime.of(2026, 1, 1, 12, 0))
+                .updatedAt(LocalDateTime.of(2026, 1, 1, 12, 0))
+                .build());
+    }
+}

--- a/src/test/java/com/dokdok/book/service/PersonalReadingRecordServiceTest.java
+++ b/src/test/java/com/dokdok/book/service/PersonalReadingRecordServiceTest.java
@@ -596,7 +596,8 @@ class PersonalReadingRecordServiceTest {
             PersonalBookGatheringProjection p2 = mockProjection(2L, "독서모임B");
 
             when(bookValidator.validatePersonalBook(userId, personalBookId)).thenReturn(personalBook);
-            when(personalBookRepository.findActiveGatheringsWithMeetingsByUserAndBook(userId, personalBookId))
+            // personalBookId(10L) 가 아니라 변환된 실제 bookId(100L) 로 조회해야 한다 (회귀 방지)
+            when(personalBookRepository.findActiveGatheringsWithMeetingsByUserAndBook(userId, bookId))
                     .thenReturn(List.of(p1, p2));
 
             // when
@@ -615,7 +616,7 @@ class PersonalReadingRecordServiceTest {
         void getGatheringsForBook_EmptyList() {
             // given
             when(bookValidator.validatePersonalBook(userId, personalBookId)).thenReturn(personalBook);
-            when(personalBookRepository.findActiveGatheringsWithMeetingsByUserAndBook(userId, personalBookId))
+            when(personalBookRepository.findActiveGatheringsWithMeetingsByUserAndBook(userId, bookId))
                     .thenReturn(List.of());
 
             // when


### PR DESCRIPTION
## PR 요약
> 책 상세의 독서모임 필터(GET /api/book/{personalBookId}/gatherings)가 그 책과 무관한 모임까지 노출하던 문제를 수정합니다. 필터 기준을 personal_book.gathering_id 에서 meeting 기반(그 책으로 약속이 잡혔고 내가 멤버인 모임)으로 변경했습니다.

- [x] 버그 수정

---

## 이슈 번호
- #457

Closes #457

---

## 주요 변경 사항
- `PersonalBookRepository.findActiveGatheringsWithMeetingsByUserAndBook`: `personal_book` JOIN → `meeting` 기반으로 교체. `m.book_id = :bookId` 이고 사용자가 `meeting_member` 인 모임의 gathering 만 DISTINCT 반환. 파라미터도 `personalBookId` → `bookId`.
- `PersonalReadingRecordService.getGatheringsForBook`: `personalBook.getBook().getId()` 로 실제 bookId 를 해석해 전달.
- `PersonalReadingRecordServiceTest`: 서비스가 personalBookId(10L) 가 아닌 실제 bookId(100L) 로 조회하는지 검증(회귀 방지).
- `PersonalBookRepositoryGatheringFilterTest`(신규, @DataJpaTest): 무관한 책 모임 제외 / 미참여 모임 제외 / 중복 제거 검증.

---

## 참고 사항
- 동작 근거: 모임 책장은 별도 테이블이 아니라 그 모임의 약속에 달린 책에서 도출되므로(meeting.book_id), 필터도 동일 기준이 맞음. 타임라인(m.book_id) 이 보여주는 모임 집합과 일치.
- 엣지: 그룹 회고만 있고 그 책 약속엔 미참여인 모임은 필터에 안 뜰 수 있음(meeting_member 기준). QA 의도(무관 모임 제거)엔 부합.
- 직전 커밋 32edb81("책장 id에 해당하는 모임만 출력") 의 과교정(단일 personal_book 행 조회 → 개인 책장 사본 진입 시 빈 목록)도 함께 해소.
- 테스트: `./gradlew test --tests "*PersonalBookRepositoryGatheringFilterTest" --tests "*PersonalReadingRecordServiceTest"` 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
